### PR TITLE
docs: add LWA Worlds synced execution controls

### DIFF
--- a/docs/company/lwa-architecture-compatibility-map.md
+++ b/docs/company/lwa-architecture-compatibility-map.md
@@ -1,0 +1,122 @@
+# LWA Architecture Compatibility Map
+
+## Purpose
+
+This document keeps future implementation aligned with the real repo instead of blindly copying assumptions from planning files.
+
+The existing repository is the source of truth. Planning documents are requirements and strategy, not proof that a module already exists.
+
+## Repo path compatibility
+
+Some planning docs mention:
+
+- `apps/backend`
+- `apps/web`
+
+Current repo work has used:
+
+- `lwa-backend`
+- `lwa-web`
+- `lwa-ios`
+- `tools`
+- `docs/company`
+
+Codex must adapt master prompts to the real paths. Do not create duplicate app folders unless a repo audit proves the structure changed intentionally.
+
+## Backend compatibility checklist
+
+Before backend edits, inspect:
+
+- app entrypoint
+- route registration
+- schema/model locations
+- config/settings style
+- auth/dependency style
+- test runner style
+- database/store pattern
+- storage/log path style
+- entitlement/quota behavior
+- asset retention behavior
+- source ingestion behavior
+- generated asset URL behavior
+
+## Frontend compatibility checklist
+
+Before frontend edits, inspect:
+
+- Next.js app router structure
+- layout files
+- route names and navigation
+- type definitions
+- API client utilities
+- global CSS/design tokens
+- component naming style
+- generate/workspace surface
+- homepage/generate/dashboard split
+
+## Database compatibility checklist
+
+Do not assume SQLAlchemy, SQLModel, Alembic, JSON store, Postgres, SQLite, or Redis.
+
+Audit first.
+
+If the repo does not already use Alembic, do not create migrations without a dedicated migration task.
+
+Marketplace, Realms, ledger, and payout schemas in planning docs are target architecture. They must be adapted to the existing persistence path.
+
+## Payment compatibility checklist
+
+Do not implement live money movement until the needed safety layers exist.
+
+Required before live marketplace money:
+
+- marketplace model/store
+- verified signed webhooks
+- idempotency by provider event id
+- append-only ledger or equivalent
+- admin takedown/dispute flow
+- refund policy
+- banned category policy
+- claim safety copy
+- payout holds/fraud review
+
+## Revenue event compatibility checklist
+
+Revenue intent tracking, if present, is not payment verification.
+
+It may track upgrade interest, checkout starts, demo requests, referral interest, quota-blocked upgrade pressure, and contact/booking clicks.
+
+It must not unlock access, activate subscriptions, verify payment, trigger payouts, or confirm revenue.
+
+## Social API compatibility checklist
+
+Do not store provider tokens unless encryption, revocation, OAuth state verification, scope docs, and provider status are clear.
+
+Do not implement direct posting until platform permissions/review are confirmed.
+
+## Polymarket compatibility checklist
+
+Polymarket may only be used as read-only cultural trend metadata. No betting, trading, wagering UI, or financial advice.
+
+## Blockchain compatibility checklist
+
+Early work is limited to optional provenance planning and off-chain proof records.
+
+Do not add live chain features until off-chain issuance, proof format, legal copy, user consent, and explicit approval exist.
+
+## iOS compatibility checklist
+
+Do not touch `lwa-ios/` unless the active task explicitly approves iOS.
+
+## Runtime safety rule
+
+Docs may be broad. Code must be narrow.
+
+One implementation slice at a time:
+
+1. audit
+2. plan
+3. implement smallest compatible change
+4. test
+5. commit
+6. update implementation status map

--- a/docs/company/lwa-codex-prompt-stack.md
+++ b/docs/company/lwa-codex-prompt-stack.md
@@ -1,0 +1,154 @@
+# LWA Codex Prompt Stack
+
+## Rule
+
+Use one prompt per slice. Do not paste the entire Master Council Report into Codex as one implementation task.
+
+Codex must inspect the actual repo first, preserve existing working code, and adapt paths from planning docs to the real repo structure.
+
+## Prompt order
+
+1. Master repo fusion and status map.
+2. Source handling hardening.
+3. Free launch mode.
+4. Fallback hardening.
+5. Director Brain v0.
+6. Caption preset contract.
+7. Marketplace compatibility audit.
+8. Marketplace dark scaffold.
+9. Signal Realms static shell.
+10. Social integration status shell.
+11. Off-chain provenance dry run.
+12. Trust and safety review queue.
+
+## Prompt 1 — Master Repo Fusion
+
+Task:
+
+- audit repo
+- fuse master docs
+- create implementation status map
+- correct assumed paths
+- select one safest next slice
+
+## Prompt 2 — Source Handling Hardening
+
+Task:
+
+- central format/source map if missing
+- stable source_type values
+- clean unsupported errors
+- public URL blocked fallback
+- POC runner compatibility
+- frontend accept list if safe
+
+Expected source_type values:
+
+- `video_upload`
+- `audio_upload`
+- `image_upload`
+- `prompt`
+- `music`
+- `campaign`
+- `url`
+
+## Prompt 3 — Free Launch Mode
+
+Task:
+
+- backend env flag
+- compatible guest behavior
+- abuse cap
+- frontend banner
+- Railway env docs
+- tests
+
+## Prompt 4 — Fallback Hardening
+
+Task:
+
+- deterministic fallback helpers
+- no raw tool errors
+- degraded but usable response
+- provider/source failure tests
+- no full pipeline rewrite unless proven necessary
+
+## Prompt 5 — Director Brain v0
+
+Task:
+
+- platform prompt pack
+- hook/caption/moment scoring
+- structured outputs
+- provider fallback
+- tests
+
+Do not duplicate existing Claude/OpenAI/Seedance routing if present.
+
+## Prompt 6 — Caption Presets
+
+Task:
+
+- caption preset spec
+- renderer contract
+- overlay spec output
+- no heavy render rewrite unless existing render path supports it
+
+## Prompt 7 — Marketplace Audit
+
+Task:
+
+- inspect existing architecture
+- docs only
+- choose persistence strategy
+- no live money movement
+
+## Prompt 8 — Marketplace Dark Scaffold
+
+Task:
+
+- marketplace pages/routes if compatible
+- product/job/submission statuses
+- admin review states
+- earnings disclaimers
+
+## Prompt 9 — Realms Static Shell
+
+Task:
+
+- static pages/content
+- class/faction/quest content
+- profile shell
+- no XP purchases
+- no feature unlock relics
+
+## Prompt 10 — Social Integration Status Shell
+
+Task:
+
+- provider status plan
+- safe OAuth direction
+- no posting until approved
+- Polymarket read-only only
+
+## Prompt 11 — Off-Chain Provenance Dry Run
+
+Task:
+
+- deterministic proof records
+- JSON export
+- no mainnet
+- no purchase flow
+
+## Prompt 12 — Trust/Safety Queue
+
+Task:
+
+- pending review queue
+- takedown/escalation states
+- audit events
+- dispute evidence placeholders
+
+## Required final report from Codex
+
+Every run must return branch, starting commit, files inspected, source docs used, protected files detected, files changed, implementation summary, preserved systems, tests run, blockers, commit hash/message, and next chunk prompt.

--- a/docs/company/lwa-execution-roadmap.md
+++ b/docs/company/lwa-execution-roadmap.md
@@ -1,0 +1,92 @@
+# LWA Execution Roadmap
+
+## Purpose
+
+This roadmap turns the LWA Worlds vision into staged implementation. It prevents Codex from starting marketplace, Realms, social integrations, payment rails, and proof systems before the clipping MVP is hardened.
+
+## Current priority
+
+Chunk 15 is the source-of-truth and implementation-status layer.
+
+After Chunk 15, continue with exactly one safe P0 slice at a time.
+
+## Build order
+
+### P0 — Product must work
+
+1. Source handling hardening
+2. Free launch mode
+3. Fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. Platform prompt pack
+7. Hook formula library
+8. Caption preset renderer
+9. Better generate result cards
+
+### P2 — Product must make money safely
+
+10. Monetization CTA polish
+11. Revenue intent verification audit
+12. Verified webhook audit
+13. Stripe/Whop decision doc
+14. Entitlement reconciliation
+
+### P3 — Product moat
+
+15. Marketplace compatibility audit
+16. Marketplace dark scaffold, no live payouts
+17. Signal Realms static shell
+18. Social OAuth/status shell
+19. Off-chain provenance dry run
+
+### P4 — Production scaling
+
+20. Admin trust/safety review queue
+21. Dispute flow
+22. Marketplace payout state machine after webhooks/ledger are tested
+23. Multi-account operator dashboard
+24. Analytics/feedback loop
+
+## 30-day roadmap
+
+### Week 1
+
+- Finish Chunk 15 source-of-truth docs.
+- Select and complete Chunk 16 P0 slice.
+- Keep source matrix and existing generation flow intact.
+
+### Week 2
+
+- Director Brain v0.
+- Platform prompt pack.
+- Caption/hook library foundation.
+
+### Week 3
+
+- Frontend generate flow polish.
+- CTA/revenue intent audit.
+- Marketplace compatibility audit docs.
+
+### Week 4
+
+- Marketplace dark scaffold or Realms static shell depending on MVP stability.
+- Prepare public launch checklist.
+
+## 90-day roadmap
+
+- Harden clipping and source handling.
+- Add Director Brain.
+- Add caption presets.
+- Add dark marketplace scaffold.
+- Add Realms identity shell.
+- Add social integration status shell.
+- Add off-chain provenance dry run.
+- Add trust/safety review queue.
+
+## Roadmap rule
+
+Do not promote a future system to shipped until there is repo evidence and passing checks.

--- a/docs/company/lwa-marketplace-future-plan.md
+++ b/docs/company/lwa-marketplace-future-plan.md
@@ -1,0 +1,54 @@
+# LWA Marketplace Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Goal
+
+Create a creator economy marketplace around clips, templates, hooks, captions, prompt packs, brand kits, B-roll bundles, and campaign work.
+
+## V1 marketplace should not include live payouts first
+
+First marketplace slice should be a dark/internal scaffold only:
+
+- product/listing model or mock-backed data
+- marketplace browse page
+- seller dashboard shell
+- admin review queue
+- claim safety footer
+- no live payouts
+- no Stripe transfers
+- no seller balances
+
+## Required safety before money movement
+
+- KYC plan
+- tax plan
+- fraud review
+- payout holds
+- refund policy
+- dispute window
+- admin takedown
+- signed webhooks
+- idempotent ledger
+- no guaranteed earnings copy
+
+## Future marketplace objects
+
+- creators/buyers
+- sellers/clippers
+- products/listings
+- campaign jobs
+- submissions
+- reviews
+- disputes
+- payout states
+- ledger entries
+- webhook inbox
+
+## Early copy rule
+
+Use: Earnings vary. No guarantee of income.
+
+Do not use copy that implies guaranteed customers, guaranteed sales, instant payout, or investment return.

--- a/docs/company/lwa-next-safe-slice.md
+++ b/docs/company/lwa-next-safe-slice.md
@@ -1,0 +1,73 @@
+# LWA Next Safe Slice
+
+## Selection rule
+
+After every Codex run, choose exactly one next safe slice.
+
+Do not bundle unrelated systems into one run.
+
+## Priority order
+
+### P0 — Product must work
+
+1. source handling hardening
+2. free launch mode
+3. fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. platform prompt pack
+7. hook formula library
+8. caption preset renderer
+9. better generate result cards
+
+### P2 — Product must convert safely
+
+10. monetization CTA polish
+11. webhook audit
+12. billing provider decision doc
+13. entitlement reconciliation
+
+### P3 — Product moat
+
+14. marketplace compatibility audit
+15. marketplace dark scaffold
+16. Realms static shell
+17. social integration shell
+18. off-chain provenance dry run
+
+## Current recommended next slice
+
+Run source handling hardening if source behavior is still not fully normalized.
+
+If source behavior is already normalized, run free launch mode.
+
+If free launch mode is already done, run fallback hardening.
+
+If all three are done, run README/Railway launch polish.
+
+## Decision checklist
+
+Before selecting a slice, verify:
+
+- Does `/v1/uploads` return stable `source_type`?
+- Does `/v1/generate` preserve the same source contract?
+- Does the source matrix runner still work?
+- Does public URL failure return clean fallback copy?
+- Does free launch mode exist in backend config?
+- Does the frontend free launch banner exist?
+- Do provider/source failures degrade instead of crashing?
+- Is README aligned with actual repo paths and Railway URLs?
+
+## Later systems
+
+Do not start later systems until P0 is stable.
+
+## Required update
+
+After completing a slice, update:
+
+- `docs/company/lwa-implementation-status.md`
+- this file's current recommended next slice

--- a/docs/company/lwa-realms-future-plan.md
+++ b/docs/company/lwa-realms-future-plan.md
@@ -1,0 +1,91 @@
+# LWA Signal Realms Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Purpose
+
+The Signal Realms is the retention and identity layer for creators.
+
+Users become Signalbearers with:
+
+- classes
+- factions
+- skill XP
+- quests
+- badges
+- cosmetic relics
+
+## Rule
+
+No pay-to-win.
+
+XP cannot be purchased.
+
+Relics are cosmetic only.
+
+Badges are earned only.
+
+## Safe first implementation
+
+The first implementation should be:
+
+- static `/realm` or `/worlds` page, depending on actual route direction
+- character profile shell
+- class/faction content
+- quest list
+- badge/relic gallery mock
+- no blockchain
+- no purchases
+- no XP economy tied to money
+
+## Core classes
+
+- Hookwright
+- Captioneer
+- Reframer
+- Trendseer
+- Loremaster
+- Voicewright
+- Ironforger
+- Pricer
+- Auditor
+- Diplomat
+- Cartographer
+- Oracle
+
+## Core factions
+
+- Crimson Court
+- Black Loom
+- Verdant Pact
+- Iron Choir
+- Saffron Wake
+- Glass Synod
+- Tide Marshal
+- Driftborn
+- Emberkin
+- Chorus of Thoth
+- House Polis
+- Outer Signal
+
+## Future implementation
+
+Later:
+
+- event-based XP awarder
+- quest progression
+- leaderboards
+- badge awards
+- relic holdings
+- off-chain proof
+- optional chain migration
+
+## Forbidden
+
+- NFT unlocks app features
+- XP purchases
+- investment/value appreciation claims
+- token/yield language
+- income rights from badges or relics

--- a/docs/company/lwa-revenue-and-monetization-plan.md
+++ b/docs/company/lwa-revenue-and-monetization-plan.md
@@ -1,0 +1,77 @@
+# LWA Revenue And Monetization Plan
+
+## Status
+
+This is a planning and control document for revenue work. It does not claim any payment provider is live unless repo evidence proves it.
+
+## Current foundation
+
+The safest first layer is revenue-intent tracking.
+
+Revenue-intent events are product analytics and operator signals. They are not payment verification.
+
+They may track:
+
+- upgrade clicks
+- checkout starts
+- demo requests
+- affiliate or referral interest
+- quota-blocked upgrade pressure
+- booking or contact clicks
+
+## Non-authoritative rule
+
+Revenue-intent events must not unlock access, activate subscriptions, verify payment, trigger payout state, or confirm revenue.
+
+Verified payment state must come later from signed provider webhooks.
+
+## Safe funnel
+
+1. User hits a generation, quota, or value wall.
+2. App shows upgrade, demo, or contact CTA.
+3. Frontend sends revenue-intent event if implemented.
+4. Backend logs sanitized event if the endpoint exists.
+5. User goes to checkout, demo, or contact path.
+6. Future signed webhook verifies actual payment.
+7. Entitlement changes only after verified payment or explicit admin grant.
+
+## Future payment integrations
+
+Future slices:
+
+1. Stripe webhook verification.
+2. Whop webhook verification.
+3. Lemon Squeezy webhook verification.
+4. Gumroad webhook verification.
+5. PayPal verification if needed.
+6. Entitlement reconciliation.
+7. Billing audit view.
+
+## Draft pricing direction
+
+- Free Launch: limited public usage.
+- Creator: core clipping.
+- Pro: more clips and stronger controls.
+- Scale: agency/operator workflow.
+- Marketplace: future take rate after trust and payment controls exist.
+
+## Required before live marketplace money
+
+- verified webhooks
+- idempotency
+- ledger or equivalent account record
+- seller review/KYC plan
+- payout holds
+- dispute process
+- takedown/admin queue
+- refund policy
+- banned category policy
+- claim safety copy
+
+## Current verification rule
+
+Codex must verify actual repo evidence before saying revenue-event tracking is installed.
+
+If the route/logger exists, preserve it.
+
+If it does not exist, do not add it unless the selected slice is monetization/revenue tracking.

--- a/docs/company/lwa-social-api-future-plan.md
+++ b/docs/company/lwa-social-api-future-plan.md
@@ -1,0 +1,75 @@
+# LWA Social API Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Provider direction
+
+Potential providers:
+
+- YouTube
+- TikTok
+- Instagram / Meta
+- Twitch
+- Reddit
+- Google Trends or a trend-data provider
+- Polymarket Gamma read-only
+- OpenAI
+- Anthropic Claude
+- Seedance / BytePlus ModelArk
+- Apple App Store Connect for app metadata/readiness where appropriate
+
+## Safe first slice
+
+OAuth/status shell only:
+
+- auth URL
+- callback
+- link status
+- revoke
+- encrypted tokens if tokens are stored
+- provider status docs
+- no auto-posting until approved
+
+## Polymarket rule
+
+Polymarket data may only be used as read-only cultural trend metadata.
+
+Do not implement trading, wagering, financial-advice, or buy/sell recommendation flows.
+
+## Posting rule
+
+Do not implement direct posting until provider app review, scopes, rate limits, and user consent flows are confirmed.
+
+## Token storage rule
+
+Do not store social tokens unless the backend has:
+
+- encryption at rest
+- OAuth state verification
+- refresh/revocation handling
+- clear scope display
+- provider status audit trail
+
+## First implementation direction
+
+Start with an integrations dashboard/status shell before real provider actions:
+
+- provider name
+- configured/not configured
+- connected/disconnected
+- scopes requested
+- approval status
+- last sync
+- last error
+
+## Safe customer copy
+
+Use:
+
+Social integrations are planned to help organize source metadata, trend signals, and approved publishing workflows.
+
+Avoid:
+
+Guaranteed posting, guaranteed reach, or platform approval claims.


### PR DESCRIPTION
## Summary

Adds the non-conflicting Chunk 15 execution-control docs on a fresh branch created from current `main`.

This PR supersedes the stale/conflict-heavy PR #26 for the docs that were missing from `main`.

## Runtime impact

None. Docs-only.

This PR does not touch:

- `lwa-backend/`
- `lwa-web/`
- `lwa-ios/`
- package files
- Railway config
- env vars
- payment code
- marketplace payout code
- social posting code
- chain/proof runtime code

## Files added

- `docs/company/lwa-architecture-compatibility-map.md`
- `docs/company/lwa-codex-prompt-stack.md`
- `docs/company/lwa-execution-roadmap.md`
- `docs/company/lwa-marketplace-future-plan.md`
- `docs/company/lwa-next-safe-slice.md`
- `docs/company/lwa-realms-future-plan.md`
- `docs/company/lwa-revenue-and-monetization-plan.md`
- `docs/company/lwa-social-api-future-plan.md`

## Existing docs already on main

Current `main` already contains at least:

- `docs/company/lwa-source-of-truth.md`
- `docs/company/lwa-implementation-status.md`

So this synced PR does not recreate those paths and avoids add/add conflicts.

## What this prepares

- Codex must adapt master prompts to real paths like `lwa-backend` and `lwa-web`.
- Codex must update implementation status after each slice.
- Future systems are staged and must not be marked shipped without repo evidence.
- Next implementation should be one P0 slice only: source handling, free launch, fallback hardening, or README/Railway polish.

## Verification

GitHub compare shows this branch is 8 commits ahead of `main` and 0 behind.

Docs-only; runtime tests not required.