### PR TITLE
web: harden uploaded video rendered output flow

### DIFF
--- a/lwa-web/lib/clip-utils.ts
+++ b/lwa-web/lib/clip-utils.ts
@@ -1,13 +1,27 @@
 import type { ClipResult } from "./types";
 
 const LOCAL_FILE_PREFIXES = ["file://", "/Users/", "/tmp/", "/var/", "C:\\"];
+const API_BASE_URL = (process.env.NEXT_PUBLIC_API_BASE_URL || "").replace(/\/$/, "");
 
 function cleanUrl(value?: string | null): string | undefined {
   const normalized = value?.trim();
   if (!normalized || LOCAL_FILE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
     return undefined;
   }
-  return normalized;
+
+  if (/^https?:\/\//i.test(normalized)) {
+    return normalized;
+  }
+
+  if (normalized.startsWith("//")) {
+    return `https:${normalized}`;
+  }
+
+  if (normalized.startsWith("/") && API_BASE_URL) {
+    return `${API_BASE_URL}${normalized}`;
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Ensure uploaded video → playable clip proof by preventing malformed or local-only URLs from being treated as rendered assets in the frontend, avoiding broken open/download actions and false "rendered" state.

### Description
- Tighten URL normalization in `lwa-web/lib/clip-utils.ts` by only accepting `http(s)` URLs, protocol-relative `//...` URLs, and resolving root-relative `/...` paths via `NEXT_PUBLIC_API_BASE_URL`, and treat other values (including local file paths) as non-playable.

### Testing
- Ran `cd lwa-web && npm run type-check` which completed successfully; ran `git diff --check` and `git status --short` with no issues; changes committed with message `web: harden uploaded video rendered output flow`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09dcf66e8832b992d9b0d31da565d)