### PR TITLE
backend: improve Director Brain scoring output

### DIFF
--- a/lwa-backend/app/services/director_brain.py
+++ b/lwa-backend/app/services/director_brain.py
@@ -4,7 +4,98 @@ from dataclasses import dataclass
 from typing import Any
 
 from .caption_presets import normalize_caption_preset
-from .hook_formula_library import HOOK_FORMULAS
+from .hook_formula_library import HOOK_FORMULAS, HookFormula
+
+ALGORITHM_VERSION = "director-brain-v0.2"
+
+PLATFORM_PROFILES: dict[str, dict[str, Any]] = {
+    "tiktok": {
+        "goal": "completion, replay, and first-frame retention",
+        "length": "15-45s",
+        "hook_window_seconds": 2,
+        "recommended_output_style": "fast pattern-interrupt short",
+    },
+    "instagram_reels": {
+        "goal": "DM shares, saves, and muted watch retention",
+        "length": "15-60s",
+        "hook_window_seconds": 2,
+        "recommended_output_style": "shareable clean-caption reel",
+    },
+    "reels": {
+        "goal": "DM shares, saves, and muted watch retention",
+        "length": "15-60s",
+        "hook_window_seconds": 2,
+        "recommended_output_style": "shareable clean-caption reel",
+    },
+    "youtube_shorts": {
+        "goal": "engaged views, rewatches, and low swipe-away",
+        "length": "20-60s",
+        "hook_window_seconds": 1,
+        "recommended_output_style": "tight payoff-first short",
+    },
+    "shorts": {
+        "goal": "engaged views, rewatches, and low swipe-away",
+        "length": "20-60s",
+        "hook_window_seconds": 1,
+        "recommended_output_style": "tight payoff-first short",
+    },
+    "linkedin": {
+        "goal": "dwell time, comment depth, and saves",
+        "length": "30-90s",
+        "hook_window_seconds": 3,
+        "recommended_output_style": "credible proof-led vertical clip",
+    },
+    "facebook_reels": {
+        "goal": "watch time and shares",
+        "length": "15-60s",
+        "hook_window_seconds": 3,
+        "recommended_output_style": "broad-share vertical clip",
+    },
+    "x": {
+        "goal": "replies, reposts, and conversation pull",
+        "length": "15-90s",
+        "hook_window_seconds": 2,
+        "recommended_output_style": "opinion-first conversation clip",
+    },
+    "twitter": {
+        "goal": "replies, reposts, and conversation pull",
+        "length": "15-90s",
+        "hook_window_seconds": 2,
+        "recommended_output_style": "opinion-first conversation clip",
+    },
+    "twitch": {
+        "goal": "clip velocity, chat reaction, and replay value",
+        "length": "7-45s",
+        "hook_window_seconds": 3,
+        "recommended_output_style": "reaction-first highlight clip",
+    },
+    "whop": {
+        "goal": "community retention, comment depth, and paid-member value",
+        "length": "30-120s",
+        "hook_window_seconds": 3,
+        "recommended_output_style": "community value clip",
+    },
+}
+
+CATEGORY_FORMULA_MAP: dict[str, tuple[str, ...]] = {
+    "finance": ("specific_number", "objection_first", "dataset_pattern"),
+    "business": ("specific_number", "framework_name", "contrarian_claim"),
+    "coaching": ("persona_callout", "objection_first", "framework_name"),
+    "medspa": ("before_after", "persona_callout", "specific_number"),
+    "beauty": ("before_after", "pattern_interrupt", "share_hook"),
+    "gaming": ("pattern_interrupt", "dialogue_cold_open", "reverse_hook"),
+    "podcast": ("contrarian_claim", "unexpected_admission", "dialogue_cold_open"),
+    "tech": ("dataset_pattern", "framework_name", "pattern_interrupt"),
+    "ai": ("dataset_pattern", "framework_name", "specific_number"),
+}
+
+RISK_TERMS = {
+    "guaranteed": "Avoid guaranteed result language.",
+    "cure": "Avoid medical cure claims.",
+    "investment": "Avoid investment framing.",
+    "passive income": "Avoid passive income promises.",
+    "risk free": "Avoid risk-free claims.",
+}
 
 
 @dataclass(frozen=True)
@@ -24,6 +115,20 @@ class DirectorBrainOutput:
     moments: list[dict[str, Any]]
     score: int
     rationale: str
+    algorithm_version: str
+    recommended_platform: str
+    recommended_content_type: str
+    recommended_output_style: str
+    platform_recommendation_reason: str
+    quality_gate_status: str
+    quality_gate_warnings: list[str]
+    hook_formula_codes: list[str]
+    risk_penalty: int
+
+
+def _normalize_platform(platform: str) -> str:
+    normalized = platform.strip().lower().replace(" ", "_").replace("-", "_")
+    return normalized or "tiktok"
 
 
 def _words(text: str) -> list[str]:
@@ -35,49 +140,126 @@ def _first_words(text: str, limit: int) -> str:
     return " ".join(words[:limit]).strip() or "Your strongest moment starts here"
 
 
-def _platform_goal(platform: str) -> str:
-    normalized = platform.strip().lower().replace(" ", "_").replace("-", "_")
-    goals = {
-        "tiktok": "completion and replay",
-        "instagram_reels": "sharing and saves",
-        "reels": "sharing and saves",
-        "youtube_shorts": "engaged views and rewatches",
-        "shorts": "engaged views and rewatches",
-        "linkedin": "dwell time and comments",
-        "twitch": "clip velocity",
-    }
-    return goals.get(normalized, "short-form retention")
+def _profile(platform: str) -> dict[str, Any]:
+    return PLATFORM_PROFILES.get(_normalize_platform(platform), PLATFORM_PROFILES["tiktok"])
+
+
+def _formula_by_code(code: str) -> HookFormula:
+    for formula in HOOK_FORMULAS:
+        if formula.code == code:
+            return formula
+    return HOOK_FORMULAS[0]
+
+
+def _select_formulas(category: str | None, transcript: str) -> list[HookFormula]:
+    normalized_category = (category or "").strip().lower().replace(" ", "_")
+    codes = list(CATEGORY_FORMULA_MAP.get(normalized_category, ()))
+    text = transcript.lower()
+    if any(char.isdigit() for char in text):
+        codes.append("specific_number")
+    if "wrong" in text or "mistake" in text:
+        codes.append("contrarian_claim")
+    if not codes:
+        codes = ["pattern_interrupt", "persona_callout", "framework_name"]
+    unique_codes = []
+    for code in codes:
+        if code not in unique_codes:
+            unique_codes.append(code)
+    return [_formula_by_code(code) for code in unique_codes[:3]]
+
+
+def _risk_warnings(text: str) -> list[str]:
+    lower = text.lower()
+    return [message for term, message in RISK_TERMS.items() if term in lower]
+
+
+def _score(text: str, platform: str, warnings: list[str]) -> int:
+    words = _words(text)
+    base = 58
+    base += min(len(words) // 12, 18)
+    base += 6 if any(char.isdigit() for char in text) else 0
+    base += 5 if "?" in text else 0
+    base += 4 if _normalize_platform(platform) in PLATFORM_PROFILES else 0
+    base -= min(len(warnings) * 8, 28)
+    return max(35, min(96, base))
+
+
+def _recommended_content_type(category: str | None, text: str) -> str:
+    if category:
+        return category.strip().replace("_", " ").title()
+    lower = text.lower()
+    if "mistake" in lower or "wrong" in lower:
+        return "Contrarian commentary"
+    if any(char.isdigit() for char in text):
+        return "Number-led breakdown"
+    if "how" in lower or "why" in lower:
+        return "Educational explainer"
+    return "Short-form highlight"
+
+
+def _build_hooks(seed: str, formulas: list[HookFormula]) -> list[str]:
+    hooks = [seed]
+    for formula in formulas:
+        if formula.code == "contrarian_claim":
+            hooks.append(f"Stop doing this: {seed}")
+        elif formula.code == "persona_callout":
+            hooks.append(f"If you make content, this is for you: {seed}")
+        elif formula.code == "specific_number":
+            hooks.append(f"3 reasons this moment works: {seed}")
+        elif formula.code == "framework_name":
+            hooks.append(f"The LWA clip test starts here: {seed}")
+        elif formula.code == "before_after":
+            hooks.append(f"Before you post, watch this: {seed}")
+        else:
+            hooks.append(f"The key moment: {seed}")
+    seen: list[str] = []
+    for hook in hooks:
+        if hook and hook not in seen:
+            seen.append(hook[:140])
+    return seen[:4]
 
 
 def build_director_brain_output(payload: DirectorBrainInput) -> DirectorBrainOutput:
     text = payload.transcript.strip()
-    platform = payload.target_platform or "tiktok"
+    platform = _normalize_platform(payload.target_platform or "tiktok")
+    profile = _profile(platform)
     caption_preset = normalize_caption_preset(payload.caption_preset)
+    formulas = _select_formulas(payload.category, text)
     hook_seed = _first_words(text, 9)
-    hooks = [
-        hook_seed,
-        f"Stop scrolling — {hook_seed}",
-        f"The key moment: {hook_seed}",
-    ]
+    hooks = _build_hooks(hook_seed, formulas)
     caption_text = text[:180].strip() or hook_seed
-    captions = [caption_text]
+    warnings = _risk_warnings(text)
+    score = _score(text, platform, warnings)
+    content_type = _recommended_content_type(payload.category, text)
     moments = [
         {
             "start": 0,
             "end": 30,
-            "reason": f"Opening segment optimized for {_platform_goal(platform)}",
-            "hook_formula": HOOK_FORMULAS[0].code,
+            "reason": f"Opening segment optimized for {profile['goal']}",
+            "hook_formula": formulas[0].code,
+            "platform_fit_score": score,
+            "recommended_length": profile["length"],
+            "hook_window_seconds": profile["hook_window_seconds"],
         }
     ]
-    score = min(95, max(55, 65 + len(_words(text)) // 20))
+    quality_gate_status = "warning" if warnings else "pass"
     return DirectorBrainOutput(
         target_platform=platform,
         caption_preset=caption_preset,
         hooks=hooks,
-        captions=captions,
+        captions=[caption_text],
         moments=moments,
         score=score,
-        rationale=f"Director Brain v0 selected a short-form opening for {_platform_goal(platform)}.",
+        rationale=f"Director Brain selected a short-form opening for {profile['goal']}.",
+        algorithm_version=ALGORITHM_VERSION,
+        recommended_platform=platform,
+        recommended_content_type=content_type,
+        recommended_output_style=str(profile["recommended_output_style"]),
+        platform_recommendation_reason=f"{platform} prioritizes {profile['goal']} with a {profile['hook_window_seconds']}s hook window.",
+        quality_gate_status=quality_gate_status,
+        quality_gate_warnings=warnings,
+        hook_formula_codes=[formula.code for formula in formulas],
+        risk_penalty=min(len(warnings) * 8, 28),
     )
 
 
@@ -104,4 +286,13 @@ def director_brain_package(
         "moments": output.moments,
         "score": output.score,
         "rationale": output.rationale,
+        "algorithm_version": output.algorithm_version,
+        "recommended_platform": output.recommended_platform,
+        "recommended_content_type": output.recommended_content_type,
+        "recommended_output_style": output.recommended_output_style,
+        "platform_recommendation_reason": output.platform_recommendation_reason,
+        "quality_gate_status": output.quality_gate_status,
+        "quality_gate_warnings": output.quality_gate_warnings,
+        "hook_formula_codes": output.hook_formula_codes,
+        "risk_penalty": output.risk_penalty,
     }

--- a/lwa-backend/tests/test_director_brain_upgrade.py
+++ b/lwa-backend/tests/test_director_brain_upgrade.py
@@ -1,0 +1,42 @@
+from app.services.director_brain import director_brain_package
+
+
+def test_director_brain_returns_platform_recommendation_fields() -> None:
+    package = director_brain_package(
+        transcript="Stop making this mistake before you post your next clip. Here are 3 reasons it hurts retention.",
+        target_platform="youtube_shorts",
+        category="business",
+    )
+
+    assert package["algorithm_version"].startswith("director-brain")
+    assert package["recommended_platform"] == "youtube_shorts"
+    assert package["recommended_content_type"] == "Business"
+    assert package["recommended_output_style"]
+    assert package["platform_recommendation_reason"]
+    assert package["hook_formula_codes"]
+    assert package["score"] >= 35
+
+
+def test_director_brain_applies_risk_warning_without_crashing() -> None:
+    package = director_brain_package(
+        transcript="This is guaranteed passive income and a risk free investment.",
+        target_platform="tiktok",
+    )
+
+    assert package["quality_gate_status"] == "warning"
+    assert package["quality_gate_warnings"]
+    assert package["risk_penalty"] > 0
+    assert package["hooks"]
+
+
+def test_director_brain_normalizes_platform_and_keeps_output_shape() -> None:
+    package = director_brain_package(
+        transcript="How to make a better clip with a stronger opening question?",
+        target_platform="Instagram Reels",
+        caption_preset="clean_op",
+    )
+
+    assert package["target_platform"] == "instagram_reels"
+    assert package["caption_preset"] == "clean_op"
+    assert isinstance(package["moments"], list)
+    assert package["moments"][0]["hook_window_seconds"] == 2


### PR DESCRIPTION
## Summary

Implements a narrow Phase 2 / Issue #52 Director Brain improvement slice.

## Changed

- `lwa-backend/app/services/director_brain.py`
- `lwa-backend/tests/test_director_brain_upgrade.py`

## Improvements

- Adds `director-brain-v0.2` algorithm version
- Adds richer platform profiles and recommendation reasons
- Adds category-aware hook formula selection
- Adds risk warnings / risk penalty fields
- Adds optional frontend-friendly fields:
  - `algorithm_version`
  - `recommended_platform`
  - `recommended_content_type`
  - `recommended_output_style`
  - `platform_recommendation_reason`
  - `quality_gate_status`
  - `quality_gate_warnings`
  - `hook_formula_codes`
  - `risk_penalty`

## Safety

- backend-only service/tests
- no frontend contract breakage; output fields are additive
- no `lwa-ios` changes
- no marketplace / Realms / blockchain / social posting work

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #52.