### PR TITLE
docs: add remaining LWA algorithm chunks

### DIFF
--- a/docs/lwa-worlds/chunk-4-sql-repository-layer.md
+++ b/docs/lwa-worlds/chunk-4-sql-repository-layer.md
@@ -1,0 +1,260 @@
+# LWA CHUNK 4 — SQL MIGRATIONS AND REPOSITORY LAYER
+
+This chunk continues the LWA algorithm stack with database migration order, repository responsibilities, guard queries, and implementation prompts. It is additive planning only and does not mark unfinished systems as live.
+
+## Current product truth
+
+- LWA has a working clipping MVP.
+- Public URL generation and clip packs exist.
+- Director Brain metadata and rendered-vs-strategy-only flow are part of the product direction.
+- Upload pipeline, full editor, direct social posting, marketplace, Signal Realms, blockchain provenance, and full iOS rebuild require separate feature-flagged implementation.
+
+## Core database rules
+
+```text
+- Use UUID primary keys.
+- Use integer cents for all money fields.
+- Use JSONB for flexible algorithm details.
+- Keep important searchable fields as normal columns.
+- Webhook/event ingestion must be idempotent.
+- Strategy-only clips must not have playable asset URLs.
+- Rendered clips must have real playable/downloadable asset records.
+- Long media processing should not hold open database transactions.
+```
+
+## Migration order
+
+```text
+001_feature_flags.sql
+002_upload_assets.sql
+003_generation_core.sql
+004_director_brain_scores.sql
+005_clip_results_assets.sql
+006_campaigns.sql
+007_learning_usage_webhooks.sql
+008_editor_tables.sql
+009_social_tables.sql
+010_marketplace_tables.sql
+011_realms_tables.sql
+012_proof_tables.sql
+013_operator_indexes.sql
+014_rls_policies.sql
+```
+
+## Repository structure
+
+```text
+lwa-backend/app/db/repositories/
+  feature_flags_repo.py
+  source_assets_repo.py
+  upload_assets_repo.py
+  generation_jobs_repo.py
+  transcript_repo.py
+  moment_candidates_repo.py
+  scores_repo.py
+  clip_results_repo.py
+  campaign_repo.py
+  learning_repo.py
+  usage_repo.py
+  webhook_events_repo.py
+  editor_repo.py
+  social_repo.py
+  marketplace_repo.py
+  realms_repo.py
+  proof_repo.py
+  operator_repo.py
+```
+
+## Repository rules
+
+Repositories should only read and write data. Algorithm services should make decisions.
+
+```python
+async def create_record(session, payload):
+    ...
+
+async def get_record(session, record_id):
+    ...
+
+async def update_record(session, record_id, patch):
+    ...
+
+async def list_records_for_user(session, user_id, limit=50):
+    ...
+```
+
+## Transaction boundaries
+
+```text
+Generation phase 1: create source asset and job.
+Generation phase 2: save transcript and segment signals.
+Generation phase 3: save moment candidates and scores.
+Generation phase 4: save packages and clip results.
+Generation phase 5: save assets and quality gate results.
+Generation phase 6: update final job summary.
+```
+
+Media rendering should happen outside a long database transaction. Persist state, process media, then reopen a transaction for result updates.
+
+## Feature flags table
+
+```sql
+CREATE TABLE IF NOT EXISTS feature_flags (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    feature_key TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'planned',
+    is_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    visible_to_users BOOLEAN NOT NULL DEFAULT FALSE,
+    visible_to_admins BOOLEAN NOT NULL DEFAULT TRUE,
+    visible_to_beta_users BOOLEAN NOT NULL DEFAULT FALSE,
+    rollout_percent INTEGER NOT NULL DEFAULT 0 CHECK (rollout_percent BETWEEN 0 AND 100),
+    description TEXT NULL,
+    user_facing_label TEXT NULL,
+    internal_notes TEXT NULL,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flags_key ON feature_flags(feature_key);
+CREATE INDEX IF NOT EXISTS idx_feature_flags_status ON feature_flags(status);
+```
+
+## Feature flag seed
+
+```sql
+INSERT INTO feature_flags (feature_key, display_name, status, is_enabled, visible_to_users, visible_to_admins, visible_to_beta_users, user_facing_label)
+VALUES
+('ai_clipping', 'AI Clipping Engine', 'live', TRUE, TRUE, TRUE, TRUE, 'Live'),
+('director_brain', 'Director Brain', 'beta', TRUE, TRUE, TRUE, TRUE, 'Beta'),
+('upload_pipeline', 'Upload Pipeline', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned'),
+('full_editor', 'Full Editor', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned'),
+('campaign_manager', 'Campaign Manager', 'scaffolded', FALSE, FALSE, TRUE, TRUE, 'Beta soon'),
+('direct_social_posting', 'Direct Social Posting', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned'),
+('marketplace', 'Creator Marketplace', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned'),
+('rpg_realms', 'Signal Realms RPG', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned'),
+('blockchain_provenance', 'Proof of Creation', 'planned', FALSE, FALSE, TRUE, FALSE, 'Optional future'),
+('ios_rebuild', 'Full iOS Rebuild', 'planned', FALSE, FALSE, TRUE, FALSE, 'Planned')
+ON CONFLICT (feature_key) DO NOTHING;
+```
+
+## Upload assets table
+
+```sql
+CREATE TABLE IF NOT EXISTS upload_assets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NULL,
+    creator_profile_id UUID NULL,
+    upload_source TEXT NOT NULL DEFAULT 'local_file',
+    original_filename TEXT NOT NULL,
+    storage_bucket TEXT NOT NULL,
+    storage_key TEXT NOT NULL UNIQUE,
+    public_url TEXT NULL,
+    signed_url_expires_at TIMESTAMPTZ NULL,
+    mime_type TEXT NULL,
+    file_size_bytes BIGINT NULL,
+    duration_seconds INTEGER NULL,
+    width INTEGER NULL,
+    height INTEGER NULL,
+    frame_rate NUMERIC(8,3) NULL,
+    upload_status TEXT NOT NULL DEFAULT 'requested',
+    scan_status TEXT NOT NULL DEFAULT 'pending',
+    checksum_sha256 TEXT NULL,
+    source_asset_id UUID NULL,
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    error_message TEXT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_upload_assets_user ON upload_assets(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_upload_assets_status ON upload_assets(upload_status);
+CREATE INDEX IF NOT EXISTS idx_upload_assets_checksum ON upload_assets(checksum_sha256);
+```
+
+## Generation job update query
+
+```sql
+UPDATE generation_jobs
+SET status = $2,
+    processing_summary = processing_summary || $3::jsonb,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+```
+
+## Clip result guard query: rendered clips require assets
+
+```sql
+SELECT cr.id
+FROM clip_results cr
+LEFT JOIN clip_assets ca ON ca.clip_result_id = cr.id
+WHERE cr.render_status = 'rendered'
+GROUP BY cr.id
+HAVING COUNT(ca.id) FILTER (WHERE ca.asset_type IN ('edited_clip', 'preview')) = 0;
+```
+
+Expected result: zero rows.
+
+## Clip result guard query: strategy-only has no playable asset
+
+```sql
+SELECT cr.id
+FROM clip_results cr
+JOIN clip_assets ca ON ca.clip_result_id = cr.id
+WHERE cr.strategy_only = TRUE
+  AND cr.render_status = 'strategy_only'
+  AND ca.asset_type IN ('edited_clip', 'preview', 'raw_clip');
+```
+
+Expected result: zero rows.
+
+## Operator queries
+
+Failed or partial jobs:
+
+```sql
+SELECT id, request_id, source_url, status, error_code, error_message, created_at
+FROM generation_jobs
+WHERE status IN ('failed', 'fallback', 'partial')
+ORDER BY created_at DESC
+LIMIT 100;
+```
+
+Render state report:
+
+```sql
+SELECT
+    date_trunc('day', created_at) AS day,
+    COUNT(*) AS total_clips,
+    COUNT(*) FILTER (WHERE render_status = 'rendered') AS rendered,
+    COUNT(*) FILTER (WHERE render_status = 'raw_only') AS raw_only,
+    COUNT(*) FILTER (WHERE render_status = 'strategy_only') AS strategy_only,
+    COUNT(*) FILTER (WHERE render_status = 'failed') AS failed
+FROM clip_results
+GROUP BY day
+ORDER BY day DESC;
+```
+
+## Codex prompt
+
+```text
+Implement Chunk 4 only.
+
+Task:
+Add safe SQL migration files and repository scaffolds for feature flags, upload assets, generation lifecycle, clip result guards, and operator queries.
+
+Rules:
+- Preserve existing backend routes.
+- Additive changes only.
+- Do not touch lwa-web.
+- Do not touch lwa-ios.
+- Do not mark planned features as live.
+- Do not create playable URLs without real assets.
+
+Verification:
+- git status --short
+- python -m py_compile on changed backend files
+- pytest relevant backend tests
+```

--- a/docs/lwa-worlds/chunk-5-frontend-display-logic.md
+++ b/docs/lwa-worlds/chunk-5-frontend-display-logic.md
@@ -1,0 +1,179 @@
+# LWA CHUNK 5 — FRONTEND TYPES AND DISPLAY LOGIC
+
+This chunk defines how the frontend should display Director Brain, campaign, and render state fields safely.
+
+## Truth rule
+
+The frontend must support future fields without pretending unfinished systems are live.
+
+```text
+Rendered = playable media exists.
+Raw-only = raw media exists.
+Strategy-only = no playable media, but timestamps and packaging are useful.
+Failed = do not present as a normal clip.
+```
+
+## Optional TypeScript fields
+
+```ts
+export type ClipRenderStatus = 'rendered' | 'raw_only' | 'strategy_only' | 'failed';
+
+export type DirectorBrainClipFields = {
+  algorithm_version?: string | null;
+  render_status?: ClipRenderStatus | null;
+  strategy_only?: boolean | null;
+  reason_not_rendered?: string | null;
+  post_rank?: number | null;
+  hook_variants?: string[] | null;
+  caption_style?: string | null;
+  thumbnail_text?: string | null;
+  cta_suggestion?: string | null;
+  why_this_matters?: string | null;
+  quality_gate_status?: 'pass' | 'warning' | 'fail' | 'strategy_only' | null;
+  render_readiness_score?: number | null;
+  revenue_intent_score?: number | null;
+  offer_fit_score?: number | null;
+  campaign_role?: string | null;
+  campaign_reason?: string | null;
+  funnel_stage?: string | null;
+  suggested_post_order?: number | null;
+  suggested_platform?: string | null;
+  suggested_caption_style?: string | null;
+  suggested_cta?: string | null;
+};
+```
+
+## Media-state helpers
+
+```ts
+export function getPlayableUrl(clip: ClipResult): string | null {
+  return clip.preview_url || clip.edited_clip_url || clip.clip_url || null;
+}
+
+export function getRawUrl(clip: ClipResult): string | null {
+  return clip.raw_clip_url || null;
+}
+
+export function classifyClipMediaState(clip: ClipResult) {
+  const playable = getPlayableUrl(clip);
+  const raw = getRawUrl(clip);
+
+  if (clip.render_status === 'rendered' && playable) return 'rendered';
+  if (clip.render_status === 'raw_only' && raw) return 'raw_only';
+  if (clip.strategy_only || clip.render_status === 'strategy_only') return 'strategy_only';
+  if (playable) return 'rendered';
+  if (raw) return 'raw_only';
+  return 'strategy_only';
+}
+```
+
+## Lead clip selection
+
+```ts
+export function chooseLeadClip(clips: ClipResult[]): ClipResult | null {
+  if (!clips.length) return null;
+
+  const rendered = clips.find((clip) => classifyClipMediaState(clip) === 'rendered');
+  if (rendered) return rendered;
+
+  const raw = clips.find((clip) => classifyClipMediaState(clip) === 'raw_only');
+  if (raw) return raw;
+
+  return [...clips].sort((a, b) => (b.score || 0) - (a.score || 0))[0];
+}
+```
+
+## Display lanes
+
+```text
+Lead result:
+- best rendered clip first
+- if no rendered clip exists, best raw-only clip
+- if no raw clip exists, best strategy-only clip
+
+Rendered lane:
+- only clips with playable preview/export URLs
+
+Raw-only lane:
+- clips with raw assets but no edited preview
+
+Strategy-only lane:
+- clips with packaging but no real media
+```
+
+## Component requirements
+
+### DirectorBrainPackagePanel
+
+Show:
+- post rank
+- recommended platform
+- why this matters
+- hook variants
+- caption style
+- thumbnail text
+- CTA
+- quality gate status
+- revenue/offer score only if present
+
+### VideoCard
+
+Show:
+- visual state badge
+- video player only when playable URL exists
+- raw-only action if raw URL exists
+- strategy-only panel if no media exists
+
+### HeroClip
+
+Show:
+- best clip first
+- same DirectorBrainPackagePanel as VideoCard
+- export/copy actions only when data exists
+
+## Badge language
+
+```text
+rendered: Ready now
+raw_only: Raw cut available
+strategy_only: Strategy only
+failed: Not ready
+```
+
+## Copy buttons
+
+Each card should support:
+- copy hook
+- copy caption
+- copy CTA
+- copy full package
+
+## Frontend Codex prompt
+
+```text
+Implement Chunk 5 only.
+
+Task:
+Update frontend types and display helpers so Director Brain, campaign, quality, and render state fields display safely.
+
+Files likely involved:
+- lwa-web/lib/types.ts
+- lwa-web/lib/clip-utils.ts
+- lwa-web/components/VideoCard.tsx
+- lwa-web/components/HeroClip.tsx
+- lwa-web/components/DirectorBrainPackagePanel.tsx
+
+Rules:
+- Touch lwa-web only.
+- Do not touch backend.
+- Do not touch lwa-ios.
+- Preserve existing generation flow.
+- Never show strategy-only clips as playable.
+- Never invent preview/download URLs.
+
+Verification:
+- cd lwa-web
+- npm run type-check if available
+- npm run lint if available
+- npm run build if available
+```

--- a/docs/lwa-worlds/chunk-6-campaign-social-algorithms.md
+++ b/docs/lwa-worlds/chunk-6-campaign-social-algorithms.md
@@ -1,0 +1,238 @@
+# LWA CHUNK 6 — CAMPAIGN MANAGER AND SOCIAL POSTING ALGORITHMS
+
+This chunk defines the real campaign manager and direct social posting architecture. These systems must remain behind feature flags until OAuth, scopes, publishing permissions, and verification are implemented.
+
+## Campaign Mode vs Campaign Manager
+
+```text
+Campaign Mode = assign roles to clips in one generation result.
+Campaign Manager = workspace, brief, calendar, approvals, scheduling, publishing, performance tracking.
+```
+
+## Campaign Manager Objects
+
+```text
+campaign_workspace
+campaign_brief
+campaign_plan
+campaign_calendar_item
+approval_status
+publish_status
+performance_snapshot
+```
+
+## Campaign planner algorithm
+
+```python
+def build_campaign_plan(brief, clips):
+    scored = []
+    for clip in clips:
+        score = (
+            clip.score * 0.25 +
+            (clip.revenue_intent_score or 0) * 0.20 +
+            (clip.offer_fit_score or 0) * 0.15 +
+            campaign_role_fit(clip, brief) * 0.20 +
+            platform_fit(clip, brief.primary_platforms) * 0.10 +
+            render_readiness(clip) * 0.10
+        )
+        scored.append((clip, score))
+    return choose_balanced_campaign_mix(scored)
+```
+
+## Campaign mix rules
+
+```text
+7-day campaign:
+- 2 lead or attention clips
+- 2 educational clips
+- 1 trust or proof clip
+- 1 sales or offer clip
+- 1 community or retargeting clip
+
+Launch campaign:
+- 1 announcement
+- 2 problem clips
+- 2 proof clips
+- 2 objection clips
+- 2 sales clips
+- 1 urgency or community clip
+
+Medspa campaign:
+- prioritize trust, transformation, safety, consultation, and before/after framing
+
+Whop seller campaign:
+- prioritize tactical value, proof, community, offer, and money-angle education
+```
+
+## Campaign calendar item statuses
+
+```text
+approval_status:
+- draft
+- needs_review
+- approved
+- rejected
+- revised
+
+publish_status:
+- not_scheduled
+- scheduled
+- publishing
+- published
+- failed
+- cancelled
+```
+
+## Direct social posting truth
+
+Direct posting must never happen without:
+
+```text
+- user OAuth connection
+- required scopes
+- platform approval when required
+- explicit user publish or schedule action
+- real clip asset
+- valid caption/title payload
+- audit trail
+```
+
+## Supported social platforms
+
+```text
+youtube
+tiktok
+instagram
+facebook
+x
+linkedin
+twitch
+reddit
+```
+
+## Social account status values
+
+```text
+connected
+requires_reauth
+revoked
+limited_scope
+posting_not_approved
+disabled
+```
+
+## Social post statuses
+
+```text
+draft
+scheduled
+publishing
+published
+failed
+cancelled
+requires_reauth
+blocked_by_platform
+```
+
+## Social publish algorithm
+
+```python
+def publish_social_post(post, account, asset):
+    if not account or account.status != 'connected':
+        return fail('social_account_not_connected')
+
+    if not asset:
+        return fail('missing_clip_asset')
+
+    if post.status not in {'draft', 'scheduled'}:
+        return fail('post_not_publishable_from_current_status')
+
+    if not scopes_allow_posting(account.scopes, post.platform):
+        return fail('missing_required_scope')
+
+    if platform_requires_approval(post.platform) and not account.posting_approved:
+        return fail('blocked_by_platform')
+
+    if token_expired(account):
+        account = refresh_token(account)
+
+    mark_post_status(post.id, 'publishing')
+
+    result = platform_publish(post, account, asset)
+
+    if result.success:
+        mark_post_published(post.id, result.platform_post_id, result.platform_post_url)
+    else:
+        mark_post_failed(post.id, result.error_code)
+
+    return result
+```
+
+## OAuth connection algorithm
+
+```python
+def start_social_oauth(user, platform):
+    if not feature_enabled('direct_social_posting', user):
+        return feature_not_live('Direct posting is planned, not live.')
+
+    state = create_oauth_state(user_id=user.id, platform=platform)
+    auth_url = build_authorization_url(platform=platform, state=state.value)
+
+    return {
+        'authorization_url': auth_url,
+        'state_id': state.id
+    }
+```
+
+## OAuth callback algorithm
+
+```python
+def handle_social_oauth_callback(code, state):
+    validated = validate_oauth_state(state)
+    tokens = exchange_code_for_tokens(validated.platform, code)
+    profile = fetch_platform_account_profile(validated.platform, tokens.access_token)
+
+    return upsert_social_account(
+        user_id=validated.user_id,
+        platform=validated.platform,
+        platform_account_id=profile.id,
+        access_token_encrypted=encrypt_token(tokens.access_token),
+        refresh_token_encrypted=encrypt_token(tokens.refresh_token),
+        scopes=tokens.scopes,
+        token_expires_at=tokens.expires_at
+    )
+```
+
+## Safety rules
+
+```text
+- Never ask users for social passwords.
+- Never post without explicit action.
+- Never claim posting is live until API approval and scope tests pass.
+- Encrypt all tokens.
+- Store scopes and token expiration.
+- Refresh tokens safely.
+- Log every publish attempt.
+```
+
+## Codex prompt
+
+```text
+Implement Chunk 6 only.
+
+Task:
+Scaffold campaign manager and social posting services behind feature flags.
+
+Rules:
+- Preserve current generation.
+- Do not enable direct posting as live.
+- Do not create fake publish success.
+- Encrypt token fields when real storage exists.
+- Do not touch iOS.
+- Do not touch unrelated frontend files.
+
+Verification:
+- git status --short
+- python -m py_compile on changed backend files
+- pytest relevant tests
+```

--- a/docs/lwa-worlds/chunk-7-marketplace-realms-proof.md
+++ b/docs/lwa-worlds/chunk-7-marketplace-realms-proof.md
@@ -1,0 +1,336 @@
+# LWA CHUNK 7 — MARKETPLACE, SIGNAL REALMS, AND PROOF ALGORITHMS
+
+This chunk defines marketplace ranking, seller trust, Signal Realms progression, and off-chain proof-of-creation systems. These are future/scaffolded systems until implemented behind feature flags.
+
+## Marketplace rules
+
+```text
+- Sell templates, hook packs, caption presets, B-roll packs, brand kits, Director Brain prompt packs, and commission products.
+- Use integer cents only.
+- Use idempotent webhooks.
+- No guaranteed income language.
+- Seller payouts require trusted payment state.
+- Refunds and disputes must be tracked.
+- Products must be reviewable by admin.
+```
+
+## Marketplace product types
+
+```text
+clip_template
+hook_pack
+caption_preset
+broll_pack
+brand_kit
+director_brain_prompt_pack
+clip_on_commission
+campaign_pack
+```
+
+## Marketplace ranking formula
+
+```text
+MarketplaceRank =
+  0.22 * ProductQualityScore +
+  0.18 * SellerTrustScore +
+  0.16 * BuyerFitScore +
+  0.14 * ConversionRateScore +
+  0.10 * LowRefundScore +
+  0.08 * FreshnessScore +
+  0.07 * PriceFitScore +
+  0.05 * RatingScore
+```
+
+## Seller trust formula
+
+```text
+SellerTrustScore =
+  0.25 * CompletedOrderScore +
+  0.20 * LowRefundRate +
+  0.20 * LowDisputeRate +
+  0.15 * ProductReviewScore +
+  0.10 * AccountAgeScore +
+  0.10 * ComplianceScore
+```
+
+## Marketplace money split
+
+```python
+def calculate_marketplace_split(price_cents, take_rate_bps=2000):
+    if price_cents < 0:
+        raise ValueError('price_cents cannot be negative')
+    platform_fee_cents = price_cents * take_rate_bps // 10000
+    seller_net_cents = price_cents - platform_fee_cents
+    return {
+        'subtotal_cents': price_cents,
+        'platform_fee_cents': platform_fee_cents,
+        'seller_net_cents': seller_net_cents,
+        'total_cents': price_cents,
+        'currency': 'usd'
+    }
+```
+
+## Marketplace ranking pseudocode
+
+```python
+def rank_marketplace_products(user, query, filters):
+    products = search_marketplace_products(query, filters)
+    ranked = []
+
+    for product in products:
+        seller = get_seller_profile(product.seller_user_id)
+        score = (
+            0.22 * score_product_quality(product) +
+            0.18 * seller.trust_score +
+            0.16 * score_buyer_fit(user, product) +
+            0.14 * score_conversion_rate(product) +
+            0.10 * score_low_refund(product) +
+            0.08 * score_freshness(product) +
+            0.07 * score_price_fit(product, filters) +
+            0.05 * score_rating(product.average_rating)
+        )
+        ranked.append((product, score))
+
+    return sort_desc(ranked)
+```
+
+## Marketplace safety filters
+
+```text
+Reject or review products that include:
+- guaranteed income claims
+- platform evasion promises
+- spam automation
+- impersonation
+- unsafe scraping instructions
+- investment language
+- hidden refund terms
+```
+
+---
+
+# Signal Realms RPG Layer
+
+## Purpose
+
+Signal Realms is the retention layer. It should reward real usage and identity without creating pay-to-win or legal risk.
+
+## Realms rules
+
+```text
+- XP cannot be bought.
+- Badges are earned.
+- Relics are cosmetic only.
+- No pay-to-win.
+- No gambling mechanics.
+- No investment language.
+- No yield or tokenomics.
+```
+
+## Classes
+
+```text
+clip_smith
+hook_hunter
+caption_mage
+trend_rider
+campaign_architect
+marketplace_merchant
+signal_scout
+realm_builder
+growth_alchemist
+edit_warrior
+proof_keeper
+community_summoner
+```
+
+## Factions
+
+```text
+House Velocity
+The Hookborn
+Order of Proof
+Caption Guild
+The Signal Scouts
+Marketplace Forge
+The Retention Circle
+House Whopfire
+The Local Kings
+The Creator Legion
+The Algorithm Watch
+The Black Gold Order
+```
+
+## XP formula
+
+```text
+XP required for next level = 100 + ((level - 1) * 35)
+```
+
+## XP events
+
+```text
+generation_completed: 15
+clip_downloaded: 10
+hook_copied: 4
+caption_copied: 4
+campaign_created: 25
+social_account_connected: 20
+marketplace_purchase: 5
+marketplace_product_published: 30
+quest_completed: 50
+```
+
+Marketplace purchase XP is intentionally tiny and cosmetic. It must not create a paid advantage.
+
+## XP pseudocode
+
+```python
+XP_RULES = {
+    'generation_completed': 15,
+    'clip_downloaded': 10,
+    'hook_copied': 4,
+    'caption_copied': 4,
+    'campaign_created': 25,
+    'social_account_connected': 20,
+    'marketplace_purchase': 5,
+    'marketplace_product_published': 30,
+    'quest_completed': 50,
+}
+
+def award_xp(user, event_type, source=None):
+    if not feature_enabled('rpg_realms', user):
+        return None
+    xp = XP_RULES.get(event_type, 0)
+    if xp <= 0:
+        return None
+    profile = get_or_create_realms_profile(user.id)
+    event = create_xp_event(profile.id, event_type, xp, source)
+    update_profile_xp(profile.id, xp)
+    return event
+```
+
+## Quest algorithm
+
+```python
+def update_quests_for_event(user, event_type):
+    quests = get_active_quests_for_event(event_type)
+    for quest in quests:
+        user_quest = get_or_create_user_quest(user.id, quest.id)
+        if user_quest.completed:
+            continue
+        user_quest.progress_count += 1
+        if user_quest.progress_count >= quest.required_count:
+            user_quest.completed = True
+            award_xp(user, 'quest_completed', source={'quest_id': quest.id})
+            if quest.badge_reward_key:
+                award_badge(user, quest.badge_reward_key)
+            if quest.cosmetic_reward_key:
+                award_cosmetic(user, quest.cosmetic_reward_key)
+        save_user_quest(user_quest)
+```
+
+---
+
+# Proof of Creation / Blockchain Provenance
+
+## Purpose
+
+Proof should start off-chain. Blockchain publishing is optional future infrastructure, not MVP.
+
+## Safety rules
+
+```text
+- Off-chain proof first.
+- Optional Merkle batching later.
+- Testnet before mainnet.
+- No tokenomics.
+- No yield.
+- No fractionalization.
+- No feature unlocks from NFTs.
+- No investment language.
+```
+
+## Off-chain proof algorithm
+
+```python
+def create_offchain_proof(clip, assets):
+    content_hash = sha256(stable_json({
+        'clip_id': clip.id,
+        'title': clip.title,
+        'hook': clip.hook,
+        'start_seconds': clip.start_seconds,
+        'end_seconds': clip.end_seconds,
+        'asset_urls': sorted([asset.asset_url for asset in assets])
+    }))
+
+    metadata_hash = sha256(stable_json({
+        'algorithm': 'LWA_DIRECTOR_BRAIN_V0',
+        'created_by_lwa': True
+    }))
+
+    return create_proof_event(
+        content_hash=content_hash,
+        metadata_hash=metadata_hash,
+        proof_status='offchain_recorded'
+    )
+```
+
+## Merkle batch algorithm
+
+```python
+def build_merkle_root(leaves):
+    if not leaves:
+        return None
+    level = leaves
+    while len(level) > 1:
+        next_level = []
+        for index in range(0, len(level), 2):
+            left = level[index]
+            right = level[index + 1] if index + 1 < len(level) else left
+            next_level.append(sha256(''.join(sorted([left, right]))))
+        level = next_level
+    return level[0]
+```
+
+## Badge and relic rules
+
+```text
+Soulbound badge:
+- earned only
+- non-transferable
+- no paid advantage
+- no income claim
+
+Cosmetic relic:
+- profile/identity customization only
+- no XP advantage
+- no ranking advantage
+- no paid feature unlock
+- no investment framing
+```
+
+## Codex prompt
+
+```text
+Implement Chunk 7 only.
+
+Task:
+Scaffold marketplace ranking, seller trust, Signal Realms XP/quests/badges, and off-chain proof services behind feature flags.
+
+Rules:
+- Do not enable marketplace checkout as live.
+- Money uses integer cents.
+- Webhooks are idempotent.
+- XP cannot be bought.
+- Badges are earned.
+- Relics are cosmetic only.
+- Proof remains off-chain unless a later dedicated blockchain task enables testnet publishing.
+- Do not touch iOS.
+- Do not touch unrelated frontend files.
+
+Verification:
+- git status --short
+- python -m py_compile on changed backend files
+- pytest relevant tests
+```

--- a/docs/lwa-worlds/chunk-8-editor-ios-rebuild.md
+++ b/docs/lwa-worlds/chunk-8-editor-ios-rebuild.md
@@ -1,0 +1,237 @@
+# LWA CHUNK 8 — FULL EDITOR AND iOS REBUILD ALGORITHMS
+
+This chunk defines the full editor and full iOS rebuild plan. These are not mixed into backend algorithm work. They require dedicated branches and feature gates.
+
+## Full editor truth
+
+A full editor is not a media preview. A full editor is a timeline system with versioned commands and export jobs.
+
+## Editor objects
+
+```text
+project
+timeline
+track
+item
+caption_layer
+text_layer
+broll_layer
+audio_layer
+effect_layer
+export_job
+version
+command_history
+```
+
+## Editor project lifecycle
+
+```text
+draft
+editing
+exporting
+exported
+failed
+archived
+```
+
+## Timeline validation rules
+
+```text
+- Every item must have start < end.
+- No negative start time.
+- Required source asset exists.
+- Export preset exists.
+- Captions stay inside platform safe area.
+- Audio/video assets are available.
+- Timeline version increments after every command.
+```
+
+## Editor command types
+
+```text
+trim_clip
+split_clip
+move_item
+delete_item
+add_caption
+edit_caption_text
+change_caption_style
+add_text_overlay
+add_broll
+change_crop
+change_export_preset
+save_version
+export_timeline
+```
+
+## Editor command algorithm
+
+```python
+def apply_editor_command(project, timeline, command):
+    if command.type == 'trim_clip':
+        return trim_clip(timeline, command.payload)
+    if command.type == 'split_clip':
+        return split_clip(timeline, command.payload)
+    if command.type == 'move_item':
+        return move_item(timeline, command.payload)
+    if command.type == 'delete_item':
+        return delete_item(timeline, command.payload)
+    if command.type == 'add_caption':
+        return add_caption(timeline, command.payload)
+    if command.type == 'edit_caption_text':
+        return edit_caption_text(timeline, command.payload)
+    if command.type == 'change_caption_style':
+        return change_caption_style(timeline, command.payload)
+    if command.type == 'add_broll':
+        return add_broll(timeline, command.payload)
+    raise ValueError('unsupported_editor_command')
+```
+
+## Export pipeline
+
+```text
+Load project
+→ load current timeline
+→ validate timeline
+→ build media filtergraph/render plan
+→ create export job
+→ render preview/export
+→ persist clip asset
+→ attach asset to editor project
+→ update export status
+```
+
+## Editor feature flag rules
+
+```text
+- If full_editor is planned, hide editor routes from normal users.
+- If full_editor is beta, show only to beta/admin.
+- If full_editor is live, show only after export tests pass.
+```
+
+## Editor Codex prompt
+
+```text
+Implement editor scaffold only.
+
+Rules:
+- Do not touch current generation route.
+- Do not claim full editor is live.
+- Add timeline schemas and pure command functions first.
+- Keep routes behind feature flag.
+- Do not touch iOS in this backend prompt.
+```
+
+---
+
+# Full iOS rebuild plan
+
+## iOS truth
+
+The iOS app should not be changed accidentally during backend or web tasks. The full rebuild requires a dedicated branch.
+
+## iOS modules
+
+```text
+AuthModule
+SourceInputModule
+UploadModule
+GenerationModule
+ClipReviewModule
+EditorLiteModule
+CampaignModule
+SocialPostingModule
+MarketplaceModule
+RealmsModule
+ProofModule
+SettingsModule
+OfflineHistoryModule
+ShareSheetModule
+```
+
+## iOS data model goals
+
+The iOS app must understand:
+
+```text
+- Director Brain fields
+- render_status
+- strategy_only
+- reason_not_rendered
+- quality_gate_status
+- campaign_role
+- funnel_stage
+- asset URLs
+- upload status
+- social posting status later
+- marketplace product summaries later
+- Realms profile later
+```
+
+## Swift clip model sketch
+
+```swift
+struct LWAClipResult: Identifiable, Codable {
+    let id: String
+    let rank: Int
+    let postRank: Int
+    let title: String
+    let hook: String
+    let caption: String?
+    let score: Int
+    let confidenceScore: Int
+    let recommendedPlatform: String?
+    let renderStatus: String
+    let strategyOnly: Bool
+    let reasonNotRendered: String?
+    let previewURL: URL?
+    let downloadURL: URL?
+    let campaignRole: String?
+    let funnelStage: String?
+}
+```
+
+## iOS rebuild phases
+
+```text
+Phase 1: preserve current preview/share/history flow.
+Phase 2: add Director Brain response field support.
+Phase 3: add upload from camera roll and Files.
+Phase 4: add clip review queue.
+Phase 5: add lightweight editor.
+Phase 6: add campaign manager views.
+Phase 7: add social account connections.
+Phase 8: add Realms profile.
+Phase 9: add marketplace browsing.
+Phase 10: add optional proof/cosmetic identity.
+```
+
+## iOS safety rule
+
+```text
+Never mix iOS rebuild with backend algorithm work.
+Never mix iOS rebuild with frontend web work.
+Use a dedicated iOS branch and dedicated verification.
+```
+
+## iOS Codex prompt
+
+```text
+Dedicated iOS branch only.
+
+Task:
+Add Director Brain response field support to iOS models and views without changing backend or web.
+
+Rules:
+- Preserve existing preview/share/history flow.
+- Do not build full editor in this prompt.
+- Do not build marketplace in this prompt.
+- Do not build direct social posting in this prompt.
+- Do not touch backend.
+- Do not touch lwa-web.
+
+Verification:
+- build Debug
+- build Release if available
+- confirm existing generation preview still works
+```

--- a/docs/lwa-worlds/chunk-9-execution-order.md
+++ b/docs/lwa-worlds/chunk-9-execution-order.md
@@ -1,0 +1,234 @@
+# LWA CHUNK 9 — EXECUTION ORDER AND REMAINING CODEX PROMPTS
+
+This chunk defines the safe order for turning the algorithm chunks into production work.
+
+## Global rule
+
+```text
+Preserve what already works.
+Build missing systems behind feature flags.
+Do not mark unfinished systems as live.
+Do not mix backend, frontend, and iOS changes in the same implementation prompt.
+```
+
+## Safe implementation order
+
+```text
+1. Merge safe docs and frontend staging branches.
+2. Add remaining algorithm/database documentation chunks.
+3. Build backend service modules in isolation.
+4. Build unit tests for pure functions.
+5. Add SQL migrations or SQL setup files.
+6. Wire generation output with optional fields only.
+7. Update frontend types and display components.
+8. Add upload pipeline behind feature flag.
+9. Add campaign manager behind feature flag.
+10. Add direct social OAuth shell behind feature flag.
+11. Add marketplace behind feature flag.
+12. Add Signal Realms behind feature flag.
+13. Add off-chain proof behind feature flag.
+14. Plan full iOS rebuild on a dedicated branch.
+```
+
+## Backend implementation prompt
+
+```text
+You are the LWA backend implementation engineer.
+
+Task:
+Implement backend service modules and tests from docs/lwa-worlds/chunk-4-sql-repository-layer.md, chunk-6-campaign-social-algorithms.md, chunk-7-marketplace-realms-proof.md, and chunk-8-editor-ios-rebuild.md, but only for backend-safe scaffolds.
+
+Rules:
+- Preserve existing backend routes.
+- Add optional fields only.
+- Do not touch lwa-web.
+- Do not touch lwa-ios.
+- Do not fake upload completion.
+- Do not fake direct posting.
+- Do not fake marketplace checkout.
+- Do not fake blockchain publishing.
+- Strategy-only clips must never be shown as rendered.
+- Rendered clips must require real asset URLs.
+- Money uses integer cents.
+- Webhooks are idempotent.
+- XP cannot be bought.
+- Badges are earned.
+- Relics/cosmetics provide no paid advantage.
+- Off-chain proof comes before testnet or mainnet work.
+
+Verification:
+- git status --short
+- python -m py_compile on changed backend files
+- pytest relevant backend tests
+
+Expected output:
+1. files changed
+2. services added
+3. migrations added
+4. tests added
+5. verification results
+6. risks or skipped work
+7. commit message
+```
+
+## Frontend implementation prompt
+
+```text
+You are the LWA frontend implementation engineer.
+
+Task:
+Implement the frontend display logic from docs/lwa-worlds/chunk-5-frontend-display-logic.md.
+
+Rules:
+- Touch lwa-web only.
+- Do not touch backend.
+- Do not touch lwa-ios.
+- Preserve existing generation flow.
+- Rendered clips show playable media only when URLs exist.
+- Raw-only clips show raw asset actions only when raw URLs exist.
+- Strategy-only clips never show fake players.
+- Show Director Brain package fields safely when present.
+- Keep UI premium, creator-native, and not overloaded.
+
+Verification:
+- cd lwa-web
+- npm run type-check if available
+- npm run lint if available
+- npm run build if available
+
+Expected output:
+1. files changed
+2. fields displayed
+3. media-state behavior
+4. verification results
+5. commit message
+```
+
+## Upload pipeline prompt
+
+```text
+You are the LWA upload pipeline engineer.
+
+Task:
+Implement a real upload pipeline behind the upload_pipeline feature flag.
+
+Rules:
+- Do not claim upload is live until end-to-end upload, scan/probe, source_asset creation, and generation handoff work.
+- Add upload session creation.
+- Add upload finalization scaffold.
+- Validate MIME type and file size.
+- Preserve URL-based generation.
+- Do not touch iOS unless this is the dedicated iOS upload prompt.
+
+Verification:
+- backend py_compile
+- backend tests
+- one upload-session unit test
+```
+
+## Campaign manager prompt
+
+```text
+You are the LWA campaign systems engineer.
+
+Task:
+Build campaign manager scaffolding behind feature flag.
+
+Rules:
+- Campaign Mode may assign clip roles.
+- Campaign Manager must not appear live until workspace, brief, calendar, approval status, and schedule status are implemented.
+- Do not fake social publishing.
+- Keep direct posting disabled unless the social posting feature flag is live.
+
+Verification:
+- backend py_compile
+- backend tests
+```
+
+## Marketplace prompt
+
+```text
+You are the LWA marketplace engineer.
+
+Task:
+Scaffold marketplace products, seller trust, orders, and integer-cent money math behind feature flag.
+
+Rules:
+- Do not enable live checkout in this prompt.
+- No guaranteed income language.
+- Integer cents only.
+- Webhooks idempotent.
+- Seller payouts require verified payment state.
+
+Verification:
+- backend py_compile
+- marketplace money math tests
+- seller trust tests
+```
+
+## Realms prompt
+
+```text
+You are the LWA Signal Realms engineer.
+
+Task:
+Scaffold XP, quests, badges, and cosmetic relic metadata behind feature flag.
+
+Rules:
+- XP cannot be bought.
+- Badges are earned.
+- Relics are cosmetic only.
+- No paid advantage.
+- No gambling mechanics.
+- No investment framing.
+
+Verification:
+- XP curve tests
+- quest progress tests
+```
+
+## Proof prompt
+
+```text
+You are the LWA proof-of-creation engineer.
+
+Task:
+Implement off-chain proof records and Merkle batch helpers behind feature flag.
+
+Rules:
+- No mainnet publishing.
+- No testnet publishing unless a later dedicated prompt enables it.
+- No NFT feature unlocks.
+- No investment language.
+- Proof is about provenance only.
+
+Verification:
+- stable hash tests
+- Merkle root tests
+```
+
+## iOS prompt
+
+```text
+Dedicated iOS branch only.
+
+Task:
+Add Director Brain response field support to iOS models and views.
+
+Rules:
+- Preserve existing preview/share/history flow.
+- Do not build the full editor in this prompt.
+- Do not build marketplace in this prompt.
+- Do not build direct social posting in this prompt.
+- Do not touch backend.
+- Do not touch lwa-web.
+
+Verification:
+- build Debug
+- build Release if available
+- confirm existing preview/share/history still works
+```
+
+## Final build rule
+
+The architecture includes upload, editor, campaign manager, direct posting, marketplace, Signal Realms, proof/blockchain, and iOS rebuild. Implementation must happen in separated, verifiable branches so production clipping remains stable.


### PR DESCRIPTION
## Summary

Adds the remaining LWA algorithm planning chunks as additive docs under `docs/lwa-worlds/`.

## Added

- `chunk-4-sql-repository-layer.md`
- `chunk-5-frontend-display-logic.md`
- `chunk-6-campaign-social-algorithms.md`
- `chunk-7-marketplace-realms-proof.md`
- `chunk-8-editor-ios-rebuild.md`
- `chunk-9-execution-order.md`

## Scope

Docs-only. No runtime backend, frontend, iOS, database, payment, route, or deployment behavior changed.

## Product truth preserved

- Existing clipping MVP remains the live product foundation.
- Upload pipeline, full editor, campaign manager, direct social posting, marketplace, Signal Realms, proof/blockchain, and full iOS rebuild are included in the architecture but clearly remain planned/scaffolded until separately implemented and verified.
- No unfinished feature is marked live.

## Verification

Docs-only PR. Runtime tests not run.

## Next implementation path

Use `docs/lwa-worlds/chunk-9-execution-order.md` to run Codex in separate backend, frontend, upload, marketplace, Realms, proof, and iOS branches.