### PR TITLE
Harden business logic and fallback clip intelligence

### DIFF
--- a/lwa-backend/app/core/config.py
+++ b/lwa-backend/app/core/config.py
@@ -17,6 +17,10 @@ def _default_ffmpeg_path() -> str:
     return "/usr/bin/ffmpeg"
 
 
+def _env_bool(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
 class Settings:
     def __init__(self) -> None:
         origins = os.getenv("LWA_ALLOWED_ORIGINS") or os.getenv("ALLOWED_ORIGINS", "*")
@@ -96,8 +100,11 @@ class Settings:
         self.jwt_exp_minutes = int(os.getenv("LWA_JWT_EXP_MINUTES", "43200"))
         self.openai_api_key = os.getenv("OPENAI_API_KEY", "")
         self.openai_model = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
-        self.ai_provider = os.getenv("LWA_AI_PROVIDER", "auto")
-        self.enable_anthropic = os.getenv("LWA_ENABLE_ANTHROPIC", "true").strip().lower() in {"1", "true", "yes", "on"}
+        self.ai_provider = os.getenv("LWA_AI_PROVIDER") or os.getenv("AI_PROVIDER", "auto")
+        self.enable_anthropic = _env_bool(
+            "LWA_ENABLE_ANTHROPIC",
+            os.getenv("ENABLE_ANTHROPIC", "true"),
+        )
         self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY", "")
         self.anthropic_model_opus = os.getenv("ANTHROPIC_MODEL_OPUS", "claude-opus-4-7")
         self.anthropic_model_sonnet = os.getenv("ANTHROPIC_MODEL_SONNET", "claude-sonnet-4-6")

--- a/lwa-backend/app/generation.py
+++ b/lwa-backend/app/generation.py
@@ -691,18 +691,18 @@ def build_source_grounded_hook(
     post_rank: int,
 ) -> str:
     focus = compact_phrase(source_phrase)
-    trend = lead_trend or focus
+    trend = compact_phrase(lead_trend or focus)
 
     if packaging_angle == "controversy":
-        return f"Most creators still frame {trend} the wrong way. This cut gets to the point fast."
+        return "The safer version misses the point. This cut gives the sharper take first."
     if packaging_angle == "story":
-        return f"This is the moment {trend} actually turns into a clip worth posting."
+        return f"This is the payoff behind {focus}."
     if packaging_angle == "shock":
         return f"Stop scrolling. This {target_platform} cut gets the payoff on screen immediately."
     if packaging_angle == "curiosity":
-        return f"Here is the {trend} moment most people skip before the payoff hits."
+        return f"Here is the {focus} detail most people skip before the payoff hits."
     if post_rank == 1:
-        return f"If you post one {target_platform} clip first, make it the {trend} cut."
+        return f"If you post one {target_platform} clip first, make it the {focus} cut."
     return f"This {target_platform} clip keeps the {trend} angle moving without extra setup."
 
 
@@ -833,20 +833,20 @@ def default_hook_variants(
     packaging_angle: str,
     transcript_excerpt: object = None,
 ) -> List[str]:
-    focus = selected_trend or compact_phrase(str(transcript_excerpt or title or hook))
+    focus = compact_phrase(str(transcript_excerpt or "")) or selected_trend or compact_phrase(title or hook)
     platform_label = platform_display_name(target_platform)
     angle = packaging_angle.replace("-", " ")
     if packaging_angle == "controversy":
         return [
-            f"Most people are still wrong about {focus}.",
-            f"The {focus} disagreement starts here.",
-            f"Post this when you want the comments to split.",
+            "The safe version misses the real point.",
+            "Post the sharper take before the obvious one.",
+            "Use this when you want the comments to split.",
         ]
     if packaging_angle == "story":
         return [
-            f"This is where {focus} turns.",
-            f"Watch the payoff build in one cut.",
-            f"The moment that makes the story worth posting.",
+            f"The payoff behind {focus} starts here.",
+            "Use this cut when the story needs proof.",
+            "This is the follow-up beat worth posting.",
         ]
     if packaging_angle == "shock":
         return [
@@ -904,7 +904,7 @@ def default_why_this_matters(
             f"then gives the {platform} stack a cleaner follow-up beat."
         )
     return (
-        f"Hold this for later because the {transcript_focus} moment works best after viewers understand the angle "
+        f"Hold this for later because the {transcript_focus} beat works best after viewers understand the angle "
         f"and are ready to comment, save, or follow through on {platform}."
     )
 
@@ -922,6 +922,8 @@ def default_thumbnail_text(
     post_rank: int | None = None,
 ) -> str:
     source = hook if len(hook.strip()) >= len(title.strip()) else title
+    if ":" in title:
+        source = title.split(":", 1)[0]
     words = signal_words(source, limit=3)
     if not words:
         if packaging_angle == "controversy":
@@ -1029,7 +1031,7 @@ def default_packaging_angle(*, title: str, hook: str, transcript_excerpt: object
             str(transcript_excerpt or "").lower(),
         ]
     )
-    if any(keyword in content for keyword in {"wrong", "never", "nobody", "skip", "myth"}):
+    if any(keyword in content for keyword in {"wrong", "never", "nobody", "skip", "myth", "safe version", "sharp take", "disagree", "comments"}):
         return "controversy"
     if any(keyword in content for keyword in {"story", "moment", "started", "then", "when"}):
         return "story"
@@ -1075,6 +1077,8 @@ STOP_WORDS = {
     "after",
     "again",
     "also",
+    "and",
+    "are",
     "because",
     "before",
     "breakdown",
@@ -1087,18 +1091,25 @@ STOP_WORDS = {
     "like",
     "make",
     "most",
+    "people",
     "post",
     "really",
+    "shorts",
     "short",
     "that",
+    "the",
     "their",
     "there",
+    "they",
     "this",
+    "too",
     "video",
     "watch",
     "when",
+    "where",
     "with",
     "would",
+    "youtube",
     "your",
 }
 

--- a/lwa-backend/app/generation.py
+++ b/lwa-backend/app/generation.py
@@ -308,7 +308,13 @@ def parse_generated_clips(
                 ),
                 thumbnail_text=str_or_fallback(
                     clip.get("thumbnail_text"),
-                    default_thumbnail_text(title=title, hook=hook),
+                    default_thumbnail_text(
+                        title=title,
+                        hook=hook,
+                        packaging_angle=packaging_angle,
+                        target_platform=target_platform,
+                        post_rank=index,
+                    ),
                 ),
                 cta_suggestion=str_or_fallback(
                     clip.get("cta_suggestion"),
@@ -327,6 +333,7 @@ def parse_generated_clips(
                     selected_trend=selected_trend,
                     target_platform=target_platform,
                     packaging_angle=packaging_angle,
+                    transcript_excerpt=seed.transcript_excerpt if seed else clip.get("transcript_excerpt"),
                 ),
                 caption_variants=parse_caption_variants(
                     clip.get("caption_variants"),
@@ -469,12 +476,23 @@ def build_source_grounded_fallback_clips(
             seed.transcript_excerpt,
             source_context.visual_summary or source_context.description or source_context.title,
         )
-        title_focus = default_thumbnail_text(title=source_context.title or target_platform, hook=source_phrase)
-        title = f"{title_focus} Clip"
         packaging_angle = preferred_angle if preferred_angle in {"shock", "story", "value", "curiosity", "controversy"} else default_packaging_angle(
-            title=title,
+            title=source_context.title or target_platform,
             hook=source_phrase,
             transcript_excerpt=source_phrase,
+        )
+        title_focus = default_thumbnail_text(
+            title=source_context.title or target_platform,
+            hook=source_phrase,
+            packaging_angle=packaging_angle,
+            target_platform=target_platform,
+            post_rank=index,
+        )
+        title = build_source_grounded_title(
+            title_focus=title_focus,
+            target_platform=target_platform,
+            packaging_angle=packaging_angle,
+            post_rank=index,
         )
         score = clamp_score(None, fallback=max(64, 95 - ((index - 1) * 3)))
         confidence = clamp_confidence(None, fallback=max(min(score / 100.0, 0.96), 0.58))
@@ -530,7 +548,13 @@ def build_source_grounded_fallback_clips(
                     transcript_excerpt=source_phrase,
                     source_context=source_context,
                 ),
-                thumbnail_text=default_thumbnail_text(title=title, hook=hook),
+                thumbnail_text=default_thumbnail_text(
+                    title=title,
+                    hook=hook,
+                    packaging_angle=packaging_angle,
+                    target_platform=target_platform,
+                    post_rank=index,
+                ),
                 cta_suggestion=default_cta_suggestion(
                     target_platform=target_platform,
                     post_rank=index,
@@ -544,6 +568,7 @@ def build_source_grounded_fallback_clips(
                     selected_trend=lead_trend,
                     target_platform=target_platform,
                     packaging_angle=packaging_angle,
+                    transcript_excerpt=source_phrase,
                 ),
                 caption_variants={
                     "viral": caption,
@@ -707,6 +732,27 @@ def build_source_grounded_reason(
     return f"This works later in the stack because it keeps the {focus} angle moving with a cleaner {packaging_angle} follow-through for {target_platform}."
 
 
+def build_source_grounded_title(
+    *,
+    title_focus: str,
+    target_platform: str,
+    packaging_angle: str,
+    post_rank: int,
+) -> str:
+    platform = platform_display_name(target_platform)
+    if post_rank == 1:
+        return f"{title_focus}: Lead {platform} Cut"
+    if packaging_angle == "curiosity":
+        return f"{title_focus}: Curiosity Cut"
+    if packaging_angle == "controversy":
+        return f"{title_focus}: Tension Cut"
+    if packaging_angle == "story":
+        return f"{title_focus}: Payoff Cut"
+    if packaging_angle == "shock":
+        return f"{title_focus}: Interrupt Cut"
+    return f"{title_focus}: Value Cut"
+
+
 def parse_int(value: object, fallback: int) -> int:
     try:
         return int(value)
@@ -738,6 +784,7 @@ def parse_hook_variants(
     selected_trend: Optional[str],
     target_platform: str,
     packaging_angle: str,
+    transcript_excerpt: object = None,
 ) -> List[str]:
     if isinstance(value, list):
         variants = [str(item).strip() for item in value if str(item).strip()]
@@ -749,6 +796,7 @@ def parse_hook_variants(
         selected_trend=selected_trend,
         target_platform=target_platform,
         packaging_angle=packaging_angle,
+        transcript_excerpt=transcript_excerpt,
     )
 
 
@@ -783,14 +831,39 @@ def default_hook_variants(
     selected_trend: Optional[str],
     target_platform: str,
     packaging_angle: str,
+    transcript_excerpt: object = None,
 ) -> List[str]:
-    focus = selected_trend or compact_phrase(title or hook)
-    platform_label = target_platform or "short-form"
+    focus = selected_trend or compact_phrase(str(transcript_excerpt or title or hook))
+    platform_label = platform_display_name(target_platform)
     angle = packaging_angle.replace("-", " ")
+    if packaging_angle == "controversy":
+        return [
+            f"Most people are still wrong about {focus}.",
+            f"The {focus} disagreement starts here.",
+            f"Post this when you want the comments to split.",
+        ]
+    if packaging_angle == "story":
+        return [
+            f"This is where {focus} turns.",
+            f"Watch the payoff build in one cut.",
+            f"The moment that makes the story worth posting.",
+        ]
+    if packaging_angle == "shock":
+        return [
+            f"Stop scrolling before this moment passes.",
+            f"The payoff hits faster than the setup.",
+            f"This is the interrupt cut for {platform_label}.",
+        ]
+    if packaging_angle == "curiosity":
+        return [
+            f"The skipped detail behind {focus}.",
+            f"Most viewers miss this before the payoff.",
+            f"Here is why this moment holds attention.",
+        ]
     return [
-        f"Why {focus} is the highest-upside {platform_label} {angle} angle right now.",
-        f"The {focus} moment most creators skip is the one driving this clip.",
-        f"If you post one {angle} clip for {platform_label}, start with this one.",
+        f"The useful part of {focus} starts here.",
+        f"Save this cut before posting the full breakdown.",
+        f"Use this {angle} cut first on {platform_label}.",
     ]
 
 
@@ -800,7 +873,7 @@ def default_caption_variants(
     target_platform: str,
     packaging_angle: str,
 ) -> dict[str, str]:
-    platform_label = target_platform or "short-form"
+    platform_label = platform_display_name(target_platform)
     return {
         "viral": caption,
         "story": f"{caption} Built to travel as a cleaner {packaging_angle} story for {platform_label}.",
@@ -819,19 +892,20 @@ def default_why_this_matters(
 ) -> str:
     packaging = (packaging_angle or "value").replace("_", " ")
     transcript_focus = compact_phrase(str(transcript_excerpt or title))
+    platform = platform_display_name(target_platform)
     if post_rank == 1:
         return (
-            f"Lead with this because the {transcript_focus} payoff lands fast and gives {target_platform} viewers "
-            f"the clearest first impression with a {packaging} frame."
+            f"Post this first because the {transcript_focus} payoff lands fast, sets the {packaging} frame, "
+            f"and gives {platform} viewers the clearest reason to keep watching."
         )
     if post_rank == 2:
         return (
-            f"Use this second because it deepens the {packaging} angle after the opener has already earned attention "
-            f"and keeps the {target_platform} stack coherent."
+            f"Use this second because it extends the {packaging} angle after the opener earns attention, "
+            f"then gives the {platform} stack a cleaner follow-up beat."
         )
     return (
-        f"Hold this for later in the stack because the {transcript_focus} moment works better once viewers already "
-        f"understand the angle and are ready to comment, save, or follow through on {target_platform}."
+        f"Hold this for later because the {transcript_focus} moment works best after viewers understand the angle "
+        f"and are ready to comment, save, or follow through on {platform}."
     )
 
 
@@ -839,28 +913,46 @@ def default_reason(*, title: str, target_platform: str, packaging_angle: str) ->
     return f"{title} works for {target_platform} because the {packaging_angle} framing is easy to understand and fast to react to."
 
 
-def default_thumbnail_text(*, title: str, hook: str) -> str:
+def default_thumbnail_text(
+    *,
+    title: str,
+    hook: str,
+    packaging_angle: str | None = None,
+    target_platform: str | None = None,
+    post_rank: int | None = None,
+) -> str:
     source = hook if len(hook.strip()) >= len(title.strip()) else title
-    words = [
-        word
-        for word in re.findall(r"[A-Za-z0-9']+", source)
-        if word.lower() not in {"the", "and", "that", "with", "this", "your", "from", "into"}
-    ]
+    words = signal_words(source, limit=3)
     if not words:
+        if packaging_angle == "controversy":
+            return "Wrong Take"
+        if packaging_angle == "curiosity":
+            return "Hidden Detail"
+        if packaging_angle == "shock":
+            return "Watch This"
+        if post_rank == 1:
+            return "Post First"
         return "Best Clip"
 
-    return " ".join(words[:4]).title()
+    text = " ".join(words).title()
+    if post_rank == 1 and len(words) <= 2:
+        return f"{text} First"
+    return text
 
 
 def default_cta_suggestion(*, target_platform: str, post_rank: int, packaging_angle: str | None = None) -> str:
-    platform = target_platform.lower()
+    platform = normalize_platform(target_platform)
     packaging = (packaging_angle or "").lower()
     if post_rank == 1:
-        return (
-            "End by asking viewers if they want the full breakdown next."
-            if platform == "youtube"
-            else "End by asking viewers if they want part two."
-        )
+        if platform == "youtube":
+            return "End by asking viewers to watch the full breakdown next."
+        if platform == "instagram":
+            return "End by asking viewers to save it before they forget the move."
+        if platform == "tiktok":
+            return "End by asking viewers if they want part two."
+        if platform == "facebook":
+            return "End by asking viewers which part they agree with most."
+        return "End by asking viewers what they want broken down next."
     if packaging == "controversy":
         return "Close by asking viewers which side they agree with and why."
     if packaging == "story":
@@ -873,7 +965,7 @@ def default_cta_suggestion(*, target_platform: str, post_rank: int, packaging_an
 
 
 def default_caption_style(target_platform: str, packaging_angle: str | None = None) -> str:
-    normalized = target_platform.lower()
+    normalized = normalize_platform(target_platform)
     packaging = (packaging_angle or "").lower()
     if packaging == "controversy":
         return "Tension-led contrarian"
@@ -895,7 +987,7 @@ def default_caption_style(target_platform: str, packaging_angle: str | None = No
 
 
 def default_platform_fit(*, target_platform: str, packaging_angle: str) -> str:
-    normalized = target_platform.lower()
+    normalized = normalize_platform(target_platform)
     if normalized == "tiktok":
         return f"TikTok-friendly pacing with a {packaging_angle} opening and fast payoff."
     if normalized == "instagram":
@@ -972,7 +1064,84 @@ def fallback_confidence_score(
 
 
 def compact_phrase(value: str) -> str:
-    words = re.findall(r"[A-Za-z0-9']+", value)
+    words = signal_words(value, limit=3)
     if not words:
         return "this angle"
-    return " ".join(words[:3]).lower()
+    return " ".join(words).lower()
+
+
+STOP_WORDS = {
+    "about",
+    "after",
+    "again",
+    "also",
+    "because",
+    "before",
+    "breakdown",
+    "clip",
+    "could",
+    "from",
+    "have",
+    "into",
+    "just",
+    "like",
+    "make",
+    "most",
+    "post",
+    "really",
+    "short",
+    "that",
+    "their",
+    "there",
+    "this",
+    "video",
+    "watch",
+    "when",
+    "with",
+    "would",
+    "your",
+}
+
+
+def signal_words(value: str, *, limit: int) -> list[str]:
+    words: list[str] = []
+    for word in re.findall(r"[A-Za-z0-9']+", value):
+        normalized = word.strip("'").lower()
+        if len(normalized) < 3 or normalized in STOP_WORDS:
+            continue
+        if normalized in words:
+            continue
+        words.append(normalized)
+        if len(words) >= limit:
+            break
+    return words
+
+
+def normalize_platform(value: str) -> str:
+    normalized = (value or "").strip().lower()
+    if "tiktok" in normalized:
+        return "tiktok"
+    if "instagram" in normalized or "reels" in normalized:
+        return "instagram"
+    if "youtube" in normalized or "shorts" in normalized:
+        return "youtube"
+    if "facebook" in normalized:
+        return "facebook"
+    if "linkedin" in normalized:
+        return "linkedin"
+    return "short-form"
+
+
+def platform_display_name(value: str) -> str:
+    normalized = normalize_platform(value)
+    if normalized == "tiktok":
+        return "TikTok"
+    if normalized == "instagram":
+        return "Instagram Reels"
+    if normalized == "youtube":
+        return "YouTube Shorts"
+    if normalized == "facebook":
+        return "Facebook"
+    if normalized == "linkedin":
+        return "LinkedIn"
+    return "short-form"

--- a/lwa-backend/app/services/clip_service.py
+++ b/lwa-backend/app/services/clip_service.py
@@ -391,12 +391,6 @@ def apply_plan_feature_flags(
         elif not packaging_profiles_unlocked:
             caption_variants = {"viral": caption_variants.get("viral") or clip.caption}
 
-        # Ensure all intelligence fields are always populated with meaningful fallbacks
-        why_this_matters = (
-            clip.why_this_matters
-            or clip.reason
-            or "Strong pacing, clear payoff, and creator-ready packaging."
-        )
         confidence_score = resolve_confidence_score(clip)
         confidence_label = build_confidence_label(
             {
@@ -405,13 +399,34 @@ def apply_plan_feature_flags(
                 "confidence": clip.confidence,
             }
         )
-        cta_suggestion = clip.cta_suggestion or "Prompt viewers to comment or follow."
-        thumbnail_text = clip.thumbnail_text or clip.title or (clip.hook[:40] if clip.hook else "Best Clip")
-        platform_fit = clip.platform_fit or "Optimized for fast short-form viewing."
         packaging_angle = clip.packaging_angle or "value"
         caption_style = clip.caption_style or "Short-form native"
         post_order = clip.post_rank or clip.best_post_order or clip.rank or 1
-        hook_variants = clip.hook_variants if clip.hook_variants else [clip.hook]
+        # Ensure all intelligence fields are always populated with meaningful fallbacks.
+        why_this_matters = (
+            clip.why_this_matters
+            or clip.reason
+            or build_plan_fallback_why_this_matters(
+                clip=clip,
+                post_order=post_order,
+                packaging_angle=packaging_angle,
+            )
+        )
+        cta_suggestion = clip.cta_suggestion or build_plan_fallback_cta(
+            clip=clip,
+            post_order=post_order,
+            packaging_angle=packaging_angle,
+        )
+        thumbnail_text = clip.thumbnail_text or build_plan_fallback_thumbnail(clip)
+        platform_fit = clip.platform_fit or build_plan_fallback_platform_fit(
+            clip=clip,
+            packaging_angle=packaging_angle,
+        )
+        hook_variants = clip.hook_variants if clip.hook_variants else build_plan_fallback_hook_variants(
+            clip=clip,
+            post_order=post_order,
+            packaging_angle=packaging_angle,
+        )
         if not alt_hooks_unlocked:
             hook_variants = hook_variants[:1]
         if not caption_variants:
@@ -543,6 +558,133 @@ def build_export_bundle(
         preview_ready=bool(preview_url),
         download_ready=bool(download_url),
     )
+
+
+def build_plan_fallback_why_this_matters(*, clip, post_order: int, packaging_angle: str) -> str:
+    focus = compact_clip_focus(clip.transcript_excerpt or clip.hook or clip.title)
+    if post_order == 1:
+        return f"Post this first because the {focus} payoff is the clearest opener and gives the pack a strong {packaging_angle} frame."
+    if post_order == 2:
+        return f"Use this second because it extends the {focus} angle after the lead clip earns attention."
+    return f"Use this later because the {focus} moment works best once viewers understand the angle and are ready to act."
+
+
+def build_plan_fallback_cta(*, clip, post_order: int, packaging_angle: str) -> str:
+    platform = infer_clip_platform(clip)
+    if post_order == 1 and platform == "youtube":
+        return "End by pointing viewers to the full breakdown."
+    if post_order == 1 and platform == "instagram":
+        return "End by asking viewers to save it before they forget the move."
+    if post_order == 1 and platform == "tiktok":
+        return "End by asking viewers if they want part two."
+    if packaging_angle == "controversy":
+        return "Close by asking viewers which side they agree with."
+    if packaging_angle == "story":
+        return "Close by asking viewers if they want the next part."
+    return "Close by asking viewers what they want broken down next."
+
+
+def build_plan_fallback_thumbnail(clip) -> str:
+    words = clip_signal_words(clip.hook or clip.title or "", limit=3)
+    if not words:
+        return "Post First" if (clip.post_rank or clip.rank or 1) == 1 else "Best Clip"
+    return " ".join(words).title()
+
+
+def build_plan_fallback_platform_fit(*, clip, packaging_angle: str) -> str:
+    platform = infer_clip_platform(clip)
+    if platform == "youtube":
+        return f"Shorts-ready structure with a clear {packaging_angle} setup and fast context."
+    if platform == "instagram":
+        return f"Reels-ready packaging with a polished {packaging_angle} frame and saveable payoff."
+    if platform == "tiktok":
+        return f"TikTok-friendly pacing with a {packaging_angle} opener and immediate payoff."
+    return f"Short-form native packaging built around a {packaging_angle} angle."
+
+
+def build_plan_fallback_hook_variants(*, clip, post_order: int, packaging_angle: str) -> list[str]:
+    focus = compact_clip_focus(clip.transcript_excerpt or clip.hook or clip.title)
+    if packaging_angle == "controversy":
+        return [
+            clip.hook,
+            f"Most viewers are still wrong about {focus}.",
+            f"The {focus} disagreement starts here.",
+        ]
+    if packaging_angle == "curiosity":
+        return [
+            clip.hook,
+            f"The skipped detail behind {focus}.",
+            "Most viewers miss this before the payoff.",
+        ]
+    if packaging_angle == "story":
+        return [
+            clip.hook,
+            f"This is where {focus} turns.",
+            "The payoff makes the whole story worth posting.",
+        ]
+    return [
+        clip.hook,
+        f"The useful part of {focus} starts here.",
+        "Save this before posting the full breakdown.",
+    ]
+
+
+def infer_clip_platform(clip) -> str:
+    text = " ".join(
+        str(value or "").lower()
+        for value in [clip.platform_fit, clip.caption_style, clip.title, clip.caption]
+    )
+    if "tiktok" in text:
+        return "tiktok"
+    if "instagram" in text or "reels" in text:
+        return "instagram"
+    if "youtube" in text or "shorts" in text:
+        return "youtube"
+    if "facebook" in text:
+        return "facebook"
+    return "short-form"
+
+
+CLIP_STOP_WORDS = {
+    "about",
+    "after",
+    "again",
+    "because",
+    "before",
+    "breakdown",
+    "clip",
+    "from",
+    "have",
+    "into",
+    "just",
+    "post",
+    "that",
+    "this",
+    "video",
+    "watch",
+    "when",
+    "with",
+    "your",
+}
+
+
+def compact_clip_focus(value: str) -> str:
+    words = clip_signal_words(value, limit=3)
+    return " ".join(words).lower() if words else "this angle"
+
+
+def clip_signal_words(value: str, *, limit: int) -> list[str]:
+    words: list[str] = []
+    for word in re.findall(r"[A-Za-z0-9']+", value):
+        normalized = word.strip("'").lower()
+        if len(normalized) < 3 or normalized in CLIP_STOP_WORDS:
+            continue
+        if normalized in words:
+            continue
+        words.append(normalized)
+        if len(words) >= limit:
+            break
+    return words
 
 
 def shorten_caption(value: str, limit: int = 90) -> str:


### PR DESCRIPTION
## Summary
This PR hardens the first business + intelligence pass after the premium world/frontend merge.

## What changed
- improved fallback clip intelligence in `lwa-backend/app/generation.py`
- improved final plan-gated fallback enrichment in `lwa-backend/app/services/clip_service.py`
- updated config parsing in `lwa-backend/app/core/config.py`

## Improvements made
- `why_this_matters` is more rank-aware and platform-aware
- `thumbnail_text` is sharper and less generic
- `cta_suggestion` is more platform-aware
- fallback `hook_variants` are stronger and packaging-angle aware
- source-grounded fallback titles are smarter
- existing response contracts were preserved
- export flow was preserved
- first-use no-signup flow was preserved

## Verification
- `python3 -m py_compile` passed for scoped backend files
- `git diff --check` passed
- `npm run type-check` passed

## Review focus
- fallback copy quality on one real generated pack
- repetitive wording across clips
- any overly aggressive entitlement or upgrade language