### PR TITLE
backend: add LWA core intelligence foundations

### DIFF
--- a/lwa-backend/app/api/routes/twitch_intelligence.py
+++ b/lwa-backend/app/api/routes/twitch_intelligence.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from ...services.twitch_intelligence_core import rank_twitch_moments
+
+# LWA OMEGA
+# CLAUDE HANDOFF
+# TWITCH INTELLIGENCE FOUNDATION
+# NONFATAL PIPELINE
+
+router = APIRouter(prefix="/v1/twitch-intelligence", tags=["twitch-intelligence"])
+
+
+class TwitchMomentRequest(BaseModel):
+    moments: list[dict] = Field(default_factory=list)
+    limit: int = 10
+
+
+@router.get("")
+def twitch_intelligence_index() -> dict[str, object]:
+    return {
+        "ok": True,
+        "status": "foundation",
+        "supported": ["rank_moments"],
+        "note": "Local Twitch intelligence foundation only; no live Twitch ingestion or API posting.",
+    }
+
+
+@router.post("/rank-moments")
+def rank_moments(request: TwitchMomentRequest) -> dict[str, object]:
+    return {"items": rank_twitch_moments(request.moments, limit=max(1, min(request.limit, 50)))}

--- a/lwa-backend/app/main.py
+++ b/lwa-backend/app/main.py
@@ -18,6 +18,7 @@ from .api.routes.intelligence_data import router as intelligence_data_router
 from .api.routes.me import router as me_router
 from .api.routes.posting import router as posting_router
 from .api.routes.seedance import router as seedance_router
+from .api.routes.twitch_intelligence import router as twitch_intelligence_router
 from .api.routes.upload import router as upload_router
 from .api.routes.video_analysis import router as video_analysis_router
 from .api.routes.visual_generation import router as visual_generation_router
@@ -41,7 +42,6 @@ def create_app() -> FastAPI:
             cleanup_stats.get("deleted_count", 0),
             cleanup_stats.get("retained_count", 0),
             cleanup_stats.get("bytes_deleted", 0),
-            cleanup_stats.get("store_removed", 0),
         )
     initialize_databases(settings)
     app = FastAPI(
@@ -62,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(generation_router)
     app.include_router(capabilities_router)
     app.include_router(intelligence_data_router)
+    app.include_router(twitch_intelligence_router)
     app.include_router(video_analysis_router)
     app.include_router(visual_generation_router)
     app.include_router(seedance_router)

--- a/lwa-backend/app/services/editing_core.py
+++ b/lwa-backend/app/services/editing_core.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# LWA OMEGA
+# CLAUDE HANDOFF
+# UPLOAD-FIRST CLIPPING ENGINE
+# LOCAL-FIRST FALLBACK
+# NONFATAL PIPELINE
+# PRODUCTION EDITING CORE
+
+
+@dataclass(frozen=True)
+class EditSegment:
+    start_seconds: float
+    end_seconds: float
+    role: str
+    caption: str
+    reason: str
+
+    @property
+    def duration_seconds(self) -> float:
+        return max(0.0, self.end_seconds - self.start_seconds)
+
+
+def _safe_float(value: Any, fallback: float) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def build_default_segments(source: dict[str, Any], target_count: int = 5) -> list[EditSegment]:
+    duration = max(_safe_float(source.get("duration_seconds") or source.get("duration"), 60.0), 15.0)
+    window = min(30.0, max(8.0, duration / max(target_count, 1)))
+    segments: list[EditSegment] = []
+    for index in range(target_count):
+        start = min(duration - 3.0, index * max(3.0, window * 0.75))
+        end = min(duration, start + window)
+        if end <= start:
+            continue
+        role = "hook" if index == 0 else "proof" if index < target_count - 1 else "payoff"
+        segments.append(
+            EditSegment(
+                start_seconds=round(start, 2),
+                end_seconds=round(end, 2),
+                role=role,
+                caption=f"Segment {index + 1}",
+                reason="Deterministic fallback segment generated without failing the pipeline.",
+            )
+        )
+    return segments
+
+
+def apply_override_segments(segments: list[EditSegment], override_segments: list[dict[str, Any]] | None = None) -> list[EditSegment]:
+    if not override_segments:
+        return segments
+    overrides: list[EditSegment] = []
+    for index, item in enumerate(override_segments):
+        start = _safe_float(item.get("start_seconds") or item.get("start"), 0.0)
+        end = _safe_float(item.get("end_seconds") or item.get("end"), start + 15.0)
+        if end <= start:
+            continue
+        overrides.append(
+            EditSegment(
+                start_seconds=round(start, 2),
+                end_seconds=round(end, 2),
+                role=str(item.get("role") or "override"),
+                caption=str(item.get("caption") or f"Override {index + 1}"),
+                reason=str(item.get("reason") or "Semantic cut graph override."),
+            )
+        )
+    return overrides or segments
+
+
+def build_edit_manifest(source: dict[str, Any], override_segments: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    base_segments = build_default_segments(source)
+    segments = apply_override_segments(base_segments, override_segments)
+    return {
+        "status": "ready",
+        "source_id": source.get("id") or source.get("source_id") or "local-source",
+        "fallback_mode": True,
+        "segments": [segment.__dict__ | {"duration_seconds": segment.duration_seconds} for segment in segments],
+        "notes": ["Nonfatal local editing manifest generated."],
+    }

--- a/lwa-backend/app/services/semantic_cut_graph.py
+++ b/lwa-backend/app/services/semantic_cut_graph.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# LWA OMEGA
+# CLAUDE HANDOFF
+# UPLOAD-FIRST CLIPPING ENGINE
+# LOCAL-FIRST FALLBACK
+# NONFATAL PIPELINE
+# SEMANTIC CUT GRAPH
+
+FILLER_TERMS = {"um", "uh", "like", "you know", "basically", "actually"}
+HOOK_TERMS = {"secret", "mistake", "stop", "why", "how", "money", "never", "truth"}
+
+
+@dataclass(frozen=True)
+class SemanticCut:
+    start_seconds: float
+    end_seconds: float
+    role: str
+    score: int
+    reason: str
+
+
+def _text_score(text: str) -> int:
+    lower = text.lower()
+    score = 50
+    score += sum(8 for term in HOOK_TERMS if term in lower)
+    score -= sum(5 for term in FILLER_TERMS if term in lower)
+    if "?" in text:
+        score += 6
+    if any(char.isdigit() for char in text):
+        score += 5
+    return max(0, min(100, score))
+
+
+def build_semantic_cut_graph(transcript_segments: list[dict[str, Any]]) -> list[SemanticCut]:
+    cuts: list[SemanticCut] = []
+    for index, segment in enumerate(transcript_segments):
+        text = str(segment.get("text") or segment.get("caption") or "").strip()
+        start = float(segment.get("start_seconds") or segment.get("start") or index * 15)
+        end = float(segment.get("end_seconds") or segment.get("end") or start + 15)
+        if end <= start:
+            continue
+        score = _text_score(text)
+        role = "hook" if score >= 70 and index <= 2 else "payoff" if index == len(transcript_segments) - 1 else "proof"
+        cuts.append(
+            SemanticCut(
+                start_seconds=round(start, 2),
+                end_seconds=round(end, 2),
+                role=role,
+                score=score,
+                reason="Semantic score based on hook terms, filler density, questions, and numeric specificity.",
+            )
+        )
+    return sorted(cuts, key=lambda cut: cut.score, reverse=True)
+
+
+def semantic_overrides(transcript_segments: list[dict[str, Any]], limit: int = 5) -> list[dict[str, Any]]:
+    return [cut.__dict__ for cut in build_semantic_cut_graph(transcript_segments)[:limit]]

--- a/lwa-backend/app/services/twitch_intelligence_core.py
+++ b/lwa-backend/app/services/twitch_intelligence_core.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# LWA OMEGA
+# CLAUDE HANDOFF
+# TWITCH INTELLIGENCE FOUNDATION
+# LOCAL-FIRST FALLBACK
+# NONFATAL PIPELINE
+
+CHAT_SPIKE_TERMS = {"clip", "no way", "amazing", "funny", "again", "wow", "huge", "crazy"}
+
+
+@dataclass(frozen=True)
+class TwitchMomentScore:
+    score: int
+    reason: str
+    tags: list[str]
+
+
+def score_twitch_moment(moment: dict[str, Any]) -> TwitchMomentScore:
+    title = str(moment.get("title") or moment.get("text") or "").lower()
+    chat_messages = [str(item).lower() for item in moment.get("chat_messages", []) if item]
+    viewer_delta = moment.get("viewer_delta") if isinstance(moment.get("viewer_delta"), (int, float)) else 0
+
+    tags: list[str] = []
+    score = 40
+
+    if any(term in title for term in CHAT_SPIKE_TERMS):
+        score += 15
+        tags.append("title-spike")
+
+    chat_blob = " ".join(chat_messages)
+    chat_hits = sum(1 for term in CHAT_SPIKE_TERMS if term in chat_blob)
+    if chat_hits:
+        score += min(chat_hits * 8, 24)
+        tags.append("chat-reacted")
+
+    if viewer_delta and viewer_delta > 0:
+        score += min(int(viewer_delta), 20)
+        tags.append("viewer-rise")
+
+    score = max(0, min(100, score))
+    return TwitchMomentScore(
+        score=score,
+        reason="Twitch score based on chat spike terms, title signal, and viewer movement.",
+        tags=tags,
+    )
+
+
+def rank_twitch_moments(moments: list[dict[str, Any]], limit: int = 10) -> list[dict[str, Any]]:
+    ranked: list[dict[str, Any]] = []
+    for moment in moments:
+        scored = score_twitch_moment(moment)
+        ranked.append({**moment, "twitch_score": scored.score, "twitch_reason": scored.reason, "twitch_tags": scored.tags})
+    return sorted(ranked, key=lambda item: item.get("twitch_score", 0), reverse=True)[:limit]

--- a/lwa-backend/tests/test_lwa_core_foundations.py
+++ b/lwa-backend/tests/test_lwa_core_foundations.py
@@ -1,0 +1,48 @@
+from app.services.editing_core import build_edit_manifest
+from app.services.semantic_cut_graph import semantic_overrides
+from app.services.twitch_intelligence_core import rank_twitch_moments, score_twitch_moment
+
+
+def test_build_edit_manifest_returns_nonfatal_segments() -> None:
+    manifest = build_edit_manifest({"id": "source-1", "duration_seconds": 90})
+
+    assert manifest["status"] == "ready"
+    assert manifest["source_id"] == "source-1"
+    assert manifest["segments"]
+    assert manifest["segments"][0]["end_seconds"] > manifest["segments"][0]["start_seconds"]
+
+
+def test_semantic_overrides_prefers_hook_language() -> None:
+    overrides = semantic_overrides(
+        [
+            {"text": "welcome back to the show", "start": 0, "end": 10},
+            {"text": "stop making this mistake with your content", "start": 10, "end": 25},
+        ]
+    )
+
+    assert overrides[0]["score"] >= overrides[-1]["score"]
+    assert overrides[0]["role"] in {"hook", "proof", "payoff"}
+
+
+def test_twitch_score_uses_chat_and_viewer_signals() -> None:
+    score = score_twitch_moment(
+        {
+            "title": "amazing clutch clip",
+            "chat_messages": ["wow", "clip", "again"],
+            "viewer_delta": 8,
+        }
+    )
+
+    assert score.score > 40
+    assert "chat-reacted" in score.tags
+
+
+def test_rank_twitch_moments_orders_highest_first() -> None:
+    ranked = rank_twitch_moments(
+        [
+            {"title": "quiet moment", "chat_messages": [], "viewer_delta": 0},
+            {"title": "amazing clip", "chat_messages": ["wow", "clip"], "viewer_delta": 10},
+        ]
+    )
+
+    assert ranked[0]["twitch_score"] >= ranked[1]["twitch_score"]


### PR DESCRIPTION
## Summary

Implements the practical foundation slice from #20 without touching production frontend or iOS.

## Added

- `lwa-backend/app/services/editing_core.py`
- `lwa-backend/app/services/semantic_cut_graph.py`
- `lwa-backend/app/services/twitch_intelligence_core.py`
- `lwa-backend/app/api/routes/twitch_intelligence.py`
- `lwa-backend/tests/test_lwa_core_foundations.py`

## Preserved

- Existing generation routes
- Existing fallback behavior
- Existing frontend runtime
- `lwa-ios`

## Notes

The branch already contained a richer `intelligence_data_core.py` foundation, so this PR preserves it instead of overwriting it with a weaker duplicate.

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #20.