### PR TITLE
web: add compare and use-case hub pages

### DIFF
--- a/lwa-web/app/compare/page.tsx
+++ b/lwa-web/app/compare/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { SearchHubPage } from "../../components/search/SearchHubPage";
+import { comparisonPages } from "../../lib/search-pages";
+import { absoluteUrl, breadcrumbJsonLd, buildPageMetadata, softwareJsonLd } from "../../lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Compare AI Clipping Tools",
+  description: "Compare LWA against Opus Clip, CapCut, and related clipping workflows without leaving the live product layer.",
+  path: "/compare",
+  keywords: [
+    "ai clipping tool comparison",
+    "opus clip alternative",
+    "capcut alternative for clipping",
+    "best ai clipping tool",
+  ],
+});
+
+export default function CompareHubPage() {
+  const jsonLd = [
+    softwareJsonLd({
+      name: "LWA",
+      url: absoluteUrl("/compare"),
+      description: "Comparison pages for LWA and the current AI clipping tool landscape.",
+    }),
+    breadcrumbJsonLd([
+      { name: "LWA", url: absoluteUrl("/") },
+      { name: "Compare", url: absoluteUrl("/compare") },
+    ]),
+  ];
+
+  return (
+    <SearchHubPage
+      kicker="Compare"
+      title="Open the clipping comparisons without cluttering the product."
+      description="These pages help high-intent traffic understand where LWA wins on ranked output, packaging, and operator flow before they move into the generator."
+      pages={comparisonPages}
+      jsonLd={<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />}
+    />
+  );
+}

--- a/lwa-web/app/sitemap.ts
+++ b/lwa-web/app/sitemap.ts
@@ -12,6 +12,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/settings",
     "/history",
     "/upload",
+    "/compare",
+    "/use-cases",
   ];
 
   const dynamicRoutes = [...comparisonPages, ...useCasePages].map((page) => page.path);
@@ -19,7 +21,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [...staticRoutes, ...dynamicRoutes].map((route) => ({
     url: absoluteUrl(route),
     lastModified: new Date(),
-    changeFrequency: route === "" ? "weekly" : "monthly",
-    priority: route === "" ? 1 : route === "/generate" ? 0.95 : 0.72,
+    changeFrequency: route === "" ? "weekly" : route === "/generate" ? "weekly" : "monthly",
+    priority:
+      route === ""
+        ? 1
+        : route === "/generate"
+          ? 0.95
+          : route === "/compare" || route === "/use-cases"
+            ? 0.82
+            : 0.72,
   }));
 }

--- a/lwa-web/app/use-cases/page.tsx
+++ b/lwa-web/app/use-cases/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { SearchHubPage } from "../../components/search/SearchHubPage";
+import { useCasePages } from "../../lib/search-pages";
+import { absoluteUrl, breadcrumbJsonLd, buildPageMetadata, softwareJsonLd } from "../../lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "AI Clipping Use Cases",
+  description: "Open creator, podcast, and clipping-operator use cases that map directly to the live LWA workflow.",
+  path: "/use-cases",
+  keywords: [
+    "podcast clip generator",
+    "creator repurposing tool",
+    "whop clipping workflow",
+    "ai clipping use cases",
+  ],
+});
+
+export default function UseCasesHubPage() {
+  const jsonLd = [
+    softwareJsonLd({
+      name: "LWA",
+      url: absoluteUrl("/use-cases"),
+      description: "Use-case pages for creators, podcasters, and clipping operators using LWA.",
+    }),
+    breadcrumbJsonLd([
+      { name: "LWA", url: absoluteUrl("/") },
+      { name: "Use Cases", url: absoluteUrl("/use-cases") },
+    ]),
+  ];
+
+  return (
+    <SearchHubPage
+      kicker="Use Cases"
+      title="Show the workflow by audience, not with generic SEO sludge."
+      description="These pages map LWA to real creator, podcast, and clipping-operator workflows so search traffic lands on something that still feels like the product."
+      pages={useCasePages}
+      jsonLd={<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />}
+    />
+  );
+}

--- a/lwa-web/components/search/SearchHubPage.tsx
+++ b/lwa-web/components/search/SearchHubPage.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { AIBackground } from "../AIBackground";
+import Navbar from "../Navbar";
+import { SearchLandingData } from "../../lib/search-pages";
+
+type SearchHubPageProps = {
+  kicker: string;
+  title: string;
+  description: string;
+  pages: SearchLandingData[];
+  jsonLd?: ReactNode;
+};
+
+const searchNavItems = [
+  { href: "/generate", label: "Forge Clips" },
+  { href: "/compare", label: "Compare" },
+  { href: "/use-cases", label: "Use Cases" },
+] as const;
+
+export function SearchHubPage({ kicker, title, description, pages, jsonLd }: SearchHubPageProps) {
+  return (
+    <main className="app-shell-grid min-h-screen">
+      <AIBackground variant="home" />
+      {jsonLd}
+
+      <div className="mx-auto w-full max-w-7xl px-4 pb-20 pt-6 sm:px-6 lg:px-8">
+        <Navbar
+          items={searchNavItems.map((item) => ({ href: item.href, label: item.label }))}
+          variant="home"
+          showTagline
+          rightSlot={
+            <div className="flex items-center gap-2">
+              <Link href="/generate" className="primary-button inline-flex rounded-full px-4 py-2.5 text-sm font-semibold">
+                Forge Clips
+              </Link>
+              <Link href="/dashboard" className="secondary-button inline-flex rounded-full px-4 py-2.5 text-sm font-medium">
+                Open Control Room
+              </Link>
+            </div>
+          }
+        />
+
+        <section className="home-stage grid gap-10 pb-12 pt-16 lg:grid-cols-[1.04fr,0.96fr] lg:items-start">
+          <div className="space-y-6">
+            <div className="home-stage-grid" aria-hidden="true">
+              <div className="home-stage-sigil" />
+              <div className="home-stage-constellation" />
+              <div className="home-stage-fog" />
+            </div>
+
+            <div className="space-y-4">
+              <p className="section-kicker">{kicker}</p>
+              <h1 className="page-title max-w-5xl text-5xl font-semibold leading-[0.98] text-ink sm:text-6xl lg:text-7xl" dir="auto">
+                {title}
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-subtext sm:text-lg" dir="auto">
+                {description}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link href="/generate" className="primary-button inline-flex items-center justify-center rounded-full px-6 py-3.5 text-sm font-semibold">
+                Forge Clips
+              </Link>
+              <Link href="/dashboard" className="secondary-button inline-flex items-center justify-center rounded-full px-6 py-3.5 text-sm font-medium">
+                Open Control Room
+              </Link>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {[`${pages.length} pages live`, "Search-friendly", "No UI clutter"].map((item, index) => (
+                <span
+                  key={item}
+                  className={[
+                    "rounded-full border px-3 py-1.5 text-xs font-semibold",
+                    index === 0
+                      ? "border-accentCrimson/35 bg-[linear-gradient(135deg,rgba(255,0,60,0.2),rgba(255,45,166,0.14),rgba(0,231,255,0.08))] text-white shadow-crimson"
+                      : "border-white/10 bg-white/[0.05] text-ink/72",
+                  ].join(" ")}
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="home-proof-card home-proof-card-lead rounded-[28px] p-6">
+              <p className="section-kicker">Why this layer matters</p>
+              <h2 className="mt-3 text-2xl font-semibold text-ink">The discovery layer should be useful and still feel like the product.</h2>
+              <p className="mt-3 text-sm leading-7 text-ink/70" dir="auto">
+                These pages help search traffic land on real workflow context, then move directly into generation, review, and operator surfaces without cluttering the main app.
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="signal-card rounded-[26px] p-5">
+                <p className="text-sm font-semibold text-ink">Comparison intent</p>
+                <p className="mt-2 text-sm leading-6 text-ink/62">Catch high-buying-intent traffic already looking for an alternative.</p>
+              </div>
+              <div className="glass-panel rounded-[26px] p-5">
+                <p className="text-sm font-semibold text-ink">Use-case intent</p>
+                <p className="mt-2 text-sm leading-6 text-ink/62">Meet creators, clippers, and operators at the exact workflow they are trying to solve.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-5 pb-8 lg:grid-cols-2">
+          {pages.map((page, index) => (
+            <article key={page.path} className={index === 0 ? "home-proof-card home-proof-card-lead rounded-[28px] p-6" : "glass-panel rounded-[28px] p-6"}>
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="section-kicker">{page.kicker}</p>
+                <span className="rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-ink/62">
+                  {page.type === "comparison" ? "Comparison" : "Use case"}
+                </span>
+              </div>
+              <h2 className="mt-3 text-2xl font-semibold text-ink" dir="auto">
+                {page.title}
+              </h2>
+              <p className="mt-4 text-sm leading-7 text-subtext" dir="auto">
+                {page.description}
+              </p>
+              <div className="mt-5 flex flex-wrap gap-2">
+                {page.proofPoints.map((point, pointIndex) => (
+                  <span
+                    key={point}
+                    className={[
+                      "rounded-full border px-3 py-1.5 text-xs font-semibold",
+                      pointIndex === 0
+                        ? "border-accentCrimson/35 bg-[linear-gradient(135deg,rgba(255,0,60,0.2),rgba(255,45,166,0.14),rgba(0,231,255,0.08))] text-white shadow-crimson"
+                        : "border-white/10 bg-white/[0.05] text-ink/72",
+                    ].join(" ")}
+                  >
+                    {point}
+                  </span>
+                ))}
+              </div>
+              <div className="mt-5 space-y-3">
+                {page.sections.slice(0, 2).map((section) => (
+                  <div key={section.title} className="metric-tile rounded-[22px] px-4 py-3 text-sm text-ink/78" dir="auto">
+                    <span className="block font-semibold text-ink">{section.title}</span>
+                    <span className="mt-1 block text-ink/62">{section.body}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <Link href={page.path} className="primary-button inline-flex items-center justify-center rounded-full px-5 py-3 text-sm font-semibold">
+                  Open page
+                </Link>
+                <Link href="/generate" className="secondary-button inline-flex items-center justify-center rounded-full px-5 py-3 text-sm font-medium">
+                  Forge clips
+                </Link>
+              </div>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Recreates the search hub work from the conflicted PR on a clean branch from current `main`.

## What changed

- Adds `lwa-web/components/search/SearchHubPage.tsx`
- Adds `/compare` hub route
- Adds `/use-cases` hub route
- Adds both hub routes to the sitemap

## Runtime scope

Frontend/search-discovery only. No backend, iOS, Railway, payment, marketplace, or generation route changes.