### PR TITLE
docs: add LWA Worlds master council report and audit

### DIFF
--- a/docs/company/lwa-architecture-compatibility-map.md
+++ b/docs/company/lwa-architecture-compatibility-map.md
@@ -1,0 +1,122 @@
+# LWA Architecture Compatibility Map
+
+## Purpose
+
+This document keeps future implementation aligned with the real repo instead of blindly copying assumptions from planning files.
+
+The existing repository is the source of truth. Planning documents are requirements and strategy, not proof that a module already exists.
+
+## Repo path compatibility
+
+Some planning docs mention:
+
+- `apps/backend`
+- `apps/web`
+
+Current repo work has used:
+
+- `lwa-backend`
+- `lwa-web`
+- `lwa-ios`
+- `tools`
+- `docs/company`
+
+Codex must adapt master prompts to the real paths. Do not create duplicate app folders unless a repo audit proves the structure changed intentionally.
+
+## Backend compatibility checklist
+
+Before backend edits, inspect:
+
+- app entrypoint
+- route registration
+- schema/model locations
+- config/settings style
+- auth/dependency style
+- test runner style
+- database/store pattern
+- storage/log path style
+- entitlement/quota behavior
+- asset retention behavior
+- source ingestion behavior
+- generated asset URL behavior
+
+## Frontend compatibility checklist
+
+Before frontend edits, inspect:
+
+- Next.js app router structure
+- layout files
+- route names and navigation
+- type definitions
+- API client utilities
+- global CSS/design tokens
+- component naming style
+- generate/workspace surface
+- homepage/generate/dashboard split
+
+## Database compatibility checklist
+
+Do not assume SQLAlchemy, SQLModel, Alembic, JSON store, Postgres, SQLite, or Redis.
+
+Audit first.
+
+If the repo does not already use Alembic, do not create migrations without a dedicated migration task.
+
+Marketplace, Realms, ledger, and payout schemas in planning docs are target architecture. They must be adapted to the existing persistence path.
+
+## Payment compatibility checklist
+
+Do not implement live money movement until the needed safety layers exist.
+
+Required before live marketplace money:
+
+- marketplace model/store
+- verified signed webhooks
+- idempotency by provider event id
+- append-only ledger or equivalent
+- admin takedown/dispute flow
+- refund policy
+- banned category policy
+- claim safety copy
+- payout holds/fraud review
+
+## Revenue event compatibility checklist
+
+Revenue intent tracking, if present, is not payment verification.
+
+It may track upgrade interest, checkout starts, demo requests, referral interest, quota-blocked upgrade pressure, and contact/booking clicks.
+
+It must not unlock access, activate subscriptions, verify payment, trigger payouts, or confirm revenue.
+
+## Social API compatibility checklist
+
+Do not store provider tokens unless encryption, revocation, OAuth state verification, scope docs, and provider status are clear.
+
+Do not implement direct posting until platform permissions/review are confirmed.
+
+## Polymarket compatibility checklist
+
+Polymarket may only be used as read-only cultural trend metadata. No betting, trading, wagering UI, or financial advice.
+
+## Blockchain compatibility checklist
+
+Early work is limited to optional provenance planning and off-chain proof records.
+
+Do not add live chain features until off-chain issuance, proof format, legal copy, user consent, and explicit approval exist.
+
+## iOS compatibility checklist
+
+Do not touch `lwa-ios/` unless the active task explicitly approves iOS.
+
+## Runtime safety rule
+
+Docs may be broad. Code must be narrow.
+
+One implementation slice at a time:
+
+1. audit
+2. plan
+3. implement smallest compatible change
+4. test
+5. commit
+6. update implementation status map

--- a/docs/company/lwa-codex-prompt-stack.md
+++ b/docs/company/lwa-codex-prompt-stack.md
@@ -1,0 +1,154 @@
+# LWA Codex Prompt Stack
+
+## Rule
+
+Use one prompt per slice. Do not paste the entire Master Council Report into Codex as one implementation task.
+
+Codex must inspect the actual repo first, preserve existing working code, and adapt paths from planning docs to the real repo structure.
+
+## Prompt order
+
+1. Master repo fusion and status map.
+2. Source handling hardening.
+3. Free launch mode.
+4. Fallback hardening.
+5. Director Brain v0.
+6. Caption preset contract.
+7. Marketplace compatibility audit.
+8. Marketplace dark scaffold.
+9. Signal Realms static shell.
+10. Social integration status shell.
+11. Off-chain provenance dry run.
+12. Trust and safety review queue.
+
+## Prompt 1 — Master Repo Fusion
+
+Task:
+
+- audit repo
+- fuse master docs
+- create implementation status map
+- correct assumed paths
+- select one safest next slice
+
+## Prompt 2 — Source Handling Hardening
+
+Task:
+
+- central format/source map if missing
+- stable source_type values
+- clean unsupported errors
+- public URL blocked fallback
+- POC runner compatibility
+- frontend accept list if safe
+
+Expected source_type values:
+
+- `video_upload`
+- `audio_upload`
+- `image_upload`
+- `prompt`
+- `music`
+- `campaign`
+- `url`
+
+## Prompt 3 — Free Launch Mode
+
+Task:
+
+- backend env flag
+- compatible guest behavior
+- abuse cap
+- frontend banner
+- Railway env docs
+- tests
+
+## Prompt 4 — Fallback Hardening
+
+Task:
+
+- deterministic fallback helpers
+- no raw tool errors
+- degraded but usable response
+- provider/source failure tests
+- no full pipeline rewrite unless proven necessary
+
+## Prompt 5 — Director Brain v0
+
+Task:
+
+- platform prompt pack
+- hook/caption/moment scoring
+- structured outputs
+- provider fallback
+- tests
+
+Do not duplicate existing Claude/OpenAI/Seedance routing if present.
+
+## Prompt 6 — Caption Presets
+
+Task:
+
+- caption preset spec
+- renderer contract
+- overlay spec output
+- no heavy render rewrite unless existing render path supports it
+
+## Prompt 7 — Marketplace Audit
+
+Task:
+
+- inspect existing architecture
+- docs only
+- choose persistence strategy
+- no live money movement
+
+## Prompt 8 — Marketplace Dark Scaffold
+
+Task:
+
+- marketplace pages/routes if compatible
+- product/job/submission statuses
+- admin review states
+- earnings disclaimers
+
+## Prompt 9 — Realms Static Shell
+
+Task:
+
+- static pages/content
+- class/faction/quest content
+- profile shell
+- no XP purchases
+- no feature unlock relics
+
+## Prompt 10 — Social Integration Status Shell
+
+Task:
+
+- provider status plan
+- safe OAuth direction
+- no posting until approved
+- Polymarket read-only only
+
+## Prompt 11 — Off-Chain Provenance Dry Run
+
+Task:
+
+- deterministic proof records
+- JSON export
+- no mainnet
+- no purchase flow
+
+## Prompt 12 — Trust/Safety Queue
+
+Task:
+
+- pending review queue
+- takedown/escalation states
+- audit events
+- dispute evidence placeholders
+
+## Required final report from Codex
+
+Every run must return branch, starting commit, files inspected, source docs used, protected files detected, files changed, implementation summary, preserved systems, tests run, blockers, commit hash/message, and next chunk prompt.

--- a/docs/company/lwa-execution-roadmap.md
+++ b/docs/company/lwa-execution-roadmap.md
@@ -1,0 +1,92 @@
+# LWA Execution Roadmap
+
+## Purpose
+
+This roadmap turns the LWA Worlds vision into staged implementation. It prevents Codex from starting marketplace, Realms, social integrations, payment rails, and proof systems before the clipping MVP is hardened.
+
+## Current priority
+
+Chunk 15 is the source-of-truth and implementation-status layer.
+
+After Chunk 15, continue with exactly one safe P0 slice at a time.
+
+## Build order
+
+### P0 — Product must work
+
+1. Source handling hardening
+2. Free launch mode
+3. Fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. Platform prompt pack
+7. Hook formula library
+8. Caption preset renderer
+9. Better generate result cards
+
+### P2 — Product must make money safely
+
+10. Monetization CTA polish
+11. Revenue intent verification audit
+12. Verified webhook audit
+13. Stripe/Whop decision doc
+14. Entitlement reconciliation
+
+### P3 — Product moat
+
+15. Marketplace compatibility audit
+16. Marketplace dark scaffold, no live payouts
+17. Signal Realms static shell
+18. Social OAuth/status shell
+19. Off-chain provenance dry run
+
+### P4 — Production scaling
+
+20. Admin trust/safety review queue
+21. Dispute flow
+22. Marketplace payout state machine after webhooks/ledger are tested
+23. Multi-account operator dashboard
+24. Analytics/feedback loop
+
+## 30-day roadmap
+
+### Week 1
+
+- Finish Chunk 15 source-of-truth docs.
+- Select and complete Chunk 16 P0 slice.
+- Keep source matrix and existing generation flow intact.
+
+### Week 2
+
+- Director Brain v0.
+- Platform prompt pack.
+- Caption/hook library foundation.
+
+### Week 3
+
+- Frontend generate flow polish.
+- CTA/revenue intent audit.
+- Marketplace compatibility audit docs.
+
+### Week 4
+
+- Marketplace dark scaffold or Realms static shell depending on MVP stability.
+- Prepare public launch checklist.
+
+## 90-day roadmap
+
+- Harden clipping and source handling.
+- Add Director Brain.
+- Add caption presets.
+- Add dark marketplace scaffold.
+- Add Realms identity shell.
+- Add social integration status shell.
+- Add off-chain provenance dry run.
+- Add trust/safety review queue.
+
+## Roadmap rule
+
+Do not promote a future system to shipped until there is repo evidence and passing checks.

--- a/docs/company/lwa-marketplace-future-plan.md
+++ b/docs/company/lwa-marketplace-future-plan.md
@@ -1,0 +1,54 @@
+# LWA Marketplace Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Goal
+
+Create a creator economy marketplace around clips, templates, hooks, captions, prompt packs, brand kits, B-roll bundles, and campaign work.
+
+## V1 marketplace should not include live payouts first
+
+First marketplace slice should be a dark/internal scaffold only:
+
+- product/listing model or mock-backed data
+- marketplace browse page
+- seller dashboard shell
+- admin review queue
+- claim safety footer
+- no live payouts
+- no Stripe transfers
+- no seller balances
+
+## Required safety before money movement
+
+- KYC plan
+- tax plan
+- fraud review
+- payout holds
+- refund policy
+- dispute window
+- admin takedown
+- signed webhooks
+- idempotent ledger
+- no guaranteed earnings copy
+
+## Future marketplace objects
+
+- creators/buyers
+- sellers/clippers
+- products/listings
+- campaign jobs
+- submissions
+- reviews
+- disputes
+- payout states
+- ledger entries
+- webhook inbox
+
+## Early copy rule
+
+Use: Earnings vary. No guarantee of income.
+
+Do not use copy that implies guaranteed customers, guaranteed sales, instant payout, or investment return.

--- a/docs/company/lwa-next-safe-slice.md
+++ b/docs/company/lwa-next-safe-slice.md
@@ -1,0 +1,73 @@
+# LWA Next Safe Slice
+
+## Selection rule
+
+After every Codex run, choose exactly one next safe slice.
+
+Do not bundle unrelated systems into one run.
+
+## Priority order
+
+### P0 — Product must work
+
+1. source handling hardening
+2. free launch mode
+3. fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. platform prompt pack
+7. hook formula library
+8. caption preset renderer
+9. better generate result cards
+
+### P2 — Product must convert safely
+
+10. monetization CTA polish
+11. webhook audit
+12. billing provider decision doc
+13. entitlement reconciliation
+
+### P3 — Product moat
+
+14. marketplace compatibility audit
+15. marketplace dark scaffold
+16. Realms static shell
+17. social integration shell
+18. off-chain provenance dry run
+
+## Current recommended next slice
+
+Run source handling hardening if source behavior is still not fully normalized.
+
+If source behavior is already normalized, run free launch mode.
+
+If free launch mode is already done, run fallback hardening.
+
+If all three are done, run README/Railway launch polish.
+
+## Decision checklist
+
+Before selecting a slice, verify:
+
+- Does `/v1/uploads` return stable `source_type`?
+- Does `/v1/generate` preserve the same source contract?
+- Does the source matrix runner still work?
+- Does public URL failure return clean fallback copy?
+- Does free launch mode exist in backend config?
+- Does the frontend free launch banner exist?
+- Do provider/source failures degrade instead of crashing?
+- Is README aligned with actual repo paths and Railway URLs?
+
+## Later systems
+
+Do not start later systems until P0 is stable.
+
+## Required update
+
+After completing a slice, update:
+
+- `docs/company/lwa-implementation-status.md`
+- this file's current recommended next slice

--- a/docs/company/lwa-realms-future-plan.md
+++ b/docs/company/lwa-realms-future-plan.md
@@ -1,0 +1,91 @@
+# LWA Signal Realms Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Purpose
+
+The Signal Realms is the retention and identity layer for creators.
+
+Users become Signalbearers with:
+
+- classes
+- factions
+- skill XP
+- quests
+- badges
+- cosmetic relics
+
+## Rule
+
+No pay-to-win.
+
+XP cannot be purchased.
+
+Relics are cosmetic only.
+
+Badges are earned only.
+
+## Safe first implementation
+
+The first implementation should be:
+
+- static `/realm` or `/worlds` page, depending on actual route direction
+- character profile shell
+- class/faction content
+- quest list
+- badge/relic gallery mock
+- no blockchain
+- no purchases
+- no XP economy tied to money
+
+## Core classes
+
+- Hookwright
+- Captioneer
+- Reframer
+- Trendseer
+- Loremaster
+- Voicewright
+- Ironforger
+- Pricer
+- Auditor
+- Diplomat
+- Cartographer
+- Oracle
+
+## Core factions
+
+- Crimson Court
+- Black Loom
+- Verdant Pact
+- Iron Choir
+- Saffron Wake
+- Glass Synod
+- Tide Marshal
+- Driftborn
+- Emberkin
+- Chorus of Thoth
+- House Polis
+- Outer Signal
+
+## Future implementation
+
+Later:
+
+- event-based XP awarder
+- quest progression
+- leaderboards
+- badge awards
+- relic holdings
+- off-chain proof
+- optional chain migration
+
+## Forbidden
+
+- NFT unlocks app features
+- XP purchases
+- investment/value appreciation claims
+- token/yield language
+- income rights from badges or relics

--- a/docs/company/lwa-revenue-and-monetization-plan.md
+++ b/docs/company/lwa-revenue-and-monetization-plan.md
@@ -1,0 +1,77 @@
+# LWA Revenue And Monetization Plan
+
+## Status
+
+This is a planning and control document for revenue work. It does not claim any payment provider is live unless repo evidence proves it.
+
+## Current foundation
+
+The safest first layer is revenue-intent tracking.
+
+Revenue-intent events are product analytics and operator signals. They are not payment verification.
+
+They may track:
+
+- upgrade clicks
+- checkout starts
+- demo requests
+- affiliate or referral interest
+- quota-blocked upgrade pressure
+- booking or contact clicks
+
+## Non-authoritative rule
+
+Revenue-intent events must not unlock access, activate subscriptions, verify payment, trigger payout state, or confirm revenue.
+
+Verified payment state must come later from signed provider webhooks.
+
+## Safe funnel
+
+1. User hits a generation, quota, or value wall.
+2. App shows upgrade, demo, or contact CTA.
+3. Frontend sends revenue-intent event if implemented.
+4. Backend logs sanitized event if the endpoint exists.
+5. User goes to checkout, demo, or contact path.
+6. Future signed webhook verifies actual payment.
+7. Entitlement changes only after verified payment or explicit admin grant.
+
+## Future payment integrations
+
+Future slices:
+
+1. Stripe webhook verification.
+2. Whop webhook verification.
+3. Lemon Squeezy webhook verification.
+4. Gumroad webhook verification.
+5. PayPal verification if needed.
+6. Entitlement reconciliation.
+7. Billing audit view.
+
+## Draft pricing direction
+
+- Free Launch: limited public usage.
+- Creator: core clipping.
+- Pro: more clips and stronger controls.
+- Scale: agency/operator workflow.
+- Marketplace: future take rate after trust and payment controls exist.
+
+## Required before live marketplace money
+
+- verified webhooks
+- idempotency
+- ledger or equivalent account record
+- seller review/KYC plan
+- payout holds
+- dispute process
+- takedown/admin queue
+- refund policy
+- banned category policy
+- claim safety copy
+
+## Current verification rule
+
+Codex must verify actual repo evidence before saying revenue-event tracking is installed.
+
+If the route/logger exists, preserve it.
+
+If it does not exist, do not add it unless the selected slice is monetization/revenue tracking.

--- a/docs/company/lwa-social-api-future-plan.md
+++ b/docs/company/lwa-social-api-future-plan.md
@@ -1,0 +1,75 @@
+# LWA Social API Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Provider direction
+
+Potential providers:
+
+- YouTube
+- TikTok
+- Instagram / Meta
+- Twitch
+- Reddit
+- Google Trends or a trend-data provider
+- Polymarket Gamma read-only
+- OpenAI
+- Anthropic Claude
+- Seedance / BytePlus ModelArk
+- Apple App Store Connect for app metadata/readiness where appropriate
+
+## Safe first slice
+
+OAuth/status shell only:
+
+- auth URL
+- callback
+- link status
+- revoke
+- encrypted tokens if tokens are stored
+- provider status docs
+- no auto-posting until approved
+
+## Polymarket rule
+
+Polymarket data may only be used as read-only cultural trend metadata.
+
+Do not implement trading, wagering, financial-advice, or buy/sell recommendation flows.
+
+## Posting rule
+
+Do not implement direct posting until provider app review, scopes, rate limits, and user consent flows are confirmed.
+
+## Token storage rule
+
+Do not store social tokens unless the backend has:
+
+- encryption at rest
+- OAuth state verification
+- refresh/revocation handling
+- clear scope display
+- provider status audit trail
+
+## First implementation direction
+
+Start with an integrations dashboard/status shell before real provider actions:
+
+- provider name
+- configured/not configured
+- connected/disconnected
+- scopes requested
+- approval status
+- last sync
+- last error
+
+## Safe customer copy
+
+Use:
+
+Social integrations are planned to help organize source metadata, trend signals, and approved publishing workflows.
+
+Avoid:
+
+Guaranteed posting, guaranteed reach, or platform approval claims.

--- a/docs/lwa-worlds-master-council-audit.md
+++ b/docs/lwa-worlds-master-council-audit.md
@@ -1,0 +1,283 @@
+# LWA Worlds Master Council Audit
+
+**Audit purpose:** make the LWA Worlds report safe to keep in the repo without confusing it with executable scope.
+
+**Repo:** `jcamacho611/lwa-app`  
+**Source report:** `docs/lwa-worlds-master-council-report.md`  
+**Audit date:** April 30, 2026
+
+---
+
+## 1. Repo Placement Audit
+
+The report belongs under `docs/`, not `README.md`, not app code, and not deployment config.
+
+Reason:
+
+- It is a roadmap and strategy document.
+- It contains speculative future features.
+- It includes legal, market, pricing, API, and compensation claims that need verification before external use.
+- It should not change runtime behavior.
+
+Result:
+
+- Added repo-safe strategy document at `docs/lwa-worlds-master-council-report.md`.
+- Added this audit file at `docs/lwa-worlds-master-council-audit.md`.
+- No backend code changed.
+- No frontend code changed.
+- No iOS code changed.
+
+---
+
+## 2. Critical Path Audit
+
+The report contains many future systems, but the implementation order must stay narrow.
+
+### Immediate Phase 1 Scope
+
+Only these should be treated as immediate engineering work:
+
+1. `FREE_LAUNCH_MODE`
+2. fallback hardening
+3. README polish
+4. Director Brain v0 only after hardening passes
+5. webhook idempotency and rate limiting
+
+### Not Phase 1
+
+These must not be mixed into the first hardening PR:
+
+- marketplace schema and Stripe Connect
+- Whop seller rails
+- RPG / Signal Realms implementation
+- blockchain / NFT / Merkle anchoring
+- social posting APIs
+- TikTok / Instagram publishing
+- operator multi-account dashboard
+- trust and safety admin queues
+
+---
+
+## 3. Existing Repo Alignment Notes
+
+The current repo README describes this layout:
+
+```text
+LWA/
+├── README.md
+├── docs/
+├── lwa-backend/
+├── lwa-web/
+└── lwa-ios/
+```
+
+The report originally used `apps/backend` and `apps/web` in some prompts. That does not match the visible repo README layout.
+
+### Required correction for Codex prompts
+
+Use:
+
+```text
+lwa-backend/
+lwa-web/
+lwa-ios/
+```
+
+Do not use:
+
+```text
+apps/backend
+apps/web
+```
+
+unless the repo is later reorganized.
+
+---
+
+## 4. Codex Safety Rule
+
+Do not paste the whole Master Council Report into Codex.
+
+Use one scoped prompt per PR.
+
+### First safe Codex prompt
+
+```text
+ROLE: You are a senior backend/frontend engineer on the lwa-app repo.
+TASK: Implement the Day 3 hardening sprint only.
+
+Scope:
+- allowed backend path: lwa-backend/
+- allowed web path: lwa-web/
+- forbidden path: lwa-ios/
+- do not build marketplace
+- do not build Signal Realms
+- do not build blockchain
+- do not build social posting
+- do not add new external services
+
+Work:
+1. Add FREE_LAUNCH_MODE config support.
+2. Add public-launch guest behavior only when the flag is true.
+3. Add anonymous IP rate limiting at RATE_LIMIT_GUEST_RPM.
+4. Add NEXT_PUBLIC_FREE_LAUNCH_MODE web banner.
+5. Harden the clip pipeline so download/transcribe/detect/render failures return degraded structured output instead of 500.
+6. Update README only if needed to document the flag and fallback behavior.
+
+Verification:
+cd lwa-backend && python3 -m py_compile $(git ls-files '*.py')
+cd lwa-backend && python3 -m unittest discover
+cd lwa-web && npm run type-check
+cd lwa-web && npm run lint
+
+Output:
+- files changed
+- what was preserved
+- verification results
+- commit message
+```
+
+---
+
+## 5. Claims Requiring Fresh Verification Before Public Use
+
+Before this report is used with investors, public marketing, hiring, or legal/compliance discussions, verify these categories with live sources:
+
+1. Competitor pricing and plan limits
+2. OpusClip user count, clips generated, funding, and valuation
+3. Stripe Connect pricing, payout fees, and 1099 handling
+4. Whop fees, API capabilities, payout territories, and KYC details
+5. TikTok developer review rules and posting caps
+6. Instagram Graph API app review requirements and rate limits
+7. YouTube API quota, upload scopes, and audit rules
+8. Reddit API pricing and commercial restrictions
+9. Apple NFT / IAP rule posture
+10. SEC/CFTC digital-asset statements and NFT/security treatment
+11. Compensation bands for hiring roles
+12. Social ranking-signal claims such as LinkedIn dwell, Reels sends, and Shorts engaged views
+
+Until verified, these should be labeled as strategic assumptions, not facts.
+
+---
+
+## 6. Product Scope Audit
+
+### Strong product direction
+
+The strongest direction in the report is:
+
+> LWA should become the operator layer around AI clipping.
+
+That means the clipper remains the wedge, while the defensible platform becomes:
+
+- rendered-first clipping workflow
+- Director Brain explanation layer
+- per-platform packaging intelligence
+- marketplace later
+- Realms progression later
+- operator dashboard later
+
+### Risky product direction
+
+The riskiest direction is trying to build too much at once:
+
+- marketplace
+- RPG
+- crypto
+- social APIs
+- payouts
+- admin queues
+- public launch
+
+These systems compound complexity and should be staged behind the working clipping core.
+
+---
+
+## 7. Backend Audit Notes
+
+The report’s backend architecture is directionally strong, but implementation must follow the actual repo.
+
+### Must preserve
+
+- existing routes
+- existing Railway deploy spine
+- existing fallback/strategy-only behavior
+- existing frontend/backend contract
+- existing iOS folder untouched
+
+### Must add carefully
+
+- `FREE_LAUNCH_MODE`
+- rate limit env support
+- typed degraded results
+- structured logging
+- tests around bad URL / provider outage behavior
+
+### Must not add in the first PR
+
+- new database schemas for marketplace
+- Stripe Connect
+- Whop Connect
+- OAuth providers
+- NFT proof jobs
+- multi-account dashboard models
+
+---
+
+## 8. Frontend Audit Notes
+
+### Safe first frontend addition
+
+Only the free-launch banner belongs in the first hardening PR.
+
+### Later frontend additions
+
+- marketplace pages
+- `/realm` pages
+- `/dashboard` operator view
+- wallet display
+- proof tabs
+
+These should be separate PRs.
+
+---
+
+## 9. Legal / Compliance Audit Notes
+
+This report includes helpful guardrails, but none of it is legal advice.
+
+Before shipping marketplace, payouts, crypto, or earnings claims, get human legal review for:
+
+- Terms of Service
+- Privacy Policy
+- Refund Policy
+- DMCA policy
+- FTC earnings / endorsement disclosures
+- Stripe / Whop seller obligations
+- NFT/relic copy and restrictions
+- Apple App Store implications if iOS is ever reintroduced
+
+---
+
+## 10. Decision
+
+The report is useful and should stay in the repo as a strategic reference.
+
+The implementation path should be:
+
+1. Hardening sprint
+2. Director Brain v0
+3. webhook/rate-limit foundation
+4. marketplace schema only after core stability
+5. Signal Realms after marketplace events exist
+6. blockchain only after product-market signal and legal approval
+
+---
+
+## Final Audit Summary
+
+**Approved for docs:** yes.  
+**Approved for direct Codex execution as a whole:** no.  
+**Approved first engineering scope:** Day 3 hardening only.  
+**Paths touched by this docs addition:** `docs/` only.  
+**Runtime behavior changed:** no.

--- a/docs/lwa-worlds-master-council-report.md
+++ b/docs/lwa-worlds-master-council-report.md
@@ -1,0 +1,390 @@
+# LWA Worlds — Master Council Report
+
+**Status:** Strategic architecture and execution roadmap.  
+**Compiled:** April 29, 2026.  
+**Repository:** `jcamacho611/lwa-app`  
+**Backend:** `lwa-backend-production-c9cc.up.railway.app`  
+**Frontend:** `lwa-the-god-app-production.up.railway.app`
+
+> This document is a planning, product, hiring, and Codex prompt pack for the LWA / IWA platform. It is intentionally stored under `docs/` so it does not change runtime behavior. Treat broad market, legal, pricing, API, compensation, and blockchain claims as items requiring fresh verification before investor, legal, or production use.
+
+---
+
+## Document Map
+
+1. Phase 1: LWA Clipping Engine — Day 3 Sprint
+2. Competitive Intelligence Matrix
+3. Platform Signal Database
+4. Marketplace Architecture
+5. RPG / World System — The Signal Realms
+6. Social API Integration Plan
+7. Blockchain / NFT / Appchain Roadmap
+8. Hiring Plan — Founding Council
+9. Master Codex Prompt Stack
+10. Council Executive Summary
+
+`[ASSUMPTION]` marks reasoned inference, not verified fact. `FREE_LAUNCH_MODE` is the proposed public launch flag.
+
+---
+
+# Part 1 — Phase 1: LWA Clipping Engine
+
+## Phase 1 Objective
+
+The current MVP should be hardened before adding marketplace, RPG, blockchain, or social posting. The safest first move is to improve production reliability without changing the core product spine.
+
+## What ships first
+
+1. **FREE_LAUNCH_MODE** — an environment-driven flag that opens the app for public testing while keeping abuse controls.
+2. **Fallback hardening** — every external dependency is wrapped so failures return degraded structured output instead of crashing the frontend.
+3. **README polish** — a concise onboarding document for engineers and candidates.
+
+## Day 3 Codex Prompt
+
+```text
+ROLE: You are a senior backend engineer working on the lwa-app monorepo.
+TASK: Implement Day 3 of the Director Brain sprint in a single PR.
+Never touch iOS, never add a native build target, and never introduce a new external service.
+
+1. Add FREE_LAUNCH_MODE
+   - Read os.getenv("FREE_LAUNCH_MODE", "false").lower() == "true" in backend config and expose settings.free_launch_mode.
+   - When true, get_current_user() should return a synthetic GuestUser(id="guest", tier="free_launch") instead of returning 401 for unauthenticated public testing.
+   - When true, rate limit anonymous traffic by IP at 30 requests/minute and skip paid entitlement checks.
+   - Add a web banner component that renders only when NEXT_PUBLIC_FREE_LAUNCH_MODE === "true".
+
+2. Fallback hardening
+   - Wrap download, transcription, moment detection, and render steps with typed try/except handling.
+   - Log structured fields: step, video_id, error_class, error_msg.
+   - Return a typed degraded result object instead of raising out of the pipeline.
+   - Add deterministic fallbacks for transcript windows, moment windows, captions, and hooks.
+
+3. README polish
+   - Include what it does, live URLs, local dev, required env vars, architecture diagram, API surface, and deploy notes.
+
+4. Verification
+   cd lwa-backend && python3 -m py_compile $(git ls-files '*.py')
+   cd lwa-backend && python3 -m unittest discover
+   cd lwa-web && npm run type-check
+   cd lwa-web && npm run lint
+
+OUTPUT: git diff and one-paragraph PR description.
+```
+
+## Phase 1 Railway Env Vars
+
+| Var | Value | Service |
+|---|---|---|
+| `FREE_LAUNCH_MODE` | `true` | backend |
+| `NEXT_PUBLIC_FREE_LAUNCH_MODE` | `true` | web |
+| `OPENAI_API_KEY` | existing | backend |
+| `ANTHROPIC_API_KEY` | existing | backend |
+| `WHISPER_MODEL` | `small` | backend |
+| `MAX_VIDEO_MINUTES` | `30` | backend |
+| `RATE_LIMIT_GUEST_RPM` | `30` | backend |
+| `DATABASE_URL` | Railway database, if enabled | backend |
+| `REDIS_URL` | Railway Redis, if enabled | backend |
+| `LOG_LEVEL` | `info` | backend |
+
+---
+
+# Part 2 — Competitive Intelligence Matrix
+
+## Positioning
+
+The clipping market is crowded. LWA should not position itself as only another long-form-to-short-form clipping tool. The stronger wedge is:
+
+**AI clipping + operator dashboard + marketplace + progression layer + per-platform intelligence.**
+
+## Competitor Summary
+
+| Tool | Known category | LWA wedge |
+|---|---|---|
+| OpusClip | AI clipping/category leader | Per-platform Director Brain, transparent credit ledger, marketplace layer |
+| Vizard | Long upload clipping, captions, brand kit | Override and re-rank moments; marketplace for creative assets |
+| Munch | Trend-aware clipping | Transparent trend sources and platform-specific scoring |
+| Descript | Transcript-first editor | Short-form-native workflow instead of full editor competition |
+| Captions.ai | Mobile-native capture/edit/caption | Web-first automation and operator flow |
+| CapCut | Template-heavy manual editor | Bulk repurposing and operator workflows |
+| Submagic | Caption styling and B-roll | Add marketplace, RPG, and Director Brain beyond captions |
+| Klap | AI clipping/dubbing | Pair dubbing with marketplace and operator dashboard |
+| Veed.io | Browser video editor | Avoid editor depth fight; focus on creator operations |
+| Repurpose.io | Routing/automation | Own creation plus routing |
+
+## Sales Objection Responses
+
+- **“OpusClip already does this.”** LWA should answer: “OpusClip gives clips. LWA gives a director, platform strategy, packaging, and eventually marketplace distribution.”
+- **“Cheaper tools exist.”** LWA should compete on operator value, not lowest price.
+- **“I don’t trust crypto.”** Blockchain features must remain optional, cosmetic, and provenance-only.
+
+---
+
+# Part 3 — Platform Signal Database
+
+## Platform Signal Draft
+
+| Platform | Hook window | Primary signal draft | LWA action |
+|---|---:|---|---|
+| TikTok | 1–3s | Completion, rewatches, shares | Optimize first frame and retention loop |
+| Instagram Reels | ~2s | Sends/DM shares, watch time, saves | Package for shareability and clean captions |
+| YouTube Shorts | ~1s | Viewed vs swiped, engaged views, retention | Strong cold open and title keywords |
+| LinkedIn | ~3s | Dwell, comment quality, saves | Professional hook and no external-link dependency |
+| Facebook Reels | ~3s | Watch time and shares | Clear visual context and broad captions |
+| X video | ~2s | Replies/reposts | Opinionated hook and debate angle |
+| Twitch clips | ~3s | Clip velocity and context | Open on in-action moment |
+| Whop/community | ~3s | Completion, retention, comments | Education/community packaging |
+
+## Hook Formula Library
+
+Use these formulas as prompt-pack seeds:
+
+1. Contrarian claim
+2. Named-persona callout
+3. Dollar amount, with truthful disclosure
+4. Pattern interrupt
+5. Numbered-list promise
+6. Time compression
+7. Reverse hook
+8. Named enemy
+9. Specific name-drop
+10. Before/after
+11. Unfinished number
+12. Unexpected admission
+13. Framework name
+14. Implied secret
+15. CTA-shaped hook
+16. Objection-first hook
+17. Paradox
+18. Dialogue cold-open
+19. Counter-trend
+20. Dataset hook
+
+## Caption Style Presets
+
+| Preset | Use |
+|---|---|
+| `crimson_pulse` | sales, finance, debate |
+| `clean_op` | education, B2B, coaching |
+| `karaoke_neon` | gaming, music, entertainment |
+| `signal_low` | podcasts/talking heads |
+| `bigframe` | cinematic/personal brand |
+| `medspa_safe` | regulated beauty/health/finance-safe phrasing |
+| `dev_brutal` | AI/tech/dev demos |
+
+---
+
+# Part 4 — Marketplace Architecture
+
+## Marketplace V1 Decision
+
+Stripe Connect Express should be the first marketplace payment rail. Whop integration should be a separate later PR. Keep the marketplace out of Phase 1 hardening.
+
+## Core Backend Concepts
+
+- `users`
+- `seller_accounts`
+- `products`
+- `product_assets`
+- `orders`
+- `payouts`
+- `disputes`
+- `ledger_entries`
+- `webhook_events`
+
+## Marketplace Routes
+
+```text
+POST   /sellers/onboard
+GET    /sellers/me
+POST   /products
+PATCH  /products/{id}
+GET    /products/{id}
+GET    /marketplace
+POST   /orders
+GET    /orders/{id}
+POST   /webhooks/stripe
+POST   /disputes
+GET    /sellers/{id}/payouts
+POST   /admin/takedown
+```
+
+## Marketplace Safety Requirements
+
+- Money stored as integer cents only.
+- Webhooks idempotent via `webhook_events.id`.
+- Append-only ledger is source of truth.
+- Seller payout state machine must support holds, refunds, disputes, failures, and reversals.
+- UI must include earnings disclaimers and banned-category guardrails.
+
+---
+
+# Part 5 — RPG / World System: The Signal Realms
+
+## Premise
+
+The Signal Realms is the LWA progression layer. Creators are “Signalbearers” with classes, factions, quests, badges, and relics. This should be retention and identity, not pay-to-win.
+
+## Classes
+
+Hookwright, Captioneer, Reframer, Trendseer, Loremaster, Voicewright, Ironforger, Pricer, Auditor, Diplomat, Cartographer, Oracle.
+
+## Factions
+
+Crimson Court, Black Loom, Verdant Pact, Iron Choir, Saffron Wake, Glass Synod, Tide Marshal, Driftborn, Emberkin, Chorus of Thoth, House Polis, Outer Signal.
+
+## Rules
+
+- XP comes from real creator outcomes.
+- XP cannot be purchased.
+- Relics are cosmetic only.
+- Badges confer no monetary rights.
+- Blockchain migration, if any, must be exportable from Postgres.
+
+---
+
+# Part 6 — Social API Integration Plan
+
+## Build Order
+
+1. YouTube read integrations
+2. Twitch read/clip integrations
+3. Polymarket public trend reads, with no betting UX
+4. Reddit/Google Trends trend reads where allowed
+5. TikTok Login Kit sandbox
+6. Instagram sandbox/dev flow
+7. TikTok/Instagram publishing only after approval
+
+## Token Security
+
+Social tokens must be encrypted at rest. Add one provider adapter per API and a shared integration-links table.
+
+---
+
+# Part 7 — Blockchain / NFT / Appchain Roadmap
+
+## Guiding Rule
+
+No blockchain feature should be required for core app usage. No item should imply ROI, yield, ownership of revenue, securities value, or feature unlocks.
+
+## Phases
+
+| Phase | Ship |
+|---|---|
+| 0 | Off-chain Postgres ledger |
+| 1 | Optional proof-of-creation Merkle root dry run |
+| 2 | Optional mainnet badges, if legally approved |
+| 3 | Cosmetic relics only |
+| 4 | Appchain decision only after scale forces it |
+
+---
+
+# Part 8 — Hiring Plan
+
+## Founding Council Roles
+
+1. Founder / CEO — High Director of the Signal
+2. Founding Product Architect — Architect of Realms
+3. Principal Full-Stack Engineer — Hand of the Director
+4. AI / Media Pipeline Engineer — Forgemaster of Signals
+5. Game Systems Designer — Loremaster of the Realms
+6. Marketplace Operations Lead — Auditor of the Glass Synod
+7. UI/UX Product Designer — Veilwright
+8. Blockchain / Economy Engineer — Sigilbearer
+9. Legal / Compliance Advisor — Keeper of the Charter
+
+## Human-Required Areas
+
+- Legal/compliance
+- Marketplace trust and safety
+- Smart contract audit
+- RPG economy balancing
+- Final design taste
+- Sales, fundraising, and partnership relationships
+
+---
+
+# Part 9 — Master Codex Prompt Stack
+
+## Immediate Prompt Order
+
+1. Day 3 hardening
+2. Fallback result typing
+3. Director Brain v0
+4. Webhook idempotency
+5. Rate limit middleware
+6. Marketplace MVP scaffolding
+7. Whop integration
+8. Dispute UI
+9. Payout cron
+10. Hook rewriter
+11. Caption renderer
+12. Realms scaffolding
+13. XP awarder hooks
+14. Quest engine
+15. OAuth shell
+16. Polymarket ingestor
+17. Off-chain issuance
+18. Daily Merkle dry run
+19. Operator dashboard
+20. Trust and Safety review queue
+
+**Important:** Do not paste all 20 prompts into Codex at once. Execute one narrow PR at a time.
+
+---
+
+# Part 10 — Council Executive Summary
+
+## Product Truth
+
+LWA should become the operator layer around AI clipping. The clipper is the wedge. The moat is the marketplace, Realms identity, per-platform intelligence, and operator dashboard.
+
+## Top Backend Requirements
+
+1. FastAPI + simple deploy spine
+2. No microservices until forced by scale
+3. Structured fallback behavior
+4. Idempotent webhooks
+5. Integer money math
+6. Append-only ledger
+7. Token encryption
+8. Redis-backed rate limits
+9. Evidence-hash XP awarder
+10. Structured logs and request IDs
+
+## Top Frontend Requirements
+
+1. Dark premium operator aesthetic
+2. Simple source-first clipping flow
+3. Rendered-first results
+4. Strategy-only lane clearly separated
+5. Realms pages later, not Phase 1
+6. Marketplace pages later, not Phase 1
+7. Earnings disclaimers where monetization appears
+8. Optional wallet display only
+9. Type checking before PRs
+10. No iOS scope in Phase 1
+
+## 30-Day Build Plan
+
+| Week | Deliverable |
+|---|---|
+| 1 | Day 3 hardening + Director Brain v0 |
+| 2 | Marketplace scaffolding + design system |
+| 3 | XP/quest design + caption/hook systems |
+| 4 | Stripe Connect sandbox + public free-launch testing |
+
+## Critical Mistakes To Avoid
+
+- Do not let roadmap docs become active implementation scope.
+- Do not promise guaranteed earnings.
+- Do not build crypto before product-market signal.
+- Do not build iOS during Phase 1 hardening.
+- Do not skip webhooks, ledger, fallback tests, or rate limits.
+- Do not paste the whole report into Codex at once.
+
+---
+
+## Implementation Note
+
+This document is the repo-safe version of the LWA Worlds Master Council Report. The full source draft was provided in chat/uploaded markdown and should be used as strategic source material. The audited implementation order is captured in `docs/lwa-worlds-master-council-audit.md`.
+
+**Cosmetic items only. Earnings vary. No guarantee of income. Not legal, financial, or investment advice. Blockchain features are optional and provenance-only. Web-first; iOS is out of scope for Phase 1.**


### PR DESCRIPTION
## Superseded

This PR was replaced by the cleaner docs-only PR #30.

Reason: this branch included eight older `docs/company/...` planning files in addition to the two new LWA Worlds files. To avoid accidental merge confusion, use PR #30 instead.

Clean replacement: #30