### PR TITLE
docs: merge LWA council doctrine and source of truth

### DIFF
--- a/docs/company/lwa-architecture-compatibility-map.md
+++ b/docs/company/lwa-architecture-compatibility-map.md
@@ -1,0 +1,122 @@
+# LWA Architecture Compatibility Map
+
+## Purpose
+
+This document keeps future implementation aligned with the real repo instead of blindly copying assumptions from planning files.
+
+The existing repository is the source of truth. Planning documents are requirements and strategy, not proof that a module already exists.
+
+## Repo path compatibility
+
+Some planning docs mention:
+
+- `apps/backend`
+- `apps/web`
+
+Current repo work has used:
+
+- `lwa-backend`
+- `lwa-web`
+- `lwa-ios`
+- `tools`
+- `docs/company`
+
+Codex must adapt master prompts to the real paths. Do not create duplicate app folders unless a repo audit proves the structure changed intentionally.
+
+## Backend compatibility checklist
+
+Before backend edits, inspect:
+
+- app entrypoint
+- route registration
+- schema/model locations
+- config/settings style
+- auth/dependency style
+- test runner style
+- database/store pattern
+- storage/log path style
+- entitlement/quota behavior
+- asset retention behavior
+- source ingestion behavior
+- generated asset URL behavior
+
+## Frontend compatibility checklist
+
+Before frontend edits, inspect:
+
+- Next.js app router structure
+- layout files
+- route names and navigation
+- type definitions
+- API client utilities
+- global CSS/design tokens
+- component naming style
+- generate/workspace surface
+- homepage/generate/dashboard split
+
+## Database compatibility checklist
+
+Do not assume SQLAlchemy, SQLModel, Alembic, JSON store, Postgres, SQLite, or Redis.
+
+Audit first.
+
+If the repo does not already use Alembic, do not create migrations without a dedicated migration task.
+
+Marketplace, Realms, ledger, and payout schemas in planning docs are target architecture. They must be adapted to the existing persistence path.
+
+## Payment compatibility checklist
+
+Do not implement live money movement until the needed safety layers exist.
+
+Required before live marketplace money:
+
+- marketplace model/store
+- verified signed webhooks
+- idempotency by provider event id
+- append-only ledger or equivalent
+- admin takedown/dispute flow
+- refund policy
+- banned category policy
+- claim safety copy
+- payout holds/fraud review
+
+## Revenue event compatibility checklist
+
+Revenue intent tracking, if present, is not payment verification.
+
+It may track upgrade interest, checkout starts, demo requests, referral interest, quota-blocked upgrade pressure, and contact/booking clicks.
+
+It must not unlock access, activate subscriptions, verify payment, trigger payouts, or confirm revenue.
+
+## Social API compatibility checklist
+
+Do not store provider tokens unless encryption, revocation, OAuth state verification, scope docs, and provider status are clear.
+
+Do not implement direct posting until platform permissions/review are confirmed.
+
+## Polymarket compatibility checklist
+
+Polymarket may only be used as read-only cultural trend metadata. No betting, trading, wagering UI, or financial advice.
+
+## Blockchain compatibility checklist
+
+Early work is limited to optional provenance planning and off-chain proof records.
+
+Do not add live chain features until off-chain issuance, proof format, legal copy, user consent, and explicit approval exist.
+
+## iOS compatibility checklist
+
+Do not touch `lwa-ios/` unless the active task explicitly approves iOS.
+
+## Runtime safety rule
+
+Docs may be broad. Code must be narrow.
+
+One implementation slice at a time:
+
+1. audit
+2. plan
+3. implement smallest compatible change
+4. test
+5. commit
+6. update implementation status map

--- a/docs/company/lwa-autonomous-codex-execution-brief.md
+++ b/docs/company/lwa-autonomous-codex-execution-brief.md
@@ -1,0 +1,403 @@
+# LWA Autonomous Codex Execution Brief
+
+## Status
+
+This is the consolidated execution brief for the next time Codex is available.
+
+It combines:
+
+- ChatGPT doctrine
+- Codex execution ledger
+- LWA Worlds direction
+- source/revenue/CTA/backend intelligence work already reported
+- the instruction to integrate provided Claude code only after repo reconciliation proves exactly where it fits
+
+This document exists so Codex can work autonomously without losing context.
+
+## Absolute Mission
+
+Build LWA into the full LWA Worlds platform:
+
+**AI clipping engine + any-source generation + marketplace + UGC + RPG/world progression + internal economy ledger + social intelligence + admin/moderation + future proof/chain layer.**
+
+The current clipping engine is the foundation. Do not replace it. Extend it.
+
+## Mandatory Source Documents
+
+Before coding, Codex must read:
+
+1. `docs/lwa-worlds-mandatory-doctrine.md`
+2. `docs/company/lwa-codex-execution-ledger.md`
+3. `docs/lwa-worlds-integrated-architecture.md` if present
+4. `docs/lwa-ios-app-store-mobile-readiness-bridge.md` if present
+5. Any Claude doctrine/spec/code file added under `docs/company/`, `docs/`, or attached by the operator
+
+## Execution Philosophy
+
+Codex should be aggressive and autonomous in execution, but not destructive.
+
+Execution-first means:
+
+- inspect the repo
+- identify missing parts
+- implement the next highest-value slice
+- add tests
+- run verification
+- commit cleanly
+- report exact changes
+- continue to the next slice when safe
+
+Execution-first does **not** mean:
+
+- deleting working systems
+- overwriting the clipping engine
+- inventing fake finished features
+- shipping payment unlocks without verification
+- creating illegal earnings/investment claims
+- touching iOS without an iOS task
+- pasting code that imports modules that do not exist
+
+## Non-Negotiable Integration Rule For Claude Code
+
+If the operator provides Claude code/specs, Codex must not discard them.
+
+Codex must:
+
+1. Preserve the Claude code/spec in repo docs or source files.
+2. Inspect every referenced import/path/module.
+3. Adapt the code to the actual LWA repo structure.
+4. Integrate the code fully where it belongs if it compiles and matches the architecture.
+5. If direct paste would break the app, create the missing supporting module or adapt the imports.
+6. If a feature depends on unavailable secrets, external accounts, legal review, Apple review, or payment-provider setup, scaffold it behind disabled-by-default feature flags.
+7. Write an integration report explaining what was used, what was adapted, what remains blocked, and why.
+
+Do not ignore Claude code. Do not blindly paste Claude code if it breaks imports. Adapt and install it correctly.
+
+## Current Reported Codex Work To Reconcile
+
+From `docs/company/lwa-codex-execution-ledger.md`, Codex must verify whether these are installed on the working branch:
+
+1. Backend revenue event tracking foundation
+   - reported commit `80a2970`
+   - `POST /v1/revenue/events`
+   - JSONL revenue intent logger
+   - `authoritative=false`
+   - metadata sanitization
+   - quota-blocked hook
+
+2. Web multi-destination money CTA system
+   - reported local commit `0be4645`
+   - pushed matching commit found as `05567ea1e7050dd3bd7f4214c3decd080500cd3a`
+   - centralized money links
+   - `MoneyCtaPanel`
+   - `/offers`
+   - frontend `/api/revenue-events`
+
+3. Backend clip intelligence and entitlement hardening
+   - reported commit `4b2e17f`
+   - safer clip limits
+   - packaging profiles
+   - provider/intelligence provenance
+   - Attention Compiler helpers
+   - route contract tests
+
+4. Any-source source-engine realignment
+   - reported commit `2c95f7e`
+   - source material / prompts / files / campaigns / ideas / objectives through `/generate`
+
+5. Company ops / recruitment docs
+   - elite recruitment system
+   - creator tester program
+   - sales closer program
+   - advisor/partner/investor system
+   - support-the-build MVO
+   - outreach scripts
+   - intake forms
+   - 7-day execution plan
+
+## First Autonomous Task
+
+The first task is not to build a random new feature.
+
+The first task is:
+
+**Repo Reconciliation Audit + Missing Slice Installation Plan**
+
+Codex must inspect the actual current branch and mark each reported slice as:
+
+- installed
+- missing
+- partially installed
+- conflicting
+- needs tests
+- safe next repair
+
+Only after the audit may Codex begin installing missing pieces.
+
+## Required Audit Commands
+
+Run from repo root:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git rev-parse --short=7 HEAD
+git status --short
+find docs -maxdepth 4 -type f | sort | sed -n '1,300p'
+find lwa-backend -maxdepth 5 -type f | sort | sed -n '1,520p'
+find lwa-web -maxdepth 5 -type f | sort | sed -n '1,520p'
+```
+
+Search:
+
+```bash
+rg -n "revenue_events|RevenueEvent|revenue_event_log|authoritative|MoneyCtaPanel|money-links|/offers|packaging_profiles|ProviderProvenance|IntelligenceProvenance|source_type|source_formats|any-source|campaign_goal|worlds|ledger|marketplace|ugc|relic|quest|wallet|payout|moderation|fraud" docs lwa-backend lwa-web || true
+```
+
+## Required Reconciliation Report
+
+Before coding, Codex must output:
+
+1. branch
+2. commit
+3. dirty files
+4. doctrine files found
+5. ledger files found
+6. Claude files found
+7. installed Codex slices
+8. missing Codex slices
+9. partially installed slices
+10. conflicts
+11. files Codex plans to touch
+12. files Codex will not touch
+13. tests Codex will run
+14. commit plan
+
+## Installation Priority
+
+After audit, install missing pieces in this order:
+
+### P0 — Preserve and stabilize current app
+
+- routes separated correctly
+- `/generate` working
+- `/dashboard` not fake if existing workspace exists
+- source upload/source-type handling working
+- public URLs best-effort with clean fallback
+- backend tests passing
+- frontend type-check passing
+
+### P1 — Install Codex-reported foundations if missing
+
+- backend revenue event tracking
+- frontend multi-destination CTA system
+- backend clip intelligence hardening
+- any-source source engine
+- company ops docs
+
+### P2 — Marketplace skeleton + internal economy placeholders + RPG profile shell
+
+Implement as a vertical slice:
+
+- frontend pages/shells
+- backend routes/models if they fit existing persistence
+- internal ledger placeholders
+- marketplace campaign/job/submission/review states
+- pending/approved/held/disputed/refunded payout states
+- RPG profile/class/faction/XP/badge/relic shell
+- admin/moderation overview
+
+No real payouts yet. No real crypto yet. No token yet.
+
+### P3 — UGC foundation
+
+- UGC asset/template/quest submissions
+- review/moderation statuses
+- ownership/rights declaration
+- reporting/takedown hooks
+- seller-safe language
+
+### P4 — Social integration scaffold
+
+- YouTube
+- TikTok
+- Instagram
+- Twitch
+- Polymarket trend-only
+- OpenAI
+- Anthropic Claude
+- Seedance / BytePlus ModelArk
+- Apple App Store Connect
+- Whop
+- Stripe later
+
+All clients must be isolated. No hardcoded secrets.
+
+### P5 — iOS/mobile readiness bridge
+
+Only after mobile/backend compatibility audit:
+
+- `/worlds/mobile/me`
+- `/worlds/mobile/dashboard`
+- `/worlds/mobile/launch-safety`
+- `/worlds/mobile/feature-flags`
+
+Do not touch `lwa-ios/` unless explicitly assigned.
+
+## Feature Flag Rule
+
+Any unfinished or external-dependent feature must be behind a disabled-by-default flag.
+
+Examples:
+
+- real payouts
+- external checkout in iOS
+- marketplace public posting
+- UGC public selling
+- wallet connection
+- chain proof
+- Polymarket integration
+- social posting
+- Apple IAP
+- Seedance rendering
+- Anthropic routing
+
+## Required Verification
+
+Backend slice:
+
+```bash
+python3 -m compileall lwa-backend/app lwa-backend/scripts
+cd lwa-backend && python3 -m unittest discover -s tests && cd ..
+git diff --check
+git status --short
+```
+
+Frontend slice:
+
+```bash
+cd lwa-web
+npm run type-check
+npm run build
+cd ..
+git diff --check
+git status --short
+```
+
+Docs-only slice:
+
+```bash
+git diff --check
+git status --short
+```
+
+Full-stack slice:
+
+```bash
+python3 -m compileall lwa-backend/app lwa-backend/scripts
+cd lwa-backend && python3 -m unittest discover -s tests && cd ..
+cd lwa-web && npm run type-check && npm run build && cd ..
+git diff --check
+git status --short
+```
+
+## Commit Rules
+
+Use small commits:
+
+- `docs: reconcile LWA doctrine and Codex ledger`
+- `backend: restore revenue event tracking foundation`
+- `web: restore multi-destination money CTA system`
+- `backend: add clip intelligence contract hardening`
+- `backend: realign source engine for any-source input`
+- `docs: add elite recruitment and MVO operating system`
+- `platform: add marketplace economy worlds skeleton`
+
+Do not mix unrelated backend, frontend, iOS, and docs unless the slice truly requires it.
+
+## Final Autonomous Codex Prompt
+
+Paste this into Codex:
+
+```text
+You are Codex operating inside repo jcamacho611/lwa-app.
+
+You are the autonomous implementation operator for LWA / IWA / LWA Worlds.
+
+Read these first:
+- docs/lwa-worlds-mandatory-doctrine.md
+- docs/company/lwa-codex-execution-ledger.md
+- docs/company/lwa-autonomous-codex-execution-brief.md
+- docs/lwa-worlds-integrated-architecture.md if present
+- docs/lwa-ios-app-store-mobile-readiness-bridge.md if present
+- any Claude doctrine/spec/code files present in docs or provided by the operator
+
+Mission:
+Build LWA into the full LWA Worlds platform: AI clipping engine, any-source generation, marketplace, UGC, RPG/world progression, internal economy ledger, social intelligence, admin/moderation, and future proof/chain layer.
+
+Execution mode:
+- Work autonomously.
+- Do not ask for permission after every small step.
+- Inspect, implement, test, commit, and report.
+- Preserve working clipping/generation flow.
+- Use all provided ChatGPT, Claude, and Codex information.
+- Do not ignore Claude code; adapt it to the actual repo and integrate it fully where it belongs.
+- Do not blindly paste code that imports nonexistent modules; create/adapt the proper modules.
+- Do not rebuild completed Codex work from scratch; inspect and extend.
+
+First task:
+Perform a repo reconciliation audit against the doctrine and ledger.
+
+Mark each reported Codex slice as installed, missing, partially installed, conflicting, needs tests, or ready.
+
+Then install missing work in this order:
+1. current app route/source stability
+2. backend revenue event tracking if missing
+3. web multi-destination money CTA if missing
+4. backend clip intelligence/entitlement hardening if missing
+5. any-source source-engine realignment if missing
+6. docs/company elite recruitment and MVO operating system if missing
+7. marketplace skeleton + internal economy placeholders + RPG profile shell
+8. UGC foundation
+9. social integration scaffolds
+10. mobile readiness bridge
+
+Hard boundaries:
+- Do not destroy working routes.
+- Do not touch lwa-ios unless explicitly assigned.
+- No hardcoded secrets.
+- No fake payment verification.
+- No client event can unlock paid access.
+- No guaranteed earnings/views/viral claims.
+- No token/staking/yield/gambling implementation.
+- Wallet/chain features are placeholder/proof-only unless explicitly approved later.
+
+Verification:
+Run the right checks for each slice and commit only clean, scoped changes.
+
+Final report every time:
+1. branch and commit started from
+2. files inspected
+3. doctrine/ledger/Claude sources used
+4. files changed
+5. features installed
+6. features still missing
+7. tests run
+8. failures/blockers
+9. commit hash/message
+10. next autonomous slice
+
+Begin now.
+```
+
+## Success Definition
+
+Codex is ready when:
+
+- the docs are present
+- the execution ledger is present
+- Claude code/specs are preserved and reconciled
+- existing Codex work is audited against the actual repo
+- missing foundations are installed
+- the app still builds/tests
+- the next vertical slice can be implemented without losing context

--- a/docs/company/lwa-blockchain-proof-future-plan.md
+++ b/docs/company/lwa-blockchain-proof-future-plan.md
@@ -1,0 +1,67 @@
+# LWA Blockchain / Proof Future Plan
+
+## Status
+
+Future phase.
+
+## Principle
+
+Blockchain features are optional cosmetics and provenance only.
+
+They must not unlock app functionality.
+
+They must not imply investment value.
+
+They must not be required for the core clipping product.
+
+## Phase 0
+
+Off-chain proof only:
+
+- deterministic issuance records
+- badge/relic records in the existing backend persistence layer when Realms exists
+- Merkle root generation
+- JSON proof export
+- no chain write
+- no wallet required
+
+## Phase 1
+
+Optional testnet anchor only after Phase 0 is tested.
+
+Requirements before testnet:
+
+- off-chain issuance works
+- Merkle proof format is stable
+- legal copy exists
+- user consent copy exists where needed
+- no app feature unlocks depend on badges/relics
+
+## Phase 2+
+
+Only after legal/security review:
+
+- soulbound badges
+- cosmetic relics
+- optional wallet display
+- optional proof viewer
+
+## Frontend copy rule
+
+Every proof/relic/badge surface must say:
+
+Cosmetic/provenance only. No investment value. No income rights. No guarantee.
+
+## Forbidden
+
+- fractionalization
+- yield
+- ROI
+- token sale
+- investment language
+- required wallet
+- NFT feature unlocks
+- staking
+- gambling
+- betting
+- mainnet deploys without explicit approval

--- a/docs/company/lwa-claim-safety-rules.md
+++ b/docs/company/lwa-claim-safety-rules.md
@@ -1,0 +1,148 @@
+# LWA Claim Safety Rules
+
+## Purpose
+
+This file controls what LWA can safely say in product copy, sales pages, investor notes, demos, marketplace pages, Realms pages, and Codex-generated UI.
+
+Use repo evidence only. Planned systems must be labeled as planned.
+
+## Allowed claims now, when supported by repo evidence
+
+- AI-assisted clipping MVP
+- ranked clip packs
+- hooks and captions
+- timestamps and scores
+- upload-first source support
+- public URL support is best-effort
+- revenue intent tracking
+- free launch mode, only if implemented
+- strategy packages for prompt, music, campaign, or image-style inputs, only if implemented
+- source matrix tooling, only if present and passing
+
+## Not allowed unless implemented and verified
+
+- guaranteed YouTube extraction
+- guaranteed TikTok extraction
+- guaranteed Instagram extraction
+- guaranteed Twitch extraction
+- guaranteed virality
+- guaranteed revenue
+- full editor
+- full marketplace
+- real payouts
+- verified payment access
+- direct social posting
+- NFT marketplace
+- on-chain proof
+- appchain
+
+## Money language
+
+Allowed:
+
+- revenue intent
+- checkout click
+- demo request
+- upgrade interest
+- verified payment webhook planned
+- earnings vary
+- no guarantee of income
+
+Forbidden:
+
+- payment verified unless server-side verified
+- subscription active unless entitlement is verified
+- guaranteed money
+- guaranteed sales
+- passive income guarantee
+- risk-free income
+
+## Public URL language
+
+Allowed:
+
+Public URLs are best-effort because platforms can block server extraction.
+
+Forbidden:
+
+Works with every YouTube, TikTok, Instagram, or Twitch link.
+
+## Marketplace language
+
+Allowed:
+
+- creator marketplace planned
+- marketplace scaffold
+- pending approval
+- approved payout
+- payout review
+- earnings vary
+- platform fee may apply
+
+Forbidden until fully implemented:
+
+- instant payouts
+- guaranteed buyers
+- guaranteed sales
+- verified seller earnings
+- automated escrow without tested webhook/ledger support
+
+## Realms language
+
+Allowed:
+
+- progression layer
+- classes
+- factions
+- quests
+- badges
+- cosmetic relics
+- no purchasable XP
+
+Forbidden:
+
+- pay-to-win
+- income rights from badges
+- feature unlocks from relic ownership
+- investment value
+
+## Blockchain language
+
+Allowed:
+
+- cosmetic only
+- provenance only
+- optional future proof layer
+- no investment value
+- no income rights
+- no feature unlocks
+
+Forbidden:
+
+- investment
+- ROI
+- yield
+- future value
+- revenue share from relic ownership
+- token sale
+- fractionalization
+
+## Polymarket language
+
+Allowed:
+
+- read-only cultural trend metadata
+- attention research
+- trend signal
+
+Forbidden:
+
+- trading
+- betting
+- wagering
+- financial advice
+- buy/sell recommendations
+
+## Default safe customer-facing claim
+
+LWA supports upload-first clipping for common video/audio sources plus strategy generation for prompt, music, campaign, and image-style inputs. Public URLs are best-effort because platforms can block server extraction.

--- a/docs/company/lwa-claude-codex-fusion-guardrails.md
+++ b/docs/company/lwa-claude-codex-fusion-guardrails.md
@@ -1,0 +1,224 @@
+# LWA Claude + Codex Fusion Guardrails
+
+## Status
+
+This file exists to protect completed Claude/Codex work while LWA Worlds is fused into the repo and prepared for pull, push, commit, PR review, and merge to `main`.
+
+The founder has identified the Claude work as protected implementation context. Future agents must not overwrite it, casually rewrite it, or replace it with generic architecture.
+
+## Protected Claude / Codex Workstreams
+
+### 1. Any-source engine and upload-first source typing
+
+Protected files/areas:
+
+- `.gitignore`
+- `tools/poc/source_matrix_runner.py`
+- `tools/poc/test_source_matrix_runner.py`
+- `tools/poc/README.md`
+- `lwa-backend/app/services/source_ingest.py`
+- `lwa-backend/app/api/routes/upload.py`
+- `lwa-backend/app/api/routes/generate.py`
+- `lwa-backend/app/models/schemas.py`
+- `lwa-backend/tests/test_any_source_engine.py`
+- `lwa-backend/tests/test_premium_guards.py`
+- `lwa-web/lib/types.ts`
+
+Protected behavior:
+
+- Upload acceptance reports `source_type`.
+- Upload source classification must remain shared through `source_ingest`.
+- Video uploads classify as `video_upload`.
+- Audio uploads classify as `audio_upload`.
+- Image uploads classify as `image_upload`.
+- `/v1/uploads` response includes `source_type`.
+- `source_ref` includes `source_type`.
+- `/v1/generate` uses the same source classifier.
+- POC matrix runner covers upload, prompt, music, campaign, YouTube fallback, Twitch fallback, and unsupported URL fallback lanes.
+- POC fixtures/results remain ignored under `poc/`.
+
+Do not remove or rewrite this. Only additive fixes are allowed unless tests prove a defect.
+
+### 2. POC source matrix tooling
+
+Protected behavior:
+
+- Runner command:
+
+```bash
+python3 tools/poc/source_matrix_runner.py --base-url http://127.0.0.1:8000
+```
+
+- Optional flags:
+
+```bash
+--youtube-url
+--twitch-url
+--unsupported-url
+--client-id
+```
+
+- Tool must continue checking:
+  - `/health`
+  - `/v1/uploads`
+  - `/v1/generate`
+  - upload media URLs
+  - strategy-only package paths
+  - public URL fallback safety
+  - raw extractor error leakage
+
+### 3. LWA Worlds frontend shell
+
+Protected files/areas:
+
+- `lwa-web/lib/worlds/types.ts`
+- `lwa-web/lib/worlds/mock-data.ts`
+- `lwa-web/lib/worlds/copy.ts`
+- `lwa-web/lib/worlds/utils.ts`
+- `lwa-web/components/worlds/*`
+- `lwa-web/app/command-center/page.tsx`
+- `lwa-web/app/marketplace/**`
+- `lwa-web/app/ugc/**`
+- `lwa-web/app/worlds/**`
+- `lwa-web/app/earnings/page.tsx`
+- `lwa-web/app/economy/page.tsx`
+- `lwa-web/app/integrations/page.tsx`
+- `lwa-web/app/admin/marketplace/page.tsx`
+
+Protected behavior:
+
+- Command Center routes through App Router.
+- Worlds pages are additive and do not replace existing generation flow.
+- Command Center links to existing `/generate`.
+- Mock data remains available as fallback until backend `/worlds` endpoints are connected.
+- Earnings, rights, blockchain, AI, and Polymarket safety copy must remain visible.
+- No guaranteed revenue/views/payouts copy.
+- No live crypto or payout claims.
+
+### 4. Claude / Seedance branches
+
+Known branches:
+
+- `feat/claude-seedance-platform`
+- `feat/claude-seedance-integration`
+
+Known PR:
+
+- PR #6: `[codex] Add Claude routing and simplify premium generation`
+  - Current target: `dev`
+  - Status observed: open draft
+  - Scope includes Claude routing, disabled-safe Seedance adapter, premium generator UI improvements.
+
+Guardrail:
+
+- Do not duplicate Claude/Seedance provider code in a separate path.
+- Do not remove disabled-safe behavior.
+- Do not claim Seedance is live unless the exact vendor contract and keys are verified.
+- If main needs Claude/Seedance, first compare PR #6 against current main/dev and rebase or cherry-pick carefully.
+
+### 5. Open PRs / merge posture observed
+
+Observed PRs:
+
+- PR #25: `web: harden uploaded video rendered output flow`
+  - Base: `main`
+  - Status observed: open, mergeable.
+  - Scope: frontend URL normalization for rendered assets.
+  - Safe priority: high, because it prevents false rendered state and broken open/download actions.
+
+- PR #9: `Finish backend health exposure and iOS auto-target contract alignment`
+  - Base: `main`
+  - Status observed: open draft, not mergeable.
+  - Scope includes `lwa-ios`.
+  - Guardrail: do not touch or merge until explicitly approved because current founder instruction repeatedly says do not touch `lwa-ios/`.
+
+- PR #6: Claude/Seedance provider work.
+  - Base: `dev`.
+  - Guardrail: inspect/rebase before any merge to `main`.
+
+## Required Safe Merge Order
+
+1. Merge or resolve PR #25 first if checks are clean.
+2. Re-check `main` after PR #25.
+3. Bring doctrine/docs branch into PR against `main`.
+4. Compare Claude/Seedance PR #6 against updated `main` and `dev` before trying to fuse provider code.
+5. Do not merge PR #9 until explicit iOS approval is given.
+6. Run full checks after each merge boundary.
+
+## Required Pre-Merge Checks
+
+Backend:
+
+```bash
+python3 -m compileall lwa-backend/app lwa-backend/scripts
+cd lwa-backend && python3 -m unittest discover -s tests && cd ..
+```
+
+POC tooling:
+
+```bash
+python3 -m unittest discover -s tools/poc
+python3 -m py_compile tools/poc/source_matrix_runner.py tools/poc/test_source_matrix_runner.py
+```
+
+Frontend:
+
+```bash
+cd lwa-web
+npm run type-check
+npm run build
+cd ..
+```
+
+Repo hygiene:
+
+```bash
+git diff --check
+git status --short
+```
+
+Manual proof where sandbox permits:
+
+```bash
+python3 tools/poc/source_matrix_runner.py --base-url http://127.0.0.1:8000
+```
+
+If localhost HTTP is blocked in sandbox, record that as blocked and run outside sandbox before final merge.
+
+## Absolute Do-Not-Touch Zones Without Explicit Approval
+
+- `lwa-ios/`
+- live payout movement
+- real crypto transactions
+- Polymarket trading/betting flows
+- direct TikTok/Instagram posting without platform approval
+- frontend env exposure of server secrets
+- removal of existing generation/upload/history/campaign/plan/credit behavior
+
+## Next Codex Instruction
+
+Before implementing any new feature, Codex must:
+
+1. read this file
+2. read `docs/lwa-worlds-master-council-report.md`
+3. inspect current PR/branch state
+4. identify overlap with Claude-protected files
+5. state whether it will edit protected files
+6. if protected files must be edited, explain why and keep changes additive/minimal
+7. run the verification matrix above
+
+## Current recommended next action
+
+Prepare the docs/doctrine PR to `main`, but do not merge provider/backend code until PR #25 is merged or explicitly skipped.
+
+Suggested doctrine PR title:
+
+`docs: add LWA Worlds master execution doctrine`
+
+Suggested PR body:
+
+- Adds Master Council Report.
+- Adds build queue and fusion guardrails.
+- Protects Claude any-source/source-matrix and Worlds frontend shell work.
+- Documents safe merge order and verification matrix.
+- Does not change runtime code.

--- a/docs/company/lwa-codex-chunk-sequence.md
+++ b/docs/company/lwa-codex-chunk-sequence.md
@@ -1,0 +1,252 @@
+# LWA Codex Chunk Sequence
+
+## Status
+
+This file converts the current LWA master stack into sequential Codex chunks. It is designed to prevent Codex from burning credits by implementing the wrong architecture or mixing unrelated systems into one PR.
+
+Use this with:
+
+- `docs/company/lwa-github-codex-master-fusion-prompt.md`
+- `docs/company/lwa-claude-codex-fusion-guardrails.md`
+- `docs/lwa-worlds-master-council-report.md`
+- `docs/lwa-worlds-mandatory-doctrine.md`
+- `docs/company/lwa-codex-execution-ledger.md`
+- `docs/company/lwa-autonomous-codex-execution-brief.md`
+
+## Chunk 15 — Master Repo Fusion + Implementation Status Map
+
+Goal:
+
+Fuse the master docs into GitHub, audit actual repo state, correct path assumptions, and create a living implementation status map.
+
+Do:
+
+- Run repo audit.
+- Confirm actual backend/frontend paths.
+- Fuse/update docs under `docs/company/`.
+- Create/update `docs/company/lwa-implementation-status.md`.
+- Create/update `docs/company/lwa-architecture-compatibility-map.md`.
+- Create/update `docs/company/lwa-source-of-truth.md`.
+- No runtime code unless the audit proves a tiny docs-linked correction is required.
+
+Do not:
+
+- Start marketplace.
+- Start Realms.
+- Start blockchain.
+- Start social integrations.
+- Touch `lwa-ios/`.
+
+Prompt source:
+
+- `docs/company/lwa-github-codex-master-fusion-prompt.md`
+
+## Chunk 16 — Source Handling / FREE_LAUNCH / Fallback Hardening
+
+Goal:
+
+Implement the single safest P0 product-hardening slice selected by the Chunk 15 audit.
+
+Priority order:
+
+1. Source handling hardening if source contracts are inconsistent.
+2. `FREE_LAUNCH_MODE` if missing/incomplete.
+3. deterministic fallback hardening if provider/source failures still 500.
+4. README polish if A-C are already done.
+
+Do:
+
+- Preserve `/health`, `/v1/generate`, `/v1/jobs`, `/v1/uploads`.
+- Preserve Source POC runner.
+- Preserve entitlements/quota.
+- Preserve revenue events.
+- Preserve generated asset retention.
+
+Do not:
+
+- Start marketplace.
+- Start Realms.
+- Start Stripe/Whop payouts.
+- Start blockchain.
+- Touch `lwa-ios/`.
+
+## Chunk 17 — Director Brain v0 + Platform Prompt Pack
+
+Goal:
+
+Add the first Director Brain layer without destabilizing generation.
+
+Do:
+
+- Add/adapt `director_brain` service.
+- Add platform-aware prompt packs.
+- Implement TikTok/Reels/Shorts/LinkedIn reasoning modes.
+- Reuse existing Claude/OpenAI routing if present.
+- Keep OpenAI-first or fallback mode when Claude is disabled.
+- Add tests/evals for output shape and provider fallback.
+
+Do not:
+
+- Duplicate Claude provider routing.
+- Claim guaranteed virality.
+- Rewrite the generation pipeline.
+
+## Chunk 18 — Caption Preset Renderer + Hook Formula Library
+
+Goal:
+
+Install the Master Council platform signal database as real structured product data.
+
+Do:
+
+- Add 20 hook formulas as data/templates.
+- Add 14 category modifiers as structured data.
+- Add 7 caption presets as overlay specs.
+- Add tests for formula/category/preset retrieval.
+- Connect to Director Brain if safe.
+
+Do not:
+
+- Force full pixel-perfect FFmpeg rendering if overlay specs are the safer first step.
+
+## Chunk 19 — Frontend Premium Generate Flow Polish
+
+Goal:
+
+Improve the revenue-facing generate flow while preserving working app behavior.
+
+Do:
+
+- Tighten first-use flow.
+- Improve source upload copy.
+- Show public URLs as best-effort.
+- Preserve CTA/revenue event tracking.
+- Preserve generated result cards and playable asset behavior.
+- Use premium dark creator-native language.
+
+Do not:
+
+- Replace the app shell.
+- Hide working outputs.
+- Break `/generate`.
+
+## Chunk 20 — Marketplace Compatibility Audit, Docs-Only First
+
+Goal:
+
+Determine how marketplace should fit the actual repo persistence and route structure.
+
+Do:
+
+- Audit backend persistence pattern.
+- Decide whether to use current store pattern, SQLite, Postgres, SQLAlchemy, Alembic, or migration plan.
+- Create marketplace implementation map.
+- Create safety copy and banned category docs.
+- No live money movement.
+
+Do not:
+
+- Add Stripe transfers.
+- Add live seller onboarding.
+- Add payout cron.
+
+## Chunk 21 — Marketplace MVP Dark Scaffold, No Live Payouts
+
+Goal:
+
+Add marketplace route/page/backend scaffold with safe placeholder states.
+
+Do:
+
+- Products/jobs/campaigns scaffold.
+- Seller profile placeholder.
+- Orders/payout statuses as mock/internal safe state.
+- Dispute/review/takedown states.
+- Earnings disclaimers.
+- Integer cents only if money fields exist.
+
+Do not:
+
+- Move real money.
+- Verify payments unless webhook infrastructure is implemented and tested.
+
+## Chunk 22 — Realms Static Content + Profile Shell, No Blockchain
+
+Goal:
+
+Install The Signal Realms as app identity/progression shell.
+
+Do:
+
+- Classes.
+- Factions.
+- Quest content.
+- Badge/relic catalogs.
+- Profile shell.
+- XP formula helpers.
+- Cosmetic-only copy.
+
+Do not:
+
+- Sell XP.
+- Unlock app features with relics.
+- Add chain writes.
+
+## Chunk 23 — Social API OAuth Shell, No Posting Until Approved
+
+Goal:
+
+Add integration scaffolds without unsafe platform actions.
+
+Do:
+
+- Provider config/env docs.
+- OAuth start/callback shells where safe.
+- Integration status endpoint/page.
+- Polymarket read-only trend plan/ingestor if compatible.
+
+Do not:
+
+- Post to TikTok/Instagram/YouTube without approval.
+- Store social tokens without encryption.
+- Add betting/trading flows.
+
+## Chunk 24 — Off-Chain Proof / Merkle Dry Run, No Mainnet
+
+Goal:
+
+Add optional provenance foundation without crypto risk.
+
+Do:
+
+- Issuance abstraction.
+- Deterministic hashable records.
+- Daily Merkle snapshot dry-run.
+- Proof UI copy.
+
+Do not:
+
+- Deploy contracts.
+- Add NFT purchases.
+- Add tokenomics.
+- Add investment language.
+
+## Standard Final Report For Every Chunk
+
+Codex must return:
+
+1. Branch and starting commit.
+2. Files inspected.
+3. Source docs used.
+4. Protected files detected.
+5. Files changed.
+6. What was implemented.
+7. What was preserved.
+8. Tests run.
+9. Blockers.
+10. Commit hash/message.
+11. Next chunk prompt.
+
+## Immediate Next Prompt
+
+Use `docs/company/lwa-github-codex-master-fusion-prompt.md` for Chunk 15.

--- a/docs/company/lwa-codex-execution-ledger.md
+++ b/docs/company/lwa-codex-execution-ledger.md
@@ -1,0 +1,314 @@
+# LWA Codex Execution Ledger
+
+## Status
+
+This document records the Codex work stream provided in `Pasted markdown.md` and treats it as mandatory implementation history for LWA / IWA.
+
+The uploaded log is not a strategy-only artifact. It contains Codex prompts, execution reports, commits, verification notes, and next-slice decisions. Future Codex, ChatGPT, Claude, and operator work must check this ledger before duplicating or replacing completed work.
+
+## Source
+
+- Source file: `Pasted markdown.md`
+- Purpose: preserve what has already been built with Codex and identify what still needs to be installed or reconciled.
+- Relationship to doctrine: this ledger complements `docs/lwa-worlds-mandatory-doctrine.md`.
+
+## Completed / Reported Codex Work
+
+### 1. Backend revenue event tracking foundation
+
+Reported branch:
+
+- `codex/finish-unfinished-backend`
+
+Reported commit:
+
+- `80a2970`
+
+Reported commit message:
+
+- `backend: add revenue event tracking foundation`
+
+Purpose:
+
+- Track monetization intent without verifying payments.
+- Add a safe backend foundation for upgrade clicks, checkout starts, demo requests, affiliate/referral interest, booking/contact clicks, and quota-blocked conversion pressure.
+
+Reported files changed:
+
+- `lwa-backend/app/core/config.py`
+- `lwa-backend/app/main.py`
+- `lwa-backend/app/models/schemas.py`
+- `lwa-backend/app/schemas.py`
+- `lwa-backend/app/services/asset_retention.py`
+- `lwa-backend/app/services/entitlements.py`
+- `lwa-backend/app/api/routes/revenue_events.py`
+- `lwa-backend/app/services/revenue_event_log.py`
+- `lwa-backend/tests/test_revenue_events.py`
+- `docs/company/backend-revenue-event-tracking.md`
+
+Key behavior:
+
+- Adds `POST /v1/revenue/events`.
+- Adds disabled-by-default JSONL revenue event logging.
+- Adds `authoritative=false` to logged revenue intent events.
+- Normalizes unknown destinations to `unknown`.
+- Rejects invalid revenue event types.
+- Sanitizes metadata and redacts secret-like keys.
+- Hashes client/user-agent/IP context rather than storing raw values.
+- Adds nonfatal `quota_blocked` intent logging when entitlement quota blocks generation.
+- Protects the revenue event JSONL path from generated asset cleanup.
+
+Critical safety boundaries:
+
+- Does not verify payments.
+- Does not unlock paid access.
+- Does not activate subscriptions.
+- Does not track payouts.
+- Does not submit campaigns.
+- Does not require Stripe, PayPal, Gumroad, Lemon Squeezy, or Whop credentials.
+
+Reported verification:
+
+- `python3 -m compileall lwa-backend/app lwa-backend/scripts` passed.
+- `python3 -m unittest tests.test_revenue_events` passed.
+- `python3 -m unittest discover -s tests` passed.
+- `git diff --check` passed.
+- `git status --short` was clean after commit.
+
+### 2. Web multi-destination money CTA system
+
+Reported branch:
+
+- `codex/finish-unfinished-backend`
+
+Reported local commit:
+
+- `0be4645`
+
+GitHub search later showed matching pushed commit:
+
+- `05567ea1e7050dd3bd7f4214c3decd080500cd3a`
+
+Reported commit message:
+
+- `web: add multi-destination money CTA system`
+
+Purpose:
+
+- Move frontend monetization away from Whop-only CTAs.
+- Add centralized support for Whop, Stripe Payment Link, PayPal, Gumroad, Lemon Squeezy, demo form, affiliate/referral form, booking link, and contact link.
+- Wire frontend CTA clicks to backend revenue event tracking.
+
+Reported files changed:
+
+- `lwa-web/lib/money-links.ts`
+- `lwa-web/components/money-cta-panel.tsx`
+- `lwa-web/app/api/revenue-events/route.ts`
+- `lwa-web/lib/api.ts`
+- `lwa-web/components/clip-studio.tsx`
+- `lwa-web/app/offers/page.tsx`
+- `lwa-web/app/page.tsx`
+- `lwa-web/.env.example`
+
+Key behavior:
+
+- Adds one centralized money-link config.
+- Keeps Whop available but no longer the only monetization path.
+- Adds `MoneyCtaPanel` for reusable safe offer CTAs.
+- Adds `/offers` as the public chooser page.
+- Adds `/api/revenue-events` frontend proxy.
+- Wires CTA click tracking to the backend `POST /v1/revenue/events` endpoint.
+- Adds UTM-building for money links.
+
+Reported verification:
+
+- `cd lwa-web && npm run type-check` passed.
+- `git diff --check` passed.
+- `git status --short` was clean after commit.
+
+Safety boundaries:
+
+- Backend was not touched in this frontend slice.
+- iOS was not touched.
+- Copy avoids guaranteed revenue, guaranteed views, automatic payout, or campaign-submission claims.
+
+### 3. Backend clip intelligence and entitlement hardening
+
+Reported branch:
+
+- `codex/finish-unfinished-backend`
+
+Reported commit:
+
+- `4b2e17f`
+
+Reported commit message:
+
+- `backend: add clip intelligence and entitlement hardening`
+
+Purpose:
+
+- Continue the backend engine toward LWA as an AI clipping and content-packaging engine, not a simple video tool.
+- Harden plan limits, intelligence fields, campaign packaging context, source/render truth, and backend route contract coverage.
+
+Reported additions / changes included:
+
+- Safer plan clip limits:
+  - `LWA_FREE_CLIP_LIMIT`
+  - `LWA_PRO_CLIP_LIMIT`
+  - `LWA_SCALE_CLIP_LIMIT`
+  - `LWA_MAX_CLIP_LIMIT`
+- Backend schema expansion for optional campaign and intelligence fields.
+- Provider provenance fields.
+- Intelligence provenance fields.
+- Packaging profiles.
+- Attention Compiler helper functions.
+- Route-level contract tests proving enriched fields survive `/generate` and `/v1/jobs`.
+
+Reported files touched included:
+
+- `lwa-backend/app/core/config.py`
+- `lwa-backend/app/models/schemas.py`
+- `lwa-backend/app/schemas.py`
+- `lwa-backend/app/services/entitlements.py`
+- `lwa-backend/app/services/attention_compiler.py`
+- `lwa-backend/app/services/clip_service.py`
+- `lwa-backend/app/services/packaging_profiles.py`
+- backend tests related to entitlements, output contract, attention compiler, and route contract coverage
+
+Key behavior:
+
+- Avoids fake 20/40 clip promises by capping safe plan limits.
+- Adds optional response fields for richer clip intelligence.
+- Adds first-three-seconds assessment and retention reasoning.
+- Adds platform packaging profiles for TikTok, Instagram, YouTube, Facebook, and Auto.
+- Keeps campaign support as manual packaging/context only.
+- Does not claim campaign submission, payout tracking, direct posting, or guaranteed results.
+
+Reported verification:
+
+- Backend compile passed.
+- Backend unittest passed.
+- `git diff --check` passed.
+- Worktree clean after commit.
+
+### 4. Any-source source-engine realignment
+
+Reported branch:
+
+- `codex/finish-unfinished-backend`
+
+Reported commit:
+
+- `2c95f7e`
+
+Reported commit message:
+
+- `backend: realign source engine for any-source input`
+
+Purpose:
+
+- Continue moving LWA from video-only toward any-source generation.
+- Let source material, prompts, files, campaign context, ideas, and objectives resolve through `/generate` safely.
+
+Reported behavior:
+
+- Source-engine slice was committed after verifying backend-only changes.
+- It keeps source handling aligned with the broader LWA direction.
+- It remains backend-focused and preserves existing app routes.
+
+Known limitation:
+
+- The full uploaded log should be reviewed before assuming all source-engine details are already pushed to GitHub main. Treat this ledger as implementation history plus verification target, not as proof that every local Codex commit is already merged remotely.
+
+## Additional Mandatory Company-Ops Work In The Log
+
+The uploaded file also contains a docs/company operations prompt for an elite recruitment and MVO system tied to Issue #22.
+
+That prompt requires docs-only company operating files:
+
+- `docs/company/lwa-elite-recruitment-and-mvo-system.md`
+- `docs/company/lwa-creator-tester-program.md`
+- `docs/company/lwa-sales-closer-program.md`
+- `docs/company/lwa-advisor-partner-investor-system.md`
+- `docs/company/lwa-support-the-build-mvo.md`
+- `docs/company/lwa-recruitment-outreach-scripts.md`
+- `docs/company/lwa-team-intake-forms.md`
+- `docs/company/lwa-7-day-team-build-plan.md`
+
+Status in this ledger:
+
+- Required by the Codex work log.
+- Should be implemented as docs-only.
+- Must not touch backend, frontend, or iOS when executed.
+
+## Installation / Reconciliation Rules
+
+When future work starts, run this decision order:
+
+1. Check this ledger.
+2. Check `docs/lwa-worlds-mandatory-doctrine.md`.
+3. Check `docs/lwa-worlds-integrated-architecture.md` if present on the working branch.
+4. Check `docs/lwa-ios-app-store-mobile-readiness-bridge.md` if the work touches iOS/App Store/mobile contracts.
+5. Inspect the actual repo state.
+6. Only then implement the next slice.
+
+## What Must Not Be Rebuilt From Scratch
+
+Do not duplicate or replace these if they already exist in the active branch:
+
+- backend revenue intent endpoint
+- revenue event JSONL logger
+- multi-destination money link config
+- `MoneyCtaPanel`
+- `/offers` page
+- frontend `/api/revenue-events` proxy
+- backend packaging profiles
+- Attention Compiler lite helpers
+- clip intelligence fields
+- source-engine any-source realignment
+- entitlement quota behavior
+
+Instead, inspect and extend.
+
+## Open Verification Checklist
+
+Before calling the Codex work fully installed, verify against the actual current repository branch:
+
+- `POST /v1/revenue/events` exists.
+- `revenue_event_log.py` exists.
+- `backend-revenue-event-tracking.md` exists.
+- `money-links.ts` exists.
+- `money-cta-panel.tsx` exists.
+- `/offers` exists.
+- `/api/revenue-events` exists.
+- `packaging_profiles.py` exists.
+- Attention Compiler helper functions exist.
+- source-engine any-source changes exist.
+- relevant tests exist and pass.
+- local Codex commits are pushed or reconciled with GitHub main.
+
+## Next Best Action
+
+Run a repo reconciliation audit:
+
+```text
+You are Codex working inside jcamacho611/lwa-app.
+
+Read:
+- docs/company/lwa-codex-execution-ledger.md
+- docs/lwa-worlds-mandatory-doctrine.md
+
+Task:
+Compare the Codex execution ledger against the actual current repo state.
+
+For each reported Codex slice, mark:
+- installed on current branch
+- missing
+- partially installed
+- conflicts with current code
+- needs tests
+- safe next repair
+
+Do not rewrite anything until the audit is complete.
+```

--- a/docs/company/lwa-codex-prompt-stack.md
+++ b/docs/company/lwa-codex-prompt-stack.md
@@ -1,0 +1,173 @@
+# LWA Codex Prompt Stack
+
+## Rule
+
+Use one prompt per slice.
+
+Do not paste the entire Master Council Report into Codex as an implementation task.
+
+Codex must inspect the actual repo first, preserve existing working code, and adapt paths from planning docs to the actual repo structure.
+
+## Prompt 1 — Master Repo Fusion
+
+Use when the repo needs docs/source-of-truth/status-map fusion.
+
+Task:
+
+- audit repo
+- fuse master docs
+- create implementation status map
+- correct assumed paths
+- select one safest next slice
+
+Primary prompt file:
+
+- `docs/company/lwa-github-codex-master-fusion-prompt.md`
+
+## Prompt 2 — Source Handling Hardening
+
+Task:
+
+- central format/source map if missing
+- stable source_type values
+- clean unsupported errors
+- public URL blocked fallback
+- POC runner compatibility
+- frontend accept list if safe
+
+Expected source_type values:
+
+- `video_upload`
+- `audio_upload`
+- `image_upload`
+- `prompt`
+- `music`
+- `campaign`
+- `url`
+
+## Prompt 3 — FREE_LAUNCH_MODE
+
+Task:
+
+- backend env flag
+- free launch guest behavior if compatible
+- abuse cap
+- frontend banner
+- Railway env docs
+- tests
+
+Do not remove paid-mode entitlement logic.
+
+## Prompt 4 — Fallback Hardening
+
+Task:
+
+- deterministic fallback helpers
+- no raw tool errors
+- degraded but usable response
+- provider/source failure tests
+- no full pipeline rewrite unless proven necessary
+
+## Prompt 5 — Director Brain v0
+
+Task:
+
+- platform prompt pack
+- hook/caption/moment scoring
+- structured JSON outputs
+- provider fallback
+- tests
+
+Do not duplicate existing Claude/OpenAI/Seedance routing if present.
+
+## Prompt 6 — Caption Presets
+
+Task:
+
+- caption preset spec
+- renderer contract
+- overlay spec output
+- no heavy render rewrite unless existing render path supports it
+
+Presets:
+
+- `crimson_pulse`
+- `clean_op`
+- `karaoke_neon`
+- `signal_low`
+- `bigframe`
+- `medspa_safe`
+- `dev_brutal`
+
+## Prompt 7 — Marketplace Audit
+
+Task:
+
+- inspect existing architecture
+- docs only
+- choose persistence strategy
+- no live money movement
+
+## Prompt 8 — Marketplace Dark Scaffold
+
+Task:
+
+- marketplace pages/routes if compatible
+- product/job/submission statuses
+- admin review states
+- earnings disclaimers
+- no real payouts
+
+## Prompt 9 — Realms Static Shell
+
+Task:
+
+- static pages/content
+- class/faction/quest content
+- profile shell
+- no chain
+- no XP purchases
+- no feature unlock relics
+
+## Prompt 10 — Social OAuth Shell
+
+Task:
+
+- provider status/OAuth plan
+- encrypted tokens if implemented
+- no posting until approved
+- Polymarket read-only only
+
+## Prompt 11 — Off-Chain Proof Dry Run
+
+Task:
+
+- deterministic proof records
+- Merkle JSON export
+- no mainnet
+- no NFT purchase flow
+
+## Prompt 12 — Trust/Safety Queue
+
+Task:
+
+- pending review queue
+- takedown/escalation states
+- audit events
+- dispute evidence placeholders
+
+## Required final report from Codex
+
+Every run must return:
+
+1. branch and starting commit
+2. files inspected
+3. source docs used
+4. protected files detected
+5. files changed
+6. what was implemented
+7. what was preserved
+8. tests run
+9. blockers
+10. commit hash/message
+11. next chunk prompt

--- a/docs/company/lwa-execution-roadmap.md
+++ b/docs/company/lwa-execution-roadmap.md
@@ -1,0 +1,92 @@
+# LWA Execution Roadmap
+
+## Purpose
+
+This roadmap turns the LWA Worlds vision into staged implementation. It prevents Codex from starting marketplace, Realms, social integrations, blockchain, and payments before the clipping MVP is hardened.
+
+## Current priority
+
+Chunk 15 is the source-of-truth and implementation-status layer.
+
+After Chunk 15, continue with exactly one safe P0 slice at a time.
+
+## Build order
+
+### P0 — Product must work
+
+1. Source handling hardening
+2. Free launch mode
+3. Fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. Platform prompt pack
+7. Hook formula library
+8. Caption preset renderer
+9. Better generate result cards
+
+### P2 — Product must make money safely
+
+10. Monetization CTA polish
+11. Revenue intent verification audit
+12. Verified webhook audit
+13. Stripe/Whop decision doc
+14. Entitlement reconciliation
+
+### P3 — Product moat
+
+15. Marketplace compatibility audit
+16. Marketplace dark scaffold, no live payouts
+17. Signal Realms static shell
+18. Social OAuth/status shell
+19. Off-chain proof dry run
+
+### P4 — Production scaling
+
+20. Admin trust/safety review queue
+21. Dispute flow
+22. Marketplace payout state machine after webhooks/ledger are tested
+23. Multi-account operator dashboard
+24. Analytics/feedback loop
+
+## 30-day roadmap
+
+### Week 1
+
+- Finish Chunk 15 source-of-truth docs.
+- Select and complete Chunk 16 P0 slice.
+- Keep source matrix and existing generation flow intact.
+
+### Week 2
+
+- Director Brain v0.
+- Platform prompt pack.
+- Caption/hook library foundation.
+
+### Week 3
+
+- Frontend generate flow polish.
+- CTA/revenue intent audit.
+- Marketplace compatibility audit docs.
+
+### Week 4
+
+- Marketplace dark scaffold or Realms static shell depending on MVP stability.
+- Prepare public launch checklist.
+
+## 90-day roadmap
+
+- Harden clipping and source handling.
+- Add Director Brain.
+- Add caption presets.
+- Add dark marketplace scaffold.
+- Add Realms identity shell.
+- Add social integration status shell.
+- Add off-chain proof dry run.
+- Add trust/safety review queue.
+
+## Roadmap rule
+
+Do not promote a future system to shipped until there is repo evidence and passing checks.

--- a/docs/company/lwa-github-codex-master-fusion-prompt.md
+++ b/docs/company/lwa-github-codex-master-fusion-prompt.md
@@ -1,0 +1,178 @@
+# LWA GitHub / Codex Master Fusion Prompt
+
+Use this prompt in GitHub-connected ChatGPT/Codex when continuing the LWA Worlds build.
+
+---
+
+## Paste-ready prompt
+
+```text
+You are now the GitHub/Codex execution operator for the LWA / IWA / LWA Worlds repo.
+
+Repository: jcamacho611/lwa-app
+Primary branch: main
+Current live frontend: https://lwa-the-god-app-production.up.railway.app
+Current live backend: https://lwa-backend-production-c9cc.up.railway.app
+
+Your job is to safely continue the work already done in this repo and fuse all uploaded LWA Worlds / Claude / Codex planning files into the actual GitHub repository so future Codex runs can keep implementing without losing context.
+
+CRITICAL FIRST ACTIONS
+
+1. Inspect the repository before editing.
+2. Read these docs first if present:
+   - docs/company/lwa-claude-codex-fusion-guardrails.md
+   - docs/lwa-worlds-master-council-report.md
+   - docs/lwa-worlds-mandatory-doctrine.md
+   - docs/company/lwa-codex-execution-ledger.md
+   - docs/company/lwa-autonomous-codex-execution-brief.md
+3. Search for existing Claude/Seedance/worlds/source-ingest work before creating anything new.
+4. Preserve existing routes, product structure, generation flow, upload flow, campaign flow, plan/credit logic, Railway deploy behavior, and frontend navigation.
+5. Do not touch lwa-ios/ unless Justin explicitly gives iOS approval in the current instruction.
+
+PROTECTED WORK THAT MUST NOT BE OVERWRITTEN
+
+Treat the following as protected unless a test proves a defect:
+
+- any-source engine/source classification
+- upload source_type behavior
+- tools/poc/source_matrix_runner.py
+- tools/poc/test_source_matrix_runner.py
+- lwa-backend/app/services/source_ingest.py
+- lwa-backend/app/api/routes/upload.py
+- lwa-backend/app/api/routes/generate.py
+- lwa-backend/app/models/schemas.py
+- lwa-web/lib/types.ts
+- LWA Worlds frontend shell under command-center, marketplace, ugc, worlds, earnings, economy, integrations, and admin marketplace pages
+- Claude/Seedance provider routing and disabled-safe Seedance adapter from feat/claude-seedance-platform / feat/claude-seedance-integration / PR #6
+
+MERGE / PR POSTURE
+
+Before implementing, inspect open PRs.
+
+Known posture from prior run:
+
+- PR #25: web rendered-output URL hardening, base main, mergeable when checked.
+- PR #26: docs execution doctrine and fusion guardrails, docs-only.
+- PR #6: Claude/Seedance provider work, base dev, draft; inspect/rebase/cherry-pick before fusing into main.
+- PR #9: touches iOS; do not merge or edit unless Justin explicitly approves iOS.
+
+SAFE ORDER
+
+1. Keep docs/doctrine changes isolated from runtime changes.
+2. Merge/check PR #25 first unless explicitly skipped.
+3. Merge/check doctrine docs PR after #25 or alongside if no conflict.
+4. Only then compare Claude/Seedance PR #6 against updated main and dev.
+5. For implementation, work in small PR chunks matching the execution chunks below.
+
+ABSOLUTE NO-GO WITHOUT EXPLICIT APPROVAL
+
+- Do not touch lwa-ios/.
+- Do not introduce live payout movement.
+- Do not introduce real crypto transactions.
+- Do not add Polymarket betting/trading flows.
+- Do not enable TikTok/Instagram direct posting beyond sandbox/approval-safe shells.
+- Do not expose server secrets to NEXT_PUBLIC vars.
+- Do not remove working fallback logic.
+- Do not replace existing product surfaces with a brand-new architecture.
+
+EXECUTION CHUNKS
+
+Chunk 0: Repo + PR audit
+- Inspect branches, open PRs, current main, current dev.
+- Summarize changed files and conflicts.
+- Do not edit runtime code.
+
+Chunk 1: Docs fusion and doctrine
+- Ensure all Master Council, Claude, Codex, launch, execution ledger, and guardrail docs live in docs/ and docs/company/.
+- Add/update an execution index linking them.
+- No runtime code.
+
+Chunk 2: Day 3 hardening only
+- Adapt paths to actual repo. This repo uses lwa-backend and lwa-web, not necessarily apps/backend and apps/web.
+- Add FREE_LAUNCH_MODE only if not already present.
+- Add typed/degraded fallback behavior only where compatible with existing generation pipeline.
+- Add FreeLaunchBanner only as additive UI.
+- README polish.
+- Do not break generation/upload.
+
+Chunk 3: Director Brain v0
+- Add platform-aware prompt/ranking/caption scaffolding.
+- Reuse existing Claude/OpenAI/Seedance provider routing if present.
+- Do not duplicate Claude provider paths.
+- Keep provider failures degraded-safe.
+
+Chunk 4: Marketplace scaffold
+- Build schemas/routes/UI as scaffold behind feature flags or safe mock-backed data if persistence is not ready.
+- Stripe/Whop real money movement must remain disabled until keys/webhooks/legal are verified.
+- Include FTC/earnings disclaimers.
+- Money must be integer cents only.
+
+Chunk 5: Signal Realms scaffold
+- Add character/classes/factions/XP/quest/badge/relic foundation.
+- Off-chain only.
+- No purchasable XP.
+- Relics cosmetic only.
+- Badges confer no monetary rights.
+
+Chunk 6: Social integrations shell
+- OAuth shell and status dashboard only.
+- Polymarket read-only cultural signal only.
+- No betting/trading.
+- TikTok/Instagram publishing must be sandbox/approval-safe only.
+
+Chunk 7: Off-chain proof placeholder
+- Issuance abstraction and deterministic Merkle snapshot only.
+- No deployed chain contract in this PR.
+- UI must say provenance only, cosmetic only, no investment value.
+
+Chunk 8: Operator dashboard + trust/safety queue
+- Add internal/operator surfaces after marketplace/realms foundations exist.
+- Takedowns/reviews must be audited.
+
+VERIFICATION MATRIX
+
+Run whatever applies to the files touched. Prefer actual repo commands over generic examples.
+
+Backend:
+python3 -m compileall lwa-backend/app lwa-backend/scripts
+cd lwa-backend && python3 -m unittest discover -s tests && cd ..
+
+POC tooling:
+python3 -m unittest discover -s tools/poc
+python3 -m py_compile tools/poc/source_matrix_runner.py tools/poc/test_source_matrix_runner.py
+
+Frontend:
+cd lwa-web
+npm run type-check
+npm run build
+cd ..
+
+Repo hygiene:
+git diff --check
+git status --short
+
+Manual proof if local backend can run:
+python3 tools/poc/source_matrix_runner.py --base-url http://127.0.0.1:8000
+
+OUTPUT FORMAT REQUIRED
+
+Return:
+
+1. What you inspected.
+2. Protected files detected.
+3. Files changed.
+4. Exact verification commands run and results.
+5. Any blocked checks and why.
+6. PR title and PR body.
+7. Next safest chunk.
+
+Start now with Chunk 0 and Chunk 1. If docs already exist, update them minimally and open a docs-only PR. Do not touch runtime code in the first PR.
+```
+
+---
+
+## Operator note
+
+This prompt is intentionally strict. It should keep Codex from blending docs, backend, frontend, payments, blockchain, and iOS into one dangerous PR.
+
+Use it before giving Codex any implementation prompt from the Master Council stack.

--- a/docs/company/lwa-implementation-status.md
+++ b/docs/company/lwa-implementation-status.md
@@ -1,37 +1,40 @@
 # LWA Implementation Status
 
-This file must be updated after every Codex slice.
+This file must be updated after every safe implementation slice.
 
-Use repo evidence only. If there is no repo evidence, mark the area as `planned`, `unknown`, or `not implemented`. Never mark a planned system as shipped.
-
-## Chunk 15 status map
+Use repo evidence only. If unknown, say unknown. If planned, say planned. Never mark a planned system as shipped.
 
 | Area | Status | Evidence in repo | Safe next step |
 |---|---|---|---|
-| Core generation | In progress / present | GitHub search finds `lwa-backend/app/api/routes/generate.py`, `lwa-backend/app/api/routes/generation.py`, `lwa-backend/app/services/clip_service.py`, `lwa-backend/app/generation.py`, `lwa-backend/app/processor.py` | Preserve and harden; do not rewrite generation flow |
-| Upload/source handling | In progress / present | GitHub search finds `lwa-backend/app/services/source_ingest.py`, `lwa-backend/tests/test_any_source_engine.py`, upload/source typing references | Normalize source contract; keep source matrix tooling passing |
-| Public URL support | Best-effort / present | Generation/source ingest files exist; source docs mention public URL/source protocols | Clean fallback messages; no guaranteed platform extraction claims |
-| Source POC Matrix | In progress / protected | Fusion guardrails protect `tools/poc/source_matrix_runner.py` and related tests | Keep runner compatible before/after source changes |
-| Revenue intent tracking | Unknown / verify locally | Uploaded Codex ledger reports revenue event foundation; GitHub search did not find `revenue_events`, `RevenueEvent`, `revenue_event_log`, or `authoritative` in the queried branch/main snapshot | Audit locally before claiming installed; reinstall only if missing and selected as a slice |
-| FREE_LAUNCH_MODE | Unknown / likely missing | No confirmed repo evidence from Chunk 15 search | Add after source handling if missing and compatible |
-| Fallback hardening | Partial / unknown | Source error and clip strategy files exist, but deterministic full fallback layer must be audited | Add deterministic fallbacks after free launch/source hardening if needed |
-| Director Brain | Planned | Master Council Report and prompt stack define it; no confirmed `director_brain` service evidence yet | Build v0 after P0 hardening |
-| Caption presets | Planned | Master Council Report defines 7 presets; no confirmed renderer evidence yet | Build structured overlay spec after Director Brain |
-| Marketplace | Future / docs planned | Master Council Report and future plan define it; do not assume runtime implementation | Run marketplace compatibility audit before code |
-| Realms/RPG | Future / docs planned | Master Council Report and doctrine define Signal Realms | Build static shell first; no blockchain, no purchasable XP |
-| Social APIs | Future / docs planned | Master Council Report defines provider plan | OAuth/status shell only later; no posting until approval |
-| Blockchain/proof | Future / docs planned | Master Council Report defines optional proof roadmap | Off-chain proof dry run only later |
-| iOS/mobile | Existing app + planned bridge | `lwa-ios` exists in project history; mobile readiness bridge doc exists/expected | Do not touch without explicit iOS approval |
-| Investor/data room | Docs/planned | Investor/company docs may exist or be added later | Keep internal/admin; do not expose claims as shipped |
-| Frontend premium UI | In progress | `lwa-web` exists; prior work includes app routes/components and premium direction | Polish after core generate/upload flow is stable |
-| Railway deployment | In progress | Live backend/frontend URLs documented in Master Council Report | Smoke test after runtime merges/deploys |
+| Core generation | In progress / verify before claim | Check `lwa-backend` generation routes and tests | Preserve and harden |
+| Upload/source handling | In progress | Check source ingest/upload routes and source matrix tooling | Normalize source contract |
+| Public URL support | Best-effort | Public platforms may block server extraction | Clean fallback messages and avoid raw tool errors |
+| Source POC Matrix | In progress if `tools/poc` exists | Source matrix runner and related tests | Keep runner passing |
+| Revenue intent tracking | Present if `/v1/revenue/events` exists | Revenue event route/logger/tests | Preserve non-authoritative behavior |
+| FREE_LAUNCH_MODE | Unknown until audit | Backend env/config and frontend banner | Add if missing after source hardening |
+| Fallback hardening | Unknown until audit | Pipeline/source failure behavior | Add deterministic degraded results |
+| Director Brain | Planned unless code exists | `director_brain` service/prompts | Build v0 after hardening |
+| Caption presets | Planned unless code exists | Caption renderer/preset files | Build after Director Brain |
+| Marketplace | Future | Marketplace routes/models/pages if present | Audit before implementation; no live payouts |
+| Realms/RPG | Future | Realm routes/pages/models if present | Static shell only first |
+| Social APIs | Future | Integration providers/OAuth if present | OAuth shell only; no posting until approved |
+| Blockchain/proof | Future | Issuance/proof/Merkle files if present | Off-chain dry run only |
+| iOS/mobile | Existing app + planned bridge | `lwa-ios` and mobile docs | Audit only before touching code |
+| Investor/data room | Docs/planned | Investor docs/routes if present | Keep internal/admin only |
+| Frontend premium UI | In progress | `lwa-web` routes/components | Polish after core flow |
+| Railway deployment | In progress | Railway URLs/env docs | Smoke test after each deploy |
 
-## Update rule
+## Current priority
 
-Every task must update this file if it changes status.
+P0 is product reliability:
+
+1. source handling hardening
+2. FREE_LAUNCH_MODE
+3. fallback hardening
+4. README/Railway launch polish
 
 ## Claim rule
 
-If there is no repo evidence, mark status as `planned`, `unknown`, or `not implemented`.
+If there is no repo evidence, mark the feature as `planned`, `unknown`, or `not implemented`.
 
-Never mark a planned system as shipped.
+Do not claim marketplace, Realms, social APIs, blockchain, verified payments, or iOS App Store readiness as shipped until code and tests prove it.

--- a/docs/company/lwa-implementation-status.md
+++ b/docs/company/lwa-implementation-status.md
@@ -1,0 +1,37 @@
+# LWA Implementation Status
+
+This file must be updated after every Codex slice.
+
+Use repo evidence only. If there is no repo evidence, mark the area as `planned`, `unknown`, or `not implemented`. Never mark a planned system as shipped.
+
+## Chunk 15 status map
+
+| Area | Status | Evidence in repo | Safe next step |
+|---|---|---|---|
+| Core generation | In progress / present | GitHub search finds `lwa-backend/app/api/routes/generate.py`, `lwa-backend/app/api/routes/generation.py`, `lwa-backend/app/services/clip_service.py`, `lwa-backend/app/generation.py`, `lwa-backend/app/processor.py` | Preserve and harden; do not rewrite generation flow |
+| Upload/source handling | In progress / present | GitHub search finds `lwa-backend/app/services/source_ingest.py`, `lwa-backend/tests/test_any_source_engine.py`, upload/source typing references | Normalize source contract; keep source matrix tooling passing |
+| Public URL support | Best-effort / present | Generation/source ingest files exist; source docs mention public URL/source protocols | Clean fallback messages; no guaranteed platform extraction claims |
+| Source POC Matrix | In progress / protected | Fusion guardrails protect `tools/poc/source_matrix_runner.py` and related tests | Keep runner compatible before/after source changes |
+| Revenue intent tracking | Unknown / verify locally | Uploaded Codex ledger reports revenue event foundation; GitHub search did not find `revenue_events`, `RevenueEvent`, `revenue_event_log`, or `authoritative` in the queried branch/main snapshot | Audit locally before claiming installed; reinstall only if missing and selected as a slice |
+| FREE_LAUNCH_MODE | Unknown / likely missing | No confirmed repo evidence from Chunk 15 search | Add after source handling if missing and compatible |
+| Fallback hardening | Partial / unknown | Source error and clip strategy files exist, but deterministic full fallback layer must be audited | Add deterministic fallbacks after free launch/source hardening if needed |
+| Director Brain | Planned | Master Council Report and prompt stack define it; no confirmed `director_brain` service evidence yet | Build v0 after P0 hardening |
+| Caption presets | Planned | Master Council Report defines 7 presets; no confirmed renderer evidence yet | Build structured overlay spec after Director Brain |
+| Marketplace | Future / docs planned | Master Council Report and future plan define it; do not assume runtime implementation | Run marketplace compatibility audit before code |
+| Realms/RPG | Future / docs planned | Master Council Report and doctrine define Signal Realms | Build static shell first; no blockchain, no purchasable XP |
+| Social APIs | Future / docs planned | Master Council Report defines provider plan | OAuth/status shell only later; no posting until approval |
+| Blockchain/proof | Future / docs planned | Master Council Report defines optional proof roadmap | Off-chain proof dry run only later |
+| iOS/mobile | Existing app + planned bridge | `lwa-ios` exists in project history; mobile readiness bridge doc exists/expected | Do not touch without explicit iOS approval |
+| Investor/data room | Docs/planned | Investor/company docs may exist or be added later | Keep internal/admin; do not expose claims as shipped |
+| Frontend premium UI | In progress | `lwa-web` exists; prior work includes app routes/components and premium direction | Polish after core generate/upload flow is stable |
+| Railway deployment | In progress | Live backend/frontend URLs documented in Master Council Report | Smoke test after runtime merges/deploys |
+
+## Update rule
+
+Every task must update this file if it changes status.
+
+## Claim rule
+
+If there is no repo evidence, mark status as `planned`, `unknown`, or `not implemented`.
+
+Never mark a planned system as shipped.

--- a/docs/company/lwa-marketplace-future-plan.md
+++ b/docs/company/lwa-marketplace-future-plan.md
@@ -1,0 +1,62 @@
+# LWA Marketplace Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Goal
+
+Create a creator economy marketplace around clips, templates, hooks, captions, prompt packs, brand kits, B-roll bundles, and campaign work.
+
+## V1 marketplace should not include live payouts first
+
+First marketplace slice should be a dark/internal scaffold only:
+
+- product/listing model or mock-backed data
+- marketplace browse page
+- seller dashboard shell
+- admin review queue
+- claim safety footer
+- no live payouts
+- no Stripe transfers
+- no seller balances
+
+## Required safety before money movement
+
+- KYC plan
+- tax plan
+- fraud review
+- payout holds
+- refund policy
+- dispute window
+- admin takedown
+- signed webhooks
+- idempotent ledger
+- no guaranteed earnings copy
+
+## Future marketplace objects
+
+- creators/buyers
+- sellers/clippers
+- products/listings
+- campaign jobs
+- submissions
+- reviews
+- disputes
+- payout states
+- ledger entries
+- webhook inbox
+
+## Forbidden early claims
+
+Do not say:
+
+- earn guaranteed money
+- passive income
+- get paid instantly
+- investment opportunity
+- marketplace income guaranteed
+
+Use:
+
+Earnings vary. No guarantee of income.

--- a/docs/company/lwa-master-council-report.md
+++ b/docs/company/lwa-master-council-report.md
@@ -1,0 +1,62 @@
+# LWA Worlds Master Council Report
+
+## Status
+
+This is the company-level pointer to the full Master Council Report.
+
+The canonical full report is stored at:
+
+- `docs/lwa-worlds-master-council-report.md`
+
+Use that file as the full source for:
+
+- Phase 1 clipping engine hardening
+- competitive intelligence
+- platform signal database
+- marketplace architecture
+- The Signal Realms RPG system
+- social API integration plan
+- blockchain/proof roadmap
+- hiring plan
+- Codex prompt stack
+- council executive summary
+
+## Required companion files
+
+Chunk 15 also splits the report into execution-ready company docs:
+
+- `docs/company/lwa-source-of-truth.md`
+- `docs/company/lwa-execution-roadmap.md`
+- `docs/company/lwa-implementation-status.md`
+- `docs/company/lwa-architecture-compatibility-map.md`
+- `docs/company/lwa-codex-prompt-stack.md`
+- `docs/company/lwa-claim-safety-rules.md`
+- `docs/company/lwa-revenue-and-monetization-plan.md`
+- `docs/company/lwa-marketplace-future-plan.md`
+- `docs/company/lwa-realms-future-plan.md`
+- `docs/company/lwa-social-api-future-plan.md`
+- `docs/company/lwa-blockchain-proof-future-plan.md`
+- `docs/company/lwa-next-safe-slice.md`
+
+## Implementation rule
+
+Do not paste the full Master Council Report into Codex as one implementation task.
+
+Use the companion docs and chunk sequence so work happens in safe, testable slices.
+
+## Current next move
+
+Read:
+
+1. `docs/company/lwa-source-of-truth.md`
+2. `docs/company/lwa-implementation-status.md`
+3. `docs/company/lwa-next-safe-slice.md`
+4. `docs/company/lwa-codex-prompt-stack.md`
+5. `docs/lwa-worlds-master-council-report.md`
+
+Then select exactly one P0 slice:
+
+- source handling hardening
+- `FREE_LAUNCH_MODE`
+- fallback hardening
+- README/Railway launch polish

--- a/docs/company/lwa-next-safe-slice.md
+++ b/docs/company/lwa-next-safe-slice.md
@@ -1,0 +1,80 @@
+# LWA Next Safe Slice
+
+## Selection rule
+
+After every Codex run, choose exactly one next safe slice.
+
+Do not stack marketplace, Realms, social APIs, blockchain, Stripe payouts, Whop payouts, and frontend redesign into one run.
+
+## Priority order
+
+### P0 — Product must work
+
+1. source handling hardening
+2. free launch mode
+3. fallback hardening
+4. README/Railway launch polish
+
+### P1 — Product must feel valuable
+
+5. Director Brain v0
+6. platform prompt pack
+7. hook formula library
+8. caption preset renderer
+9. better generate result cards
+
+### P2 — Product must make money safely
+
+10. monetization CTA polish
+11. verified webhook audit
+12. Stripe/Whop decision doc
+13. entitlement reconciliation
+
+### P3 — Product moat
+
+14. marketplace compatibility audit
+15. marketplace dark scaffold
+16. Realms static shell
+17. social OAuth shell
+18. off-chain proof dry run
+
+## Current recommended next slice
+
+Run source handling hardening if source behavior is still not fully normalized.
+
+If source behavior is already normalized, run `FREE_LAUNCH_MODE`.
+
+If `FREE_LAUNCH_MODE` is already done, run fallback hardening.
+
+If all three are done, run README/Railway launch polish.
+
+## Decision checklist
+
+Before selecting a slice, verify:
+
+- Does `/v1/uploads` return stable `source_type`?
+- Does `/v1/generate` preserve the same source contract?
+- Does the source matrix runner still work?
+- Does public URL failure return clean fallback copy?
+- Does free launch mode exist in backend config?
+- Does the frontend free launch banner exist?
+- Do provider/source failures degrade instead of crashing?
+- Is README aligned with actual repo paths and Railway URLs?
+
+## What not to select yet
+
+Do not select these until P0 is stable:
+
+- marketplace implementation
+- Realms implementation
+- social API implementation
+- blockchain proof implementation
+- live payouts
+- iOS work
+
+## Required update
+
+After completing a slice, update:
+
+- `docs/company/lwa-implementation-status.md`
+- this file's current recommended next slice

--- a/docs/company/lwa-realms-future-plan.md
+++ b/docs/company/lwa-realms-future-plan.md
@@ -1,0 +1,91 @@
+# LWA Signal Realms Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Purpose
+
+The Signal Realms is the retention and identity layer for creators.
+
+Users become Signalbearers with:
+
+- classes
+- factions
+- skill XP
+- quests
+- badges
+- cosmetic relics
+
+## Rule
+
+No pay-to-win.
+
+XP cannot be purchased.
+
+Relics are cosmetic only.
+
+Badges are earned only.
+
+## Safe first implementation
+
+The first implementation should be:
+
+- static `/realm` or `/worlds` page, depending on actual route direction
+- character profile shell
+- class/faction content
+- quest list
+- badge/relic gallery mock
+- no blockchain
+- no purchases
+- no XP economy tied to money
+
+## Core classes
+
+- Hookwright
+- Captioneer
+- Reframer
+- Trendseer
+- Loremaster
+- Voicewright
+- Ironforger
+- Pricer
+- Auditor
+- Diplomat
+- Cartographer
+- Oracle
+
+## Core factions
+
+- Crimson Court
+- Black Loom
+- Verdant Pact
+- Iron Choir
+- Saffron Wake
+- Glass Synod
+- Tide Marshal
+- Driftborn
+- Emberkin
+- Chorus of Thoth
+- House Polis
+- Outer Signal
+
+## Future implementation
+
+Later:
+
+- event-based XP awarder
+- quest progression
+- leaderboards
+- badge awards
+- relic holdings
+- off-chain proof
+- optional chain migration
+
+## Forbidden
+
+- NFT unlocks app features
+- XP purchases
+- investment/value appreciation claims
+- token/yield language
+- income rights from badges or relics

--- a/docs/company/lwa-revenue-and-monetization-plan.md
+++ b/docs/company/lwa-revenue-and-monetization-plan.md
@@ -1,0 +1,83 @@
+# LWA Revenue And Monetization Plan
+
+## Current monetization foundation
+
+The safe first layer is revenue-intent tracking.
+
+Revenue-intent events are not payment verification.
+
+They help track:
+
+- upgrade clicks
+- checkout starts
+- demo requests
+- affiliate/referral interest
+- quota-blocked upgrade pressure
+- booking/contact clicks
+
+## Non-authoritative rule
+
+Revenue events must remain non-authoritative.
+
+They must not:
+
+- unlock paid access
+- activate subscriptions
+- verify payment
+- trigger payouts
+- confirm revenue
+
+Verified payment state must come later from signed provider webhooks.
+
+## Safe funnel
+
+1. User hits a generation/quota/value wall.
+2. App shows upgrade/demo/contact CTA.
+3. Frontend sends revenue-intent event if implemented.
+4. Backend logs sanitized non-authoritative event if the endpoint exists.
+5. User goes to checkout/demo/contact path.
+6. Future signed webhook verifies actual payment.
+7. Entitlement changes only after verified payment or explicit admin grant.
+
+## Future payment integrations
+
+Future slices:
+
+1. Stripe webhook verification.
+2. Whop webhook verification.
+3. Lemon Squeezy webhook verification.
+4. Gumroad webhook verification.
+5. PayPal verification if needed.
+6. Entitlement reconciliation.
+7. Billing audit view.
+
+## Pricing direction
+
+Draft only:
+
+- Free Launch: limited public usage.
+- Creator: core clipping.
+- Pro: more clips, stronger captions/render controls.
+- Scale: agencies/operators.
+- Marketplace: future take rate.
+
+## Required before live marketplace money
+
+- verified webhooks
+- idempotency
+- ledger
+- seller KYC
+- payout holds
+- dispute system
+- takedown/admin queue
+- refund policy
+- banned category policy
+- claim safety copy
+
+## Current verification rule
+
+Codex must verify actual repo evidence before saying revenue-event tracking is installed.
+
+If the route/logger exists, preserve it.
+
+If it does not exist, do not add it unless the selected slice is monetization/revenue tracking.

--- a/docs/company/lwa-social-api-future-plan.md
+++ b/docs/company/lwa-social-api-future-plan.md
@@ -1,0 +1,81 @@
+# LWA Social API Future Plan
+
+## Status
+
+Future phase unless repo evidence proves otherwise.
+
+## Provider direction
+
+Potential providers:
+
+- YouTube
+- TikTok
+- Instagram / Meta
+- Twitch
+- Reddit
+- Google Trends or a trend-data provider
+- Polymarket Gamma read-only
+- OpenAI
+- Anthropic Claude
+- Seedance / BytePlus ModelArk
+- Apple App Store Connect for app metadata/readiness where appropriate
+
+## Safe first slice
+
+OAuth/status shell only:
+
+- auth URL
+- callback
+- link status
+- revoke
+- encrypted tokens if tokens are stored
+- provider status docs
+- no auto-posting until approved
+
+## Polymarket rule
+
+Polymarket data may only be used as read-only cultural trend metadata.
+
+Do not:
+
+- place trades
+- recommend bets
+- create betting UI
+- reward wagering
+- imply financial advice
+
+## Posting rule
+
+Do not implement direct posting until provider app review, scopes, rate limits, and user consent flows are confirmed.
+
+## Token storage rule
+
+Do not store social tokens unless the backend has:
+
+- encryption at rest
+- OAuth state verification
+- refresh/revocation handling
+- clear scope display
+- provider status audit trail
+
+## First implementation direction
+
+Start with an integrations dashboard/status shell before real provider actions:
+
+- provider name
+- configured/not configured
+- connected/disconnected
+- scopes requested
+- approval status
+- last sync
+- last error
+
+## Safe customer copy
+
+Use:
+
+Social integrations are planned to help organize source metadata, trend signals, and approved publishing workflows.
+
+Avoid:
+
+Guaranteed posting, guaranteed reach, or platform approval claims.

--- a/docs/company/lwa-source-of-truth.md
+++ b/docs/company/lwa-source-of-truth.md
@@ -2,25 +2,21 @@
 
 ## Rule
 
-The existing repo is the source of truth.
+The existing repository is the source of truth.
 
-This project is a continuation mission, not a restart.
+This is a continuation mission, not a restart. Do not create replacement apps, parallel backends, duplicate web apps, or generic templates unless a repo audit proves the existing structure is unusable.
 
-Do not create parallel apps, duplicate backend structures, or replacement frontends unless an audit proves the existing structure is unusable.
+## Actual repo direction
 
-## Actual repo paths
+Expected working paths in this repo:
 
-Use the actual repo paths discovered by audit.
-
-Expected current paths:
-
-- backend: `lwa-backend`
-- frontend: `lwa-web`
+- Backend: `lwa-backend`
+- Frontend: `lwa-web`
 - iOS: `lwa-ios`
-- tooling: `tools`
-- company docs: `docs/company`
+- Tools: `tools`
+- Company docs: `docs/company`
 
-If a master prompt says `apps/backend` or `apps/web`, adapt it to the real repo structure instead of creating new folders.
+If any outside prompt says `apps/backend` or `apps/web`, adapt it to the real repo structure instead of creating new folders.
 
 ## Product
 
@@ -28,13 +24,17 @@ LWA / IWA is an AI content repurposing product.
 
 Primary promise:
 
-Drop in one long-form source and get ranked short-form outputs with hooks, captions, timestamps, scores, and workflow-ready assets.
+> Drop in one long-form source and get ranked short-form outputs with hooks, captions, timestamps, scores, and workflow-ready assets.
+
+Operational promise:
+
+> Move from generation to queue to campaigns to payout-readiness inside one premium creator workspace.
 
 ## Current MVP truth
 
-The app should be treated as a real MVP, not a mock.
+Treat the app as a real MVP, not a mock. Verify every item in the repo before claiming it as shipped.
 
-Known current or near-current capabilities may include:
+Known working or near-current directions may include:
 
 - public video URL generation
 - target platform selection
@@ -50,35 +50,9 @@ Known current or near-current capabilities may include:
 - source matrix tooling
 - revenue intent event tracking
 
-Codex must verify every item in the repo before claiming it as shipped.
-
-## Repo evidence observed during Chunk 15 preparation
-
-GitHub search on `main` shows current evidence for:
-
-- `lwa-backend/app/api/routes/generate.py`
-- `lwa-backend/app/api/routes/generation.py`
-- `lwa-backend/app/api/routes/me.py`
-- `lwa-backend/app/services/source_ingest.py`
-- `lwa-backend/app/services/video_service.py`
-- `lwa-backend/app/services/clip_service.py`
-- `lwa-backend/app/services/platform_store.py`
-- `lwa-backend/app/models/schemas.py`
-- `lwa-backend/tests/test_any_source_engine.py`
-- `lwa-backend/tests/test_platform_store.py`
-- `lwa-backend/tests/test_clip_strategy.py`
-- `lwa-web/lib/types.ts`
-- `docs/company/lwa-any-source-engine-spec.md`
-- `docs/company/lwa-ai-output-schema-map.md`
-- `docs/company/lwa-source-output-event-protocols.md`
-- `docs/company/lwa-connector-protocol-map.md`
-- `docs/company/lwa-master-prompt-library.md`
-
-GitHub search did not find revenue event route/logger files by the queried terms `revenue_events`, `RevenueEvent`, `revenue_event_log`, or `authoritative` during this preparation pass. Codex must verify locally before marking revenue tracking as installed.
-
 ## Planned systems
 
-The following are strategic plans unless repo evidence proves they are implemented:
+The following remain planned unless repo evidence proves they are implemented:
 
 - Director Brain
 - full marketplace
@@ -88,33 +62,11 @@ The following are strategic plans unless repo evidence proves they are implement
 - social posting APIs
 - Polymarket trend ingestion
 - blockchain/NFT proof layer
-- full mobile/iOS App Store system
+- full mobile/App Store system
 
-## Safe customer claim
+## Engineering order
 
-Use:
-
-LWA supports upload-first clipping for common video/audio sources plus strategy generation for prompt, music, campaign, and image-style inputs. Public URLs are best-effort because platforms can block server extraction.
-
-Do not claim guaranteed YouTube, TikTok, Instagram, or Twitch extraction.
-
-## Safety rules
-
-Do not claim:
-
-- guaranteed virality
-- guaranteed income
-- payment verified without webhook verification
-- payout ready without KYC/tax/fraud controls
-- NFT value appreciation
-- investment return
-- platform posting approved before API review
-
-## Engineering rule
-
-One safe implementation slice at a time.
-
-Preferred order:
+Build one safe slice at a time:
 
 1. source handling hardening
 2. free launch mode
@@ -128,3 +80,21 @@ Preferred order:
 10. Realms static shell
 11. social API OAuth shell
 12. off-chain proof dry run
+
+## Safe customer-facing claim
+
+LWA supports upload-first clipping for common video/audio sources plus strategy generation for prompt, music, campaign, and image-style inputs. Public URLs are best-effort because platforms can block server extraction.
+
+Do not claim guaranteed YouTube, TikTok, Instagram, Twitch, or Instagram extraction.
+
+## Safety rules
+
+Do not claim:
+
+- guaranteed virality
+- guaranteed income
+- payment verified without server-side webhook verification
+- payout ready without KYC/tax/fraud controls
+- NFT value appreciation
+- investment return
+- platform posting approved before API review

--- a/docs/company/lwa-source-of-truth.md
+++ b/docs/company/lwa-source-of-truth.md
@@ -1,0 +1,130 @@
+# LWA / IWA Source Of Truth
+
+## Rule
+
+The existing repo is the source of truth.
+
+This project is a continuation mission, not a restart.
+
+Do not create parallel apps, duplicate backend structures, or replacement frontends unless an audit proves the existing structure is unusable.
+
+## Actual repo paths
+
+Use the actual repo paths discovered by audit.
+
+Expected current paths:
+
+- backend: `lwa-backend`
+- frontend: `lwa-web`
+- iOS: `lwa-ios`
+- tooling: `tools`
+- company docs: `docs/company`
+
+If a master prompt says `apps/backend` or `apps/web`, adapt it to the real repo structure instead of creating new folders.
+
+## Product
+
+LWA / IWA is an AI content repurposing product.
+
+Primary promise:
+
+Drop in one long-form source and get ranked short-form outputs with hooks, captions, timestamps, scores, and workflow-ready assets.
+
+## Current MVP truth
+
+The app should be treated as a real MVP, not a mock.
+
+Known current or near-current capabilities may include:
+
+- public video URL generation
+- target platform selection
+- optional angle/trend input
+- ranked clip pack output
+- hooks
+- captions
+- timestamps
+- scores
+- asset links
+- source upload work
+- prompt/music/campaign strategy lanes
+- source matrix tooling
+- revenue intent event tracking
+
+Codex must verify every item in the repo before claiming it as shipped.
+
+## Repo evidence observed during Chunk 15 preparation
+
+GitHub search on `main` shows current evidence for:
+
+- `lwa-backend/app/api/routes/generate.py`
+- `lwa-backend/app/api/routes/generation.py`
+- `lwa-backend/app/api/routes/me.py`
+- `lwa-backend/app/services/source_ingest.py`
+- `lwa-backend/app/services/video_service.py`
+- `lwa-backend/app/services/clip_service.py`
+- `lwa-backend/app/services/platform_store.py`
+- `lwa-backend/app/models/schemas.py`
+- `lwa-backend/tests/test_any_source_engine.py`
+- `lwa-backend/tests/test_platform_store.py`
+- `lwa-backend/tests/test_clip_strategy.py`
+- `lwa-web/lib/types.ts`
+- `docs/company/lwa-any-source-engine-spec.md`
+- `docs/company/lwa-ai-output-schema-map.md`
+- `docs/company/lwa-source-output-event-protocols.md`
+- `docs/company/lwa-connector-protocol-map.md`
+- `docs/company/lwa-master-prompt-library.md`
+
+GitHub search did not find revenue event route/logger files by the queried terms `revenue_events`, `RevenueEvent`, `revenue_event_log`, or `authoritative` during this preparation pass. Codex must verify locally before marking revenue tracking as installed.
+
+## Planned systems
+
+The following are strategic plans unless repo evidence proves they are implemented:
+
+- Director Brain
+- full marketplace
+- Stripe Connect payouts
+- Whop submerchant marketplace
+- Signal Realms RPG
+- social posting APIs
+- Polymarket trend ingestion
+- blockchain/NFT proof layer
+- full mobile/iOS App Store system
+
+## Safe customer claim
+
+Use:
+
+LWA supports upload-first clipping for common video/audio sources plus strategy generation for prompt, music, campaign, and image-style inputs. Public URLs are best-effort because platforms can block server extraction.
+
+Do not claim guaranteed YouTube, TikTok, Instagram, or Twitch extraction.
+
+## Safety rules
+
+Do not claim:
+
+- guaranteed virality
+- guaranteed income
+- payment verified without webhook verification
+- payout ready without KYC/tax/fraud controls
+- NFT value appreciation
+- investment return
+- platform posting approved before API review
+
+## Engineering rule
+
+One safe implementation slice at a time.
+
+Preferred order:
+
+1. source handling hardening
+2. free launch mode
+3. fallback hardening
+4. README/Railway launch polish
+5. Director Brain v0
+6. caption preset renderer
+7. frontend generate flow polish
+8. marketplace audit/docs
+9. marketplace dark scaffold without live payouts
+10. Realms static shell
+11. social API OAuth shell
+12. off-chain proof dry run

--- a/docs/lwa-worlds-mandatory-doctrine.md
+++ b/docs/lwa-worlds-mandatory-doctrine.md
@@ -1,0 +1,546 @@
+# LWA Worlds Mandatory Doctrine
+
+## Status
+
+This document is mandatory project doctrine for LWA / IWA / LWA Worlds.
+
+It consolidates the ChatGPT chunk-thread direction into a repo-visible operating spec so Codex, ChatGPT, contractors, and future hires do not treat the vision as optional brainstorming.
+
+This document does **not** mean every feature should be coded at once. It means every implementation slice must align with this system.
+
+## Supreme Product Thesis
+
+**LWA Worlds is a creator-economy operating system where AI creates media, marketplace creates money, UGC creates supply, RPG progression creates identity, social intelligence creates relevance, and blockchain later creates proof.**
+
+LWA is not only a clipping app. The clipping engine is the foundation and money/content engine for a broader platform.
+
+## Required Product Pillars
+
+1. **AI Clipping Engine**
+   - Ingest public URLs, uploads, streams, audio, files, and prompts over time.
+   - Transcribe, detect moments, remove silence, crop vertical, caption, render, score, rank, package, export, and recover failed jobs.
+   - Output must feel finished and usable, not theoretical.
+
+2. **Social Intelligence Engine**
+   - Integrate or scaffold YouTube, TikTok, Instagram, Twitch, Reddit/news/trends, Polymarket trend-only, OpenAI, Anthropic, Seedance, and Apple/App Store readiness.
+   - Use social APIs for relevance, metadata, trend intelligence, distribution planning, and creator workflows.
+   - Polymarket is trend intelligence only. No trading, betting, or gambling.
+
+3. **Marketplace Engine**
+   - Buyers post content/clipping/campaign jobs.
+   - Clippers, editors, creators, template sellers, and UGC builders submit work or sell assets.
+   - Buyers/admins approve, reject, request revision, dispute, or release payout.
+   - All earnings language must use estimated, pending, approved, payable, paid, held, disputed, refunded.
+
+4. **UGC Creation Engine**
+   - Users create templates, hook packs, caption packs, prompt packs, quests, campaigns, cosmetics, character concepts, world assets, and creator services.
+   - UGC must support review, moderation, licensing, ownership declarations, reports, and takedowns.
+
+5. **RPG / World Engine**
+   - Users have identities, avatars, classes, factions, XP, skills, quests, badges, relics, titles, ranks, and reputation.
+   - Real platform actions create progression.
+   - The world must be original. Do not copy GTA, Roblox, Fortnite, RuneScape, Elden Ring, One Piece, Sony, Nintendo, Marvel, DC, anime IP, or any existing franchise.
+
+6. **Internal Economy Ledger**
+   - Track credits, generation usage, XP, reputation, pending earnings, approved earnings, paid earnings, platform fees, holds, disputes, refunds, badges, relics, collectibles, referrals, and wallet placeholders.
+   - Every money/reputation/progression event needs source, owner, status, timestamp, and auditability.
+
+7. **Blockchain / NFT / Crypto Proof Layer**
+   - Phase 1 is internal ledger and wallet/proof placeholders only.
+   - Future chain use is proof-of-creation, proof-of-campaign-completion, optional cosmetics, badges, founder passes, and reputation proof.
+   - No token launch, staking, yield, gambling, betting, crypto payouts, or investment language in MVP.
+   - Legal/security review is required before any real NFT, wallet, token, or chain feature ships.
+
+8. **Admin / Moderation / Fraud Layer**
+   - Admin must be able to review campaigns, submissions, UGC, payouts, disputes, abuse, fraud, content rights, integrations, and system health.
+
+## Mandatory Safety Rules
+
+- Preserve the existing clipping/generation flow by default.
+- Additive edits only unless there is a proven defect.
+- Do not touch `lwa-ios/` unless the task is explicitly iOS.
+- No guaranteed earnings claims.
+- No gambling, betting, staking, yield, passive-income, or get-rich language.
+- No Polymarket trading.
+- No token launch in phase 1.
+- No real crypto payouts in phase 1.
+- NFTs/digital collectibles must be optional, cosmetic/proof/access only, and not investments.
+- Users must own or have rights to submitted content.
+- Every payout must support pending review, approved, payable, processing, paid, failed, held, disputed, refunded, cancelled.
+- Every UGC item must support moderation/review status.
+- Every money movement must be auditable.
+
+## Original World Direction
+
+Working world name: **The Signal Realms**.
+
+### Classes
+
+- Signalwright
+- Clipforger
+- Trendseer
+- Render Mage
+- Campaign Hunter
+- Relic Broker
+- Loreblade
+- Vault Runner
+- Echo Smith
+- Myth Editor
+- Worldbinder
+- Algorithm Knight
+
+### Factions
+
+- The Signalwrights
+- The Clipforged
+- The Gold Thread Guild
+- The Void Editors
+- The Renderborn
+- The Mythstream Order
+- The Echo Court
+- The Relic Cartel
+- The Campaign Houses
+- The Black Frame Syndicate
+- The Algorithm Priests
+- The Vault Runners
+- The Aether Court
+- The Proofbound
+
+### Skill Tracks
+
+- Clipping
+- Captioning
+- Trendseeing
+- Rendering
+- Campaign Craft
+- UGC Building
+- Lore Craft
+- Marketplace Trade
+- Reputation
+- Social Distribution
+- Worldbuilding
+- Relic Forging
+- Signal Reading
+- Audience Alchemy
+
+## User Money Loops
+
+Users may make money through:
+
+- approved clip jobs
+- campaign submissions
+- template sales
+- UGC asset sales
+- creator services
+- managed clipping work
+- affiliate/referral commissions
+- optional future cosmetic/access collectibles after legal review
+
+LWA may make money through:
+
+- clipping subscriptions
+- generation credits
+- marketplace platform fees
+- template/UGC sales fees
+- managed campaigns
+- agency/team plans
+- premium cosmetics
+- enterprise/API access
+- future appchain/proof services after review
+
+## Required Routes Over Time
+
+### Core
+
+- `/command-center`
+- `/generate`
+- `/results/[jobId]`
+- `/history`
+- `/pricing`
+- `/account`
+- `/billing`
+- `/support`
+
+### Marketplace
+
+- `/marketplace`
+- `/marketplace/post-job`
+- `/marketplace/campaigns`
+- `/marketplace/campaigns/[id]`
+- `/marketplace/submit/[campaignId]`
+- `/marketplace/templates`
+- `/marketplace/templates/[id]`
+- `/marketplace/seller`
+- `/marketplace/clipper/apply`
+
+### Earnings / Referrals
+
+- `/earnings`
+- `/earnings/pending`
+- `/earnings/approved`
+- `/earnings/payouts`
+- `/referrals`
+- `/referrals/dashboard`
+
+### UGC
+
+- `/ugc`
+- `/ugc/create`
+- `/ugc/assets`
+- `/ugc/assets/[id]`
+- `/ugc/quests`
+- `/ugc/quests/create`
+- `/ugc/world-builder`
+- `/ugc/templates`
+
+### Worlds / RPG
+
+- `/worlds`
+- `/worlds/profile`
+- `/worlds/map`
+- `/worlds/quests`
+- `/worlds/factions`
+- `/worlds/relics`
+- `/worlds/classes`
+- `/worlds/events`
+- `/worlds/leaderboard`
+
+### Economy / Chain
+
+- `/economy`
+- `/economy/ledger`
+- `/economy/badges`
+- `/economy/wallet`
+- `/economy/collectibles`
+- `/economy/lwa-chain`
+
+### Integrations
+
+- `/integrations`
+- `/integrations/youtube`
+- `/integrations/tiktok`
+- `/integrations/instagram`
+- `/integrations/twitch`
+- `/integrations/polymarket`
+- `/integrations/openai`
+- `/integrations/anthropic`
+- `/integrations/seedance`
+- `/integrations/apple`
+
+### Admin
+
+- `/admin`
+- `/admin/users`
+- `/admin/jobs`
+- `/admin/clips`
+- `/admin/marketplace`
+- `/admin/submissions`
+- `/admin/payouts`
+- `/admin/disputes`
+- `/admin/moderation`
+- `/admin/fraud`
+- `/admin/integrations`
+- `/admin/economy`
+- `/admin/worlds`
+
+## Required Backend Areas Over Time
+
+- auth
+- users/profiles
+- clipping/generation
+- transcription
+- captions/rendering
+- social intelligence
+- marketplace
+- campaigns
+- submissions/reviews
+- templates
+- UGC
+- quests
+- XP/reputation
+- badges/relics
+- ledger
+- wallet placeholder/proof placeholder
+- payouts placeholder then Stripe Connect after review
+- affiliates/referrals
+- admin
+- moderation
+- fraud detection
+- notifications
+- storage
+- analytics
+- integrations
+
+## Required Integration Clients
+
+Scaffold isolated integration clients under the backend without hardcoded secrets:
+
+- YouTube Data API
+- TikTok API
+- Instagram Graph API
+- Twitch API
+- Polymarket public/trend-only APIs
+- OpenAI
+- Anthropic Claude
+- Seedance / BytePlus ModelArk
+- Apple App Store Connect
+- Whop
+- Stripe/Stripe Connect later
+
+## Required Database Areas Over Time
+
+### Account
+
+- users
+- user_profiles
+- teams
+- team_members
+- roles
+- permissions
+- sessions
+- api_keys
+
+### Clipping
+
+- source_videos
+- clip_jobs
+- clip_results
+- clip_assets
+- clip_transcripts
+- clip_scores
+- clip_packages
+- caption_styles
+- render_jobs
+- render_failures
+- generation_events
+
+### Marketplace
+
+- marketplace_profiles
+- clipper_profiles
+- buyer_profiles
+- campaigns
+- campaign_requirements
+- campaign_assets
+- campaign_submissions
+- submission_reviews
+- submission_revisions
+- campaign_deliverables
+- marketplace_orders
+- marketplace_fees
+- disputes
+- ratings
+- reviews
+
+### Earnings / Payouts
+
+- earnings_accounts
+- earning_events
+- pending_earnings
+- approved_earnings
+- payouts
+- payout_methods
+- payout_holds
+- refunds
+- chargebacks
+- tax_profiles
+- platform_fee_events
+
+### UGC
+
+- ugc_assets
+- ugc_asset_versions
+- ugc_asset_categories
+- ugc_submissions
+- ugc_reviews
+- ugc_sales
+- ugc_licenses
+- ugc_reports
+- ugc_moderation_events
+- world_templates
+- quest_templates
+- cosmetic_assets
+
+### RPG / Worlds
+
+- world_profiles
+- avatar_profiles
+- classes
+- user_classes
+- factions
+- user_factions
+- quests
+- quest_steps
+- quest_completions
+- xp_events
+- skill_tracks
+- user_skills
+- badges
+- user_badges
+- relics
+- user_relics
+- titles
+- user_titles
+- leaderboards
+- world_events
+
+### Economy Ledger
+
+- internal_ledger_entries
+- credit_balances
+- credit_transactions
+- reputation_events
+- creator_reputation
+- clipper_reputation
+- marketplace_reputation
+- wallet_connections
+- collectible_placeholders
+- chain_proof_placeholders
+
+### Integrations / Admin / Security
+
+- api_integrations
+- integration_tokens
+- integration_status
+- youtube_sources
+- tiktok_sources
+- instagram_sources
+- twitch_sources
+- polymarket_trends
+- openai_usage_events
+- anthropic_usage_events
+- seedance_jobs
+- apple_connect_events
+- admin_actions
+- audit_logs
+- moderation_queue
+- fraud_flags
+- abuse_reports
+- content_rights_claims
+- dmca_requests
+- security_events
+- webhook_events
+- system_health_events
+
+## Real-World Talent Archetypes To Study / Recruit Near
+
+These are not instructions to copy IP or personalities. They are public-reference talent archetypes that explain the kind of expertise LWA needs.
+
+- Roblox / David Baszucki archetype: UGC platform economy, creator marketplaces, digital goods, payments/fraud.
+- Epic / Tim Sweeney archetype: engine-first thinking, creator tools, app/storefront ecosystems, UGC publishing.
+- OpusClip / Young Zhao and CTO-style archetype: AI clipping product and media infrastructure.
+- Whop founder archetype: creator commerce, digital products, subscriptions, app-like storefronts.
+- Stripe / Collison archetype: serious money movement, marketplace payouts, ledger discipline, fraud/disputes.
+- FromSoftware / Hidetaka Miyazaki archetype: mythic RPG identity, mystery, earned progression, lore through relics.
+- Rockstar / Dan Houser archetype: transmedia worldbuilding, characters, culture, satire, dialogue, long-form IP.
+- Jagex / RuneScape archetype: skills, progression, grind loops, economy balance, long-term player trust.
+- thirdweb/OpenZeppelin archetype: wallet/proof tooling and smart-contract/security discipline.
+
+## Mandatory Team Roles
+
+1. Founding Systems Architect / Creative Technical Director
+2. Full-Stack Platform Engineer
+3. AI / Media Pipeline Engineer
+4. AI Orchestration Engineer
+5. Game Systems Designer
+6. Marketplace Product Lead
+7. UI/UX Product Designer
+8. Blockchain / Game Economy Engineer
+9. Legal / Compliance Advisor
+10. Technical Producer / Operator
+11. Trust & Safety Lead
+12. Creator Partnerships / Marketplace Ops Lead
+13. Community Director
+14. Investor / Fundraising Lead
+
+The first mission of this team is not to code the entire fantasy. It is to build the vertical slice that proves all pillars connect.
+
+## Contest / Investor Vertical Slice
+
+The first demo that proves the platform:
+
+1. User signs in.
+2. User enters command center.
+3. User generates clips from a source.
+4. Best clip appears first with hooks/captions/package.
+5. User creates marketplace campaign from the clip pack.
+6. Clipper submits improved work.
+7. Buyer/admin approves or requests revision.
+8. Clipper receives pending/approved earnings state.
+9. XP/reputation event is awarded.
+10. Badge/relic unlocks.
+11. World profile updates.
+12. Economy ledger records events.
+13. Wallet/proof page shows future chain readiness only.
+14. Admin dashboard shows moderation/payout/dispute state.
+
+## Build Order
+
+1. Protect and harden the clipping engine.
+2. Add source/upload support and rendered-proof-first UX.
+3. Add marketplace skeleton and post-job/submission/review states.
+4. Add internal economy ledger with estimated/pending/approved earnings.
+5. Add RPG profile/progression/quests/badges tied to real app actions.
+6. Add UGC creation/review/sales placeholders.
+7. Add integrations dashboard and isolated API clients.
+8. Add admin/moderation/fraud overview.
+9. Add wallet/proof placeholder only.
+10. Add real payouts, NFTs, or chain only after legal/security review.
+
+## Immediate Codex Rule
+
+Before implementation, Codex must read this document and report:
+
+1. What existing work must be preserved.
+2. Which pillar the next task belongs to.
+3. Which files will be touched.
+4. Which files will not be touched.
+5. What will remain mocked/stubbed.
+6. What verification will run.
+
+## Immediate Next Implementation Slice
+
+After source hardening and route separation are stable, the next safe slice is:
+
+**Marketplace skeleton + internal economy placeholders + RPG profile shell.**
+
+Scope:
+
+- Add frontend pages/shells.
+- Add backend models/routes only if they fit existing persistence patterns.
+- Use safe statuses and disclaimers.
+- No real payouts.
+- No real crypto.
+- No token.
+- No iOS changes.
+
+## Canonical Safety Copy
+
+Use:
+
+- Earnings are estimated until reviewed and approved.
+- Payouts require approval and may be held during review, dispute, or fraud checks.
+- Platform fee may apply.
+- Users must own or have rights to submitted content.
+- Digital collectibles and wallet features are optional future features and are not investments.
+
+Avoid:
+
+- Guaranteed income.
+- Passive income.
+- Get rich.
+- Risk-free money.
+- Stake/yield.
+- Bet/win.
+- Token profit.
+- NFT investment.
+
+## Definition Of Done For Doctrine Sync
+
+This doctrine is synced when:
+
+- It exists in the repo.
+- Future prompts point Codex to it first.
+- Roadmap/docs/tasks reference these pillars.
+- Implementation slices preserve existing working clipping flows.
+- Marketplace/RPG/UGC/blockchain work follows this order and safety model.

--- a/docs/lwa-worlds-master-council-report.md
+++ b/docs/lwa-worlds-master-council-report.md
@@ -1,0 +1,853 @@
+# LWA Worlds — Master Council Report
+
+**Status:** mandatory execution source for LWA / IWA / LWA Worlds.
+
+**Compiled:** April 29, 2026  
+**Founder:** Justin "Big Daddy Macho" Camacho  
+**Repository:** `jcamacho611/lwa-app`  
+**Backend:** `lwa-backend-production-c9cc.up.railway.app`  
+**Frontend:** `lwa-the-god-app-production.up.railway.app`
+
+This document consolidates the uploaded Master Council Report into the repo as an execution source. It is not optional brainstorming. It is the product, technical, hiring, and Codex command plan for LWA Worlds.
+
+Codex must use this report together with:
+
+- `docs/lwa-worlds-mandatory-doctrine.md`
+- `docs/company/lwa-codex-execution-ledger.md`
+- `docs/company/lwa-autonomous-codex-execution-brief.md`
+- Claude doctrine/spec/code docs when provided
+
+## Document Map
+
+1. Phase 1: LWA Clipping Engine Day 3 Sprint
+2. Competitive Intelligence Matrix
+3. Platform Signal Database
+4. Marketplace Architecture
+5. RPG / World System: The Signal Realms
+6. Social API Integration Plan
+7. Blockchain / NFT / Appchain Roadmap
+8. Hiring Plan
+9. Master Codex Prompt Stack
+10. Council Executive Summary
+
+---
+
+# Part 1 — Phase 1: LWA Clipping Engine Day 3 Sprint
+
+## What ships in Phase 1
+
+The MVP running on Railway covers ingest, transcribe, moment detection, cut, caption, score, and 9:16 export. Day 3 hardens the production surface instead of adding disconnected features.
+
+Required deliverables:
+
+1. `FREE_LAUNCH_MODE`
+   - Single env-driven flag.
+   - Opens app with no paywall/auth gate.
+   - Keeps abuse prevention via IP cap.
+   - Allows Justin to post the public link without breaking production.
+
+2. Fallback hardening
+   - Every external call must be wrapped.
+   - Covers yt-dlp, Whisper, OpenAI, Anthropic, ffmpeg, and render/export.
+   - Typed fallback response.
+   - Deterministic degraded output.
+   - Never 500 the frontend for recoverable provider/source failures.
+
+3. README polish
+   - Clear engineer-facing repo entry point.
+   - Live URLs.
+   - Local dev.
+   - Required env vars.
+   - Architecture diagram.
+   - API examples.
+   - Railway deploy notes.
+
+## Required Day 3 implementation intent
+
+Codex must adapt this to the actual repo paths. The report uses examples like `apps/backend` and `apps/web`, but this repo may use `lwa-backend` and `lwa-web`. Codex must inspect first and adapt rather than blindly pasting paths.
+
+### FREE_LAUNCH_MODE requirements
+
+- Backend env: `FREE_LAUNCH_MODE=true|false`
+- Frontend env: `NEXT_PUBLIC_FREE_LAUNCH_MODE=true|false`
+- Backend setting exposed as `settings.free_launch_mode`
+- Auth dependencies must support synthetic guest/free-launch user when enabled.
+- Anonymous traffic must remain capped by IP.
+- Paid checks must not block free launch use.
+- Frontend banner: `FreeLaunchBanner` visible only when frontend flag is true.
+
+### Fallback requirements
+
+Add/adapt fallback service with deterministic behavior:
+
+- transcript fallback: split source timeline into 30s windows labeled `Segment N`
+- moment fallback: pick three evenly spaced 30s windows
+- caption fallback: transcript text verbatim
+- hook fallback: first seven words of segment
+- provider/source/render failures return degraded result instead of raw error leak
+- log structured error context: step, request/source id, error class, sanitized error message
+
+### Verification checklist
+
+- backend compile passes
+- backend tests pass
+- frontend type-check passes
+- frontend lint/build pass where available
+- bad URL returns degraded response or clean source fallback, not raw 500
+- repeated anonymous usage triggers rate limit eventually
+- banner renders when enabled
+- invalid Anthropic/OpenAI keys do not destroy the whole user flow
+
+### Railway env vars
+
+- `FREE_LAUNCH_MODE=true`
+- `NEXT_PUBLIC_FREE_LAUNCH_MODE=true`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `WHISPER_MODEL=small`
+- `MAX_VIDEO_MINUTES=30`
+- `RATE_LIMIT_GUEST_RPM=30`
+- `DATABASE_URL`
+- `REDIS_URL`
+- `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET` if rendered storage is enabled
+- `LOG_LEVEL=info`
+- `SENTRY_DSN` optional
+
+---
+
+# Part 2 — Competitive Intelligence Matrix
+
+## Market structure
+
+The clipping market is crowded. The wedge is not “another clipper.” LWA must become the only platform combining:
+
+- clipping engine
+- creator marketplace
+- progression/RPG identity
+- multi-platform algorithm intelligence
+- operator dashboard
+
+## Competitor positioning
+
+### OpusClip
+
+Known wedge:
+
+- Strong category recognition.
+- Virality scoring.
+- Clip generation.
+
+LWA response:
+
+- “OpusClip gives you a number. LWA gives you a director.”
+- Per-platform intelligence instead of one global virality score.
+- Transparent ledger.
+- API/automation for operators.
+- Marketplace and progression moat.
+
+### Vizard / Klap / Munch
+
+LWA response:
+
+- Director Brain reranks and explains clips.
+- UGC marketplace adds supply and monetization.
+- Trend signal becomes explicit, not black box.
+
+### Descript / Captions.ai
+
+LWA response:
+
+- Web-first, automation-first.
+- Short-form-native instead of transcript-editor-first.
+- No iOS dependency in MVP.
+
+### CapCut / Submagic
+
+LWA response:
+
+- LWA is not a manual editor. It is an operator platform.
+- Caption styles are necessary but not enough.
+- Marketplace + Realms creates retention.
+
+### Repurpose.io / Vidyo.ai
+
+LWA response:
+
+- Routing plus content creation plus economy.
+
+## Sales objection responses
+
+- “OpusClip already does this.” → OpusClip does step 1. LWA does clipping, packaging, marketplace, identity, and earnings flow.
+- “Cheaper tools exist.” → LWA is built around operator workflow, per-platform intelligence, API/economy, and marketplace—not simple minutes.
+- “I trust one virality score.” → TikTok, Reels, Shorts, LinkedIn, Twitch, and Whop rank different signals. LWA scores per platform.
+- “Crypto worries me.” → Core product does not require wallet/crypto. Blockchain is optional proof/cosmetic layer later.
+
+## Competitor-resistant features
+
+1. Director Brain
+2. Signal Realms RPG layer
+3. Marketplace
+4. Polymarket-backed trend signal as read-only cultural intelligence
+5. Multi-account operator dashboard
+
+---
+
+# Part 3 — Platform Signal Database
+
+## Per-platform ranking signals
+
+### TikTok
+
+- Optimal: 7–60s entertainment, 15–90s education
+- Hook: first 1–3s
+- Ranking: completion, shares, saves, comments, likes, rewatches
+- Captions: original burned-in preferred
+- Hashtags: 3–5 specific
+
+### Instagram Reels
+
+- Optimal: 15–60s, longer eligible where platform supports
+- Hook: first 2s
+- Ranking: DM shares, watch time, saves
+- TikTok watermark penalized
+- Hashtags: 3–5
+
+### YouTube Shorts
+
+- Optimal: 15–60s
+- Hook: first second
+- Ranking: engaged views, rewatches, swipe-away ratio
+- Title keywords matter heavily
+
+### YouTube long-form
+
+- Optimal: 8–15 minutes for new channels
+- Ranking: CTR, average view duration, satisfaction, session watch time
+
+### LinkedIn video
+
+- Optimal: under 90s vertical/native
+- Hook: first 3s
+- Ranking: dwell time, comment depth, saves, DM shares
+- External links reduce reach
+- Hashtags: 3 max
+
+### Facebook Reels
+
+- Optimal: 15–60s
+- Ranking: watch time, shares, completion
+
+### X / Twitter video
+
+- Optimal: under 2:20
+- Ranking: replies, reposts, likes, premium amplification
+
+### Twitch clips
+
+- Optimal: 5–60s
+- Ranking: clip view velocity, channel traffic
+
+### Whop / community
+
+- Optimal: course chapters 4–10 minutes, posts under 90s
+- Ranking: completion, day-7 retention, comments, member-share rate
+
+## Category modifiers
+
+- Podcast: open mid-sentence on punchline, quotability and DM shares
+- Gaming: first frame in action, rewatches and velocity
+- Finance: show specific number early, saves/comments
+- Coaching: pain point within 2s, saves/DM shares
+- Beauty: visual transformation first, saves
+- Medspa: before/after first frame, no medical-claim language
+- Music: drop/hook audio first, replays/creates
+- Sports: highlight first, shares
+- Education: curiosity gap, saves
+- Debate/commentary: strong claim, comments/replies
+- Reaction: face + context first
+- Product demo: use-case first
+- AI/tech: output demo first
+- Local business: location/offer early
+
+## Hook formula library
+
+Codex must convert these into prompt templates/eval fixtures:
+
+1. Contrarian claim
+2. Named-persona callout
+3. Dollar amount, only if true/disclosed
+4. Pattern interrupt
+5. Numbered list promise
+6. Time compression
+7. Reverse hook
+8. Named enemy/comparison
+9. Specific name-drop
+10. Before/after
+11. Unfinished number
+12. Unexpected admission
+13. Framework name
+14. Implied secret
+15. CTA-shaped hook
+16. Objection-first hook
+17. Paradox
+18. Dialogue cold-open
+19. Counter-trend
+20. Dataset/pattern hook
+
+## Caption presets
+
+1. `crimson_pulse`
+2. `clean_op`
+3. `karaoke_neon`
+4. `signal_low`
+5. `bigframe`
+6. `medspa_safe`
+7. `dev_brutal`
+
+Codex must implement them first as structured overlay specs before pixel-perfect rendering.
+
+---
+
+# Part 4 — Marketplace Architecture
+
+## Core decisions
+
+- Stripe Connect Express is primary rail for marketplace v1.
+- Whop is secondary/community/membership rail.
+- Marketplace supports clip templates, hook packs, B-roll bundles, caption presets, brand kits, prompt packs, clip commission products.
+- Platform take rate target: configurable, default around 10%.
+- Payouts: pending, held, approved, scheduled, in_transit, paid, failed, reversed/refunded/disputed.
+- No guaranteed income language.
+
+## Data areas
+
+Codex must adapt schemas to actual repo persistence. If Postgres/SQLAlchemy/Alembic exists, use migrations. If the repo currently uses JSON stores or a platform store, scaffold with that pattern first and document migration path.
+
+Required areas:
+
+- users
+- seller accounts
+- products
+- product assets
+- orders
+- payouts
+- disputes
+- ledger entries
+- webhook events
+
+## Required backend routes
+
+- `POST /sellers/onboard`
+- `GET /sellers/me`
+- `POST /products`
+- `PATCH /products/{id}`
+- `GET /products/{id}`
+- `GET /marketplace`
+- `POST /orders`
+- `GET /orders/{id}`
+- `POST /webhooks/stripe`
+- `POST /webhooks/whop`
+- `POST /disputes`
+- `GET /sellers/{id}/payouts`
+- `POST /payouts/{id}/instant`
+- `POST /admin/takedown`
+
+For first implementation, real payout movement must be feature-flagged/disabled until verification, keys, webhook signatures, refund/dispute logic, and ops/legal copy exist.
+
+## Frontend routes
+
+- `/marketplace`
+- `/marketplace/[id]`
+- `/sell/onboard`
+- `/sell/products`
+- `/sell/products/new`
+- `/disputes/new`
+- `/disputes/[id]`
+- `/admin/disputes`
+
+## Legal and fraud requirements
+
+Marketplace UI must include:
+
+- “Earnings vary. No guarantee of income.”
+- FTC disclosure fields where relevant.
+- refund policy per listing
+- banned categories list
+- rights/ownership acknowledgement
+- review/moderation state
+- KYC requirement before live public listing where payouts are enabled
+
+Fraud requirements:
+
+- first-sale payout hold
+- velocity checks
+- webhook idempotency
+- asset checksums
+- preview watermarking later
+- manual review for high-risk sellers/listings
+
+---
+
+# Part 5 — RPG / World System: The Signal Realms
+
+## Premise
+
+Creators are Signalbearers who channel attention through noise. The realm is divided into factions and classes. Progression is tied to real app actions, not purchased XP.
+
+## Classes
+
+- Hookwright
+- Captioneer
+- Reframer
+- Trendseer
+- Loremaster
+- Voicewright
+- Ironforger
+- Pricer
+- Auditor
+- Diplomat
+- Cartographer
+- Oracle
+
+## Factions
+
+- Crimson Court
+- Black Loom
+- Verdant Pact
+- Iron Choir
+- Saffron Wake
+- Glass Synod
+- Tide Marshal
+- Driftborn
+- Emberkin
+- Chorus of Thoth
+- House Polis
+- Outer Signal
+
+## XP model
+
+- Per skill, not only global.
+- XP from realized outcomes.
+- Never pay-to-win.
+- XP cannot be purchased.
+- Evidence hash/idempotency required.
+
+Formula:
+
+```text
+xp_to_next(level n) = floor(100 * 1.12^(n-1))
+total_xp(level n) = sum_{k=1..n-1} xp_to_next(k)
+```
+
+## Quest categories
+
+- Onboarding
+- Marketplace
+- Director Brain
+- Mastery
+- Civic
+- Frontier
+
+Initial quest names include:
+
+- First Signal
+- Voice of the Realm
+- The Hook is Mightier
+- Caption Cantata
+- Frame Discipline
+- Multitongue
+- Cross the Veil
+- The Patron's Mark
+- The Glass Eye
+- The Naming Ceremony
+- List the First Stone
+- Patron Found
+- Honest Coin
+- The Watermark Vow
+- The Tally
+- The Tenfold Patron
+- The Auditor's Nod
+- The Refund Returned
+- The Bundle
+- The Hundred
+- The Director's Whisper
+- Per-Platform Voice
+- The Trend Reading
+- The Polymarket Glance
+- The Reddit Pulse
+- The Algorithm Pact
+- The DM Whisper
+- The Depth Score
+- The Engaged View
+- The Director's Crown
+
+## Badge/relic model
+
+- Badges are soulbound/earned only.
+- Relics are cosmetic/tradeable later.
+- No app feature unlocks from relics.
+- No monetary rights from badges.
+- Phase 1 is off-chain only.
+
+## Required routes
+
+- `POST /characters/me`
+- `GET /characters/me`
+- `POST /quests/{code}/claim`
+- `GET /badges/me`
+- `GET /relics/me`
+- `GET /leaderboards/{skill}`
+
+Frontend:
+
+- `/realm`
+- `/realm/character`
+- `/realm/quests`
+- `/realm/badges`
+- `/realm/relics`
+- `/realm/leaderboards/[skill]`
+
+---
+
+# Part 6 — Social API Integration Plan
+
+## Providers
+
+- YouTube Data API v3
+- TikTok for Developers
+- Instagram Graph API
+- Twitch Helix
+- Polymarket Gamma API
+- Reddit API
+- Google Trends / pytrends or provider later
+
+## Build sequence
+
+Build now:
+
+- YouTube read shell
+- Twitch read/clip shell
+- Polymarket read-only trend ingestor
+- Reddit/Google Trends controlled read/scaffold
+- TikTok Login Kit/sandbox shell
+- Instagram sandbox/dev shell
+
+Build later after review:
+
+- YouTube upload
+- TikTok direct post
+- Instagram publish
+- commercial Reddit scale
+
+## Polymarket constraints
+
+- Read-only public cultural signal.
+- No trading.
+- No betting.
+- No recommendation to wager.
+- Label as cultural-attention research only.
+
+## Required tables/areas
+
+- integration links
+- encrypted access/refresh tokens
+- integration status
+- trend signals
+- trend taxonomy
+
+## Required routes
+
+- `POST /integrations/{provider}/start`
+- `GET /integrations/{provider}/callback`
+- `GET /integrations/me`
+- `DELETE /integrations/{provider}`
+
+## Trend worker
+
+- Polymarket every 10 minutes
+- Reddit hot configured subs every 15 minutes
+- normalize tags
+- store scores 0..1
+
+---
+
+# Part 7 — Blockchain / NFT / Appchain Roadmap
+
+## Principle
+
+In MVP and through Phase 5, blockchain features are optional cosmetics or proof-of-creation only.
+
+No investment framing. No feature unlocks. No tokens. No staking. No yield. No fractionalization.
+
+## Phase plan
+
+0. Off-chain ledger only
+1. Testnet proof-of-creation via daily Merkle roots
+2. Mainnet soulbound badges later
+3. Cosmetic ERC-1155 relics later
+4. Appchain decision much later
+
+## Required placeholder service
+
+Add/adapt issuance abstraction when Realms foundation exists:
+
+- `issue_badge(character_id, badge_code, evidence)`
+- `issue_relic(character_id, relic_code, qty=1)`
+- `get_proof(character_id)`
+- deterministic hashable issuance records
+- daily Merkle root JSON snapshot
+
+Frontend proof tab:
+
+- off-chain proof
+- provenance only
+- cosmetic only
+- no investment value
+
+---
+
+# Part 8 — Hiring Plan
+
+## Founding council roles
+
+1. Founder / CEO — High Director of the Signal
+2. Founding Product Architect / Creative Technical Director — Architect of Realms
+3. Principal Full-Stack Engineer — Hand of the Director
+4. AI / Media Pipeline Engineer — Forgemaster of Signals
+5. Game Systems Designer — Loremaster of the Realms
+6. Marketplace Operations Lead — Auditor of the Glass Synod
+7. UI/UX Product Designer — Veilwright
+8. Blockchain / Economy Engineer — Sigilbearer
+9. Legal / Compliance Advisor — Keeper of the Charter
+
+## Required company ops docs
+
+Codex must create/maintain:
+
+- `docs/company/lwa-elite-recruitment-and-mvo-system.md`
+- `docs/company/lwa-creator-tester-program.md`
+- `docs/company/lwa-sales-closer-program.md`
+- `docs/company/lwa-advisor-partner-investor-system.md`
+- `docs/company/lwa-support-the-build-mvo.md`
+- `docs/company/lwa-recruitment-outreach-scripts.md`
+- `docs/company/lwa-team-intake-forms.md`
+- `docs/company/lwa-7-day-team-build-plan.md`
+
+## Interview filters
+
+Codex/team docs must include interview filters for:
+
+- full-stack webhook/idempotency skill
+- AI/media pipeline fallback thinking
+- game systems/economy balance
+- marketplace fraud/dispute handling
+- premium UI taste
+- blockchain/security/legal clarity
+
+---
+
+# Part 9 — Master Codex Prompt Stack
+
+Codex prompt stack must be converted into tasks/issues and implemented in order.
+
+## P1 — Clipping engine hardening
+
+1. Day 3 sprint
+2. typed fallback result and four-layer fallbacks
+3. Director Brain v0
+4. webhook idempotency framework
+5. Redis/IP rate limit middleware
+
+## P2 — Marketplace
+
+6. marketplace MVP scaffold
+7. Whop integration
+8. dispute UI
+9. payout state machine cron
+
+## P3 — Director Brain and per-platform intelligence
+
+10. per-platform hook rewriter
+11. caption preset renderer
+
+## P4 — RPG layer
+
+12. Realms scaffold
+13. XP awarder hooks
+14. quest engine
+
+## P5 — Social APIs
+
+15. multi-provider OAuth shell
+16. Polymarket trend ingestor
+
+## P6 — Blockchain placeholder
+
+17. issuance abstraction
+18. daily Merkle anchor job
+
+## P7 — Internal tools
+
+19. operator multi-account dashboard
+20. trust and safety review queue
+
+---
+
+# Part 10 — Council Executive Summary
+
+## Top product insights
+
+1. The clipper is the wedge; the operator platform is the business.
+2. Per-platform intelligence is more defensible than one virality score.
+3. Marketplace plus clipper creates network effects.
+4. RPG progression is a retention moat.
+5. `FREE_LAUNCH_MODE` buys early usage signal.
+6. Polymarket trend signal is unique if kept read-only.
+7. Web-first avoids App Store complexity in MVP.
+8. Cosmetic-only proof assets are the durable chain posture.
+9. Stripe Connect plus Whop gives payments optionality.
+10. Operator dashboard is the long-term product center.
+
+## Top backend requirements
+
+1. FastAPI backend on current repo architecture.
+2. No microservices until forced.
+3. Money in cents only.
+4. Webhooks idempotent via event ids.
+5. Append-only ledger for balances.
+6. Encrypted social tokens.
+7. Fallback hardening everywhere.
+8. Rate limiting by IP/user.
+9. Idempotent XP awarder via evidence hash.
+10. Structured logs and request IDs.
+
+## Top frontend requirements
+
+1. Next.js App Router in current repo structure.
+2. Premium dark operator aesthetic.
+3. Free launch banner.
+4. Realms pages.
+5. Earnings disclaimer on money pages.
+6. Wallet optional only.
+7. Operator dashboard.
+8. Optimistic UI where appropriate.
+9. Shared types if/when repo supports them.
+10. Type-check and lint clean before PR.
+
+## Sales opportunities
+
+- agencies running 5–50 accounts
+- podcast networks
+- coaches and educators
+- medspa/regulated verticals
+- local business chains
+- sports clip distributors
+- music distributors
+- Whop community owners
+- streamers/Twitch creators
+- AI/tech operators
+
+## Mistakes to avoid
+
+- per-minute pricing as core model
+- guaranteed income claims
+- NFT feature unlocks
+- fractionalized relics
+- premature iOS MVP
+- missing webhook idempotency
+- floats for money
+- pay-for-XP
+- single-provider AI lock-in
+- Polymarket betting UX
+
+## 30-day build plan
+
+Week 1:
+
+- Day 3 sprint
+- Director Brain v0
+
+Week 2:
+
+- marketplace MVP scaffold
+- premium dark design/Realms moodboard
+
+Week 3:
+
+- XP curves/classes/factions/quests
+- caption presets and hook library
+
+Week 4:
+
+- Stripe Connect sandbox
+- public `FREE_LAUNCH_MODE` link and first 100 users
+
+## 90-day roadmap
+
+Days 1–30:
+
+- Phase 1 hardening
+- marketplace MVP
+- Director Brain v0
+- RPG scaffolding
+
+Days 31–60:
+
+- Whop integration
+- disputes
+- quest pass
+- Twitch/YouTube read integrations
+- Polymarket ingestor
+
+Days 61–90:
+
+- TikTok/Instagram review prep
+- operator dashboard
+- off-chain proof anchoring
+- first paying-user push
+
+## Implementation checklist
+
+1. Confirm council/team structure.
+2. Land Day 3 sprint.
+3. Set free launch env vars.
+4. Stand up Director Brain v0.
+5. Ship Realms aesthetic.
+6. Stripe Connect sandbox.
+7. Finalize quests/badges/relics.
+8. Merge marketplace MVP.
+9. Legal/ops docs.
+10. Caption renderer and hook library.
+11. Webhook idempotency.
+12. Off-chain issuance abstraction.
+13. Public launch link.
+14. Trust/safety review queue.
+15. OAuth integrations.
+16. Legal/privacy/refund posture.
+17. Chain decision later.
+18. Quarterly legal-safety review.
+
+---
+
+# Codex Execution Requirement
+
+Codex must not treat this report as optional. It must:
+
+1. read this file first
+2. audit repo compatibility
+3. preserve existing working clipping app
+4. adapt paths to the actual repo
+5. implement in ordered slices
+6. scaffold blocked external systems behind flags
+7. never ignore Claude code/specs
+8. verify and commit scoped changes
+
+## Next prompt
+
+Use the prompt in `docs/company/lwa-autonomous-codex-execution-brief.md`, then proceed with the Master Council build order above.
+
+---
+
+**End.**
+
+Cosmetic items only. Earnings vary. No guarantee of income. Not legal, financial, or investment advice. Blockchain features are optional and provenance-only. Product is web-first; iOS targets are out of scope in Phase 1.


### PR DESCRIPTION
## Summary

Merges the stronger/canonical LWA council documentation branch into main.

## Why this branch

This branch supersedes the smaller docs sync/clean branches because it includes the broader source-of-truth, guardrail, execution, safety, roadmap, and future-system docs.

## Scope

Docs-only. No runtime backend, frontend, iOS, route, database, deployment, payment, or generation behavior changed.

## Duplicate decision

Treats these branches as duplicate/subset branches after this merge:

- `docs/lwa-worlds-main-sync`
- `docs/lwa-worlds-master-council-clean`

## Verification

Docs-only PR. Runtime tests not run.