### PR TITLE
backend: add Whop verified webhook MVP

### DIFF
--- a/lwa-backend/app/api/routes/whop_webhooks.py
+++ b/lwa-backend/app/api/routes/whop_webhooks.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ...core.config import get_settings
+from ...services.whop_entitlements import WhopEntitlementStore, verify_whop_signature
+
+router = APIRouter(prefix="/v1/webhooks", tags=["webhooks"])
+settings = get_settings()
+whop_store = WhopEntitlementStore(settings.platform_db_path)
+
+
+def _signature_from_request(request: Request) -> str | None:
+    return (
+        request.headers.get("whop-signature")
+        or request.headers.get("x-whop-signature")
+        or request.headers.get("x-signature")
+    )
+
+
+@router.post("/whop")
+async def whop_webhook(request: Request) -> dict[str, object]:
+    if not settings.enable_whop_verification:
+        raise HTTPException(status_code=404, detail="Whop verification is not enabled")
+
+    body = await request.body()
+    signature = _signature_from_request(request)
+    if not verify_whop_signature(body=body, signature=signature, secret=settings.whop_webhook_secret):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    try:
+        payload = await request.json()
+    except Exception as error:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload") from error
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Webhook payload must be an object")
+
+    result = whop_store.process_event(payload)
+    return {
+        "status": "ok",
+        "event_id": result.event_id,
+        "event_type": result.event_type,
+        "processed": result.processed,
+        "replayed": result.replayed,
+        "user_email": result.user_email,
+        "plan": result.plan,
+        "message": result.message,
+    }

--- a/lwa-backend/app/main.py
+++ b/lwa-backend/app/main.py
@@ -21,6 +21,7 @@ from .api.routes.upload import router as upload_router
 from .api.routes.video_analysis import router as video_analysis_router
 from .api.routes.visual_generation import router as visual_generation_router
 from .api.routes.wallet import router as wallet_router
+from .api.routes.whop_webhooks import router as whop_webhooks_router
 from .core.config import get_settings
 from .services.asset_retention import cleanup_generated_assets_nonfatal_for_settings
 from .services.db_init import initialize_databases
@@ -72,6 +73,7 @@ def create_app() -> FastAPI:
     app.include_router(clip_status_router)
     app.include_router(clips_router)
     app.include_router(edit_router)
+    app.include_router(whop_webhooks_router)
     logger.info(
         "app_ready generated_assets_dir=%s generated_mount=/generated uploads_dir=%s uploads_mount=/uploads log_level=%s",
         settings.generated_assets_dir,

--- a/lwa-backend/app/services/whop_entitlements.py
+++ b/lwa-backend/app/services/whop_entitlements.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hmac
+import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from threading import Lock
+from typing import Any, Iterator
+
+
+def utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class WhopWebhookResult:
+    event_id: str
+    event_type: str
+    processed: bool
+    replayed: bool
+    user_email: str | None
+    plan: str | None
+    message: str
+
+
+def verify_whop_signature(*, body: bytes, signature: str | None, secret: str | None) -> bool:
+    if not secret:
+        return False
+    provided = (signature or "").strip()
+    if not provided:
+        return False
+    expected = hmac.new(secret.encode("utf-8"), body, sha256).hexdigest()
+    candidates = {provided}
+    if provided.startswith("sha256="):
+        candidates.add(provided.split("=", 1)[1])
+    return any(hmac.compare_digest(candidate, expected) for candidate in candidates)
+
+
+def extract_event_id(payload: dict[str, Any]) -> str:
+    return str(payload.get("id") or payload.get("event_id") or payload.get("webhook_id") or "").strip()
+
+
+def extract_event_type(payload: dict[str, Any]) -> str:
+    return str(payload.get("type") or payload.get("event") or payload.get("event_type") or "unknown").strip()
+
+
+def extract_user_email(payload: dict[str, Any]) -> str | None:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    candidates = [
+        data.get("email") if isinstance(data, dict) else None,
+        data.get("user_email") if isinstance(data, dict) else None,
+        data.get("customer_email") if isinstance(data, dict) else None,
+        data.get("member", {}).get("email") if isinstance(data, dict) and isinstance(data.get("member"), dict) else None,
+        data.get("user", {}).get("email") if isinstance(data, dict) and isinstance(data.get("user"), dict) else None,
+    ]
+    for candidate in candidates:
+        value = str(candidate or "").strip().lower()
+        if value and "@" in value:
+            return value
+    return None
+
+
+def plan_for_event(event_type: str) -> str | None:
+    normalized = event_type.strip().lower()
+    valid_terms = ("valid", "paid", "succeeded", "active", "created", "renewed")
+    invalid_terms = ("invalid", "cancel", "failed", "expired", "deleted", "refunded", "chargeback")
+    if any(term in normalized for term in invalid_terms):
+        return "free"
+    if any(term in normalized for term in valid_terms):
+        return "pro"
+    return None
+
+
+class WhopEntitlementStore:
+    def __init__(self, path: str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = Lock()
+        self._init_db()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        connection = sqlite3.connect(self._path, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+        try:
+            yield connection
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _init_db(self) -> None:
+        with self._lock, self._connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS whop_webhook_events (
+                    id TEXT PRIMARY KEY,
+                    event_type TEXT NOT NULL,
+                    user_email TEXT,
+                    plan TEXT,
+                    payload_json TEXT NOT NULL,
+                    processed_at TEXT NOT NULL
+                );
+                """
+            )
+
+    def process_event(self, payload: dict[str, Any]) -> WhopWebhookResult:
+        event_id = extract_event_id(payload)
+        if not event_id:
+            event_id = sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+        event_type = extract_event_type(payload)
+        user_email = extract_user_email(payload)
+        plan = plan_for_event(event_type)
+        processed_at = utcnow()
+        payload_json = json.dumps(payload, sort_keys=True)
+
+        with self._lock, self._connect() as connection:
+            existing = connection.execute(
+                "SELECT id, event_type, user_email, plan FROM whop_webhook_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if existing:
+                return WhopWebhookResult(
+                    event_id=event_id,
+                    event_type=str(existing["event_type"]),
+                    processed=False,
+                    replayed=True,
+                    user_email=existing["user_email"],
+                    plan=existing["plan"],
+                    message="Webhook event already processed.",
+                )
+
+            connection.execute(
+                """
+                INSERT INTO whop_webhook_events (id, event_type, user_email, plan, payload_json, processed_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (event_id, event_type, user_email, plan, payload_json, processed_at),
+            )
+
+            if user_email and plan:
+                connection.execute("UPDATE users SET plan = ? WHERE email = ?", (plan, user_email))
+
+        return WhopWebhookResult(
+            event_id=event_id,
+            event_type=event_type,
+            processed=True,
+            replayed=False,
+            user_email=user_email,
+            plan=plan,
+            message="Webhook processed." if plan else "Webhook stored; no entitlement change required.",
+        )

--- a/lwa-backend/tests/test_whop_entitlements.py
+++ b/lwa-backend/tests/test_whop_entitlements.py
@@ -1,0 +1,108 @@
+import hmac
+import json
+from hashlib import sha256
+from pathlib import Path
+
+from app.auth.security import hash_password
+from app.services.platform_store import PlatformStore
+from app.services.whop_entitlements import (
+    WhopEntitlementStore,
+    extract_user_email,
+    plan_for_event,
+    verify_whop_signature,
+)
+
+
+def sign(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode("utf-8"), body, sha256).hexdigest()
+
+
+def test_verify_whop_signature_accepts_hex_and_prefixed_signature() -> None:
+    body = b'{"id":"evt_1"}'
+    secret = "test-secret"
+    signature = sign(body, secret)
+    assert verify_whop_signature(body=body, signature=signature, secret=secret)
+    assert verify_whop_signature(body=body, signature=f"sha256={signature}", secret=secret)
+    assert not verify_whop_signature(body=body, signature="bad", secret=secret)
+
+
+def test_extract_user_email_from_common_payload_shapes() -> None:
+    assert extract_user_email({"data": {"member": {"email": "USER@EXAMPLE.COM"}}}) == "user@example.com"
+    assert extract_user_email({"data": {"user": {"email": "user@example.com"}}}) == "user@example.com"
+    assert extract_user_email({"data": {"customer_email": "user@example.com"}}) == "user@example.com"
+
+
+def test_plan_for_event_maps_valid_and_invalid_memberships() -> None:
+    assert plan_for_event("membership.went_valid") == "pro"
+    assert plan_for_event("payment.succeeded") == "pro"
+    assert plan_for_event("membership.went_invalid") == "free"
+    assert plan_for_event("payment.failed") == "free"
+    assert plan_for_event("unknown.event") is None
+
+
+def test_whop_event_is_idempotent_and_updates_user_plan(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "platform.sqlite3")
+    platform_store = PlatformStore(db_path)
+    platform_store.create_user(
+        email="buyer@example.com",
+        password_hash=hash_password("password123"),
+        plan="free",
+    )
+    whop_store = WhopEntitlementStore(db_path)
+
+    payload = {
+        "id": "evt_123",
+        "type": "membership.went_valid",
+        "data": {"member": {"email": "buyer@example.com"}},
+    }
+
+    result = whop_store.process_event(payload)
+    assert result.processed is True
+    assert result.replayed is False
+    assert result.plan == "pro"
+    assert platform_store.get_user_by_email("buyer@example.com").plan == "pro"
+
+    replay = whop_store.process_event(payload)
+    assert replay.processed is False
+    assert replay.replayed is True
+    assert platform_store.get_user_by_email("buyer@example.com").plan == "pro"
+
+
+def test_whop_invalid_event_downgrades_user_to_free(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "platform.sqlite3")
+    platform_store = PlatformStore(db_path)
+    platform_store.create_user(
+        email="buyer@example.com",
+        password_hash=hash_password("password123"),
+        plan="pro",
+    )
+    whop_store = WhopEntitlementStore(db_path)
+
+    payload = {
+        "id": "evt_124",
+        "type": "membership.went_invalid",
+        "data": {"member": {"email": "buyer@example.com"}},
+    }
+
+    result = whop_store.process_event(payload)
+    assert result.processed is True
+    assert result.plan == "free"
+    assert platform_store.get_user_by_email("buyer@example.com").plan == "free"
+
+
+def test_event_without_email_is_stored_without_entitlement_change(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "platform.sqlite3")
+    whop_store = WhopEntitlementStore(db_path)
+    payload = {"id": "evt_no_email", "type": "payment.succeeded", "data": {}}
+    result = whop_store.process_event(payload)
+    assert result.processed is True
+    assert result.user_email is None
+    assert result.plan == "pro"
+    assert "processed" in result.message.lower()
+
+
+def test_signature_matches_json_body() -> None:
+    payload = {"id": "evt_json", "type": "payment.succeeded"}
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    secret = "secret"
+    assert verify_whop_signature(body=body, signature=sign(body, secret), secret=secret)


### PR DESCRIPTION
## Summary

Adds the smallest safe Whop verified webhook MVP for paid entitlement updates.

## Included

- `lwa-backend/app/services/whop_entitlements.py`
  - HMAC SHA-256 signature verification
  - event id extraction
  - event type extraction
  - user email extraction from common payload shapes
  - event-to-plan mapping
  - idempotent webhook event storage in SQLite
  - user plan update by email

- `lwa-backend/app/api/routes/whop_webhooks.py`
  - `POST /v1/webhooks/whop`
  - gated by `LWA_ENABLE_WHOP_VERIFICATION=true`
  - verifies signature before processing

- `lwa-backend/app/main.py`
  - registers the Whop webhook route

- `lwa-backend/tests/test_whop_entitlements.py`
  - signature verification
  - common email extraction shapes
  - valid/invalid event plan mapping
  - idempotent replay handling
  - upgrade/downgrade user plan behavior

## Explicitly not included

- no marketplace payouts
- no seller balances
- no Stripe Connect movement
- no Whop submerchant payouts
- no iOS changes
- no frontend changes

## Env vars

Already supported by config:

```bash
LWA_ENABLE_WHOP_VERIFICATION=true
WHOP_WEBHOOK_SECRET=...
WHOP_API_KEY=...
WHOP_COMPANY_ID=...
WHOP_PRODUCT_ID=...
```

## Verification to run

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

## Launch note

After this merges, Whop can be described as webhook-backed entitlement verification only if the Railway backend has `LWA_ENABLE_WHOP_VERIFICATION=true` and `WHOP_WEBHOOK_SECRET` configured and webhook delivery is confirmed.