### PR TITLE
web: add free launch banner

### DIFF
--- a/lwa-web/app/layout.tsx
+++ b/lwa-web/app/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { Poppins } from "next/font/google";
 import { BackgroundCanvas } from "../components/BackgroundCanvas";
 import { CharacterStage } from "../components/CharacterStage";
+import { FreeLaunchBanner } from "../components/FreeLaunchBanner";
 import { resolveDirection, resolveLocale } from "../lib/intl";
 import { siteUrl } from "../lib/seo";
 import "./globals.css";
@@ -70,6 +71,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
       <body className={`${poppinsBody.variable} ${poppinsDisplay.variable} antialiased`}>
         <BackgroundCanvas />
         <CharacterStage />
+        <FreeLaunchBanner />
         <main className="lwa-ui-layer" style={{ position: "relative", zIndex: 10 }}>
           {children}
         </main>

--- a/lwa-web/components/FreeLaunchBanner.tsx
+++ b/lwa-web/components/FreeLaunchBanner.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export function FreeLaunchBanner() {
+  if (process.env.NEXT_PUBLIC_FREE_LAUNCH_MODE !== "true") {
+    return null;
+  }
+
+  return (
+    <aside className="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-black/80 px-4 py-3 text-center text-sm text-white shadow-[0_12px_40px_rgba(0,0,0,0.35)] backdrop-blur-xl">
+      <span className="font-semibold text-white">Free launch mode is live.</span>{" "}
+      <span className="text-white/72">Generate and review LWA clip packages while public launch access is open.</span>{" "}
+      <Link href="/generate" className="font-semibold text-white underline decoration-white/35 underline-offset-4 hover:decoration-white">
+        Forge clips
+      </Link>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a small environment-controlled free launch banner to the web app.

## What changed

- Adds `FreeLaunchBanner`
- Renders it in the root layout only when `NEXT_PUBLIC_FREE_LAUNCH_MODE=true`

## Scope

Frontend-only. No backend, iOS, route, payment, entitlement, or generation changes.