### PR TITLE
backend: add Signal Realms scaffold

### DIFF
--- a/docs/lwa-worlds/signal-realms-scaffold.md
+++ b/docs/lwa-worlds/signal-realms-scaffold.md
@@ -1,0 +1,47 @@
+# Signal Realms Scaffold
+
+## Status
+
+This is a non-chain backend scaffold for future Signal Realms progression work.
+
+It is not a live blockchain feature and it does not create purchasable XP, investment assets, or feature unlocks.
+
+## Current files
+
+- `lwa-backend/app/services/signal_realms_core.py`
+- `lwa-backend/tests/test_signal_realms_core.py`
+
+## Current rules
+
+- XP cannot be bought.
+- Badges are earned and soulbound by default.
+- Relics are cosmetic only.
+- Relics do not unlock app features.
+- Blockchain is not part of this scaffold.
+- No investment framing is allowed.
+
+## Current primitives
+
+- 12 classes
+- 12 factions
+- XP curve helpers
+- character creation helper
+- XP award helper
+- badge helper
+- relic helper
+- safety disclosure helper
+
+## Future order
+
+1. Persistent character records.
+2. XP event ledger.
+3. Quest progress records.
+4. Badge awards.
+5. Relic holdings.
+6. Read-only leaderboards.
+7. Frontend `/realm` shell.
+8. Optional proof layer later, separate from gameplay progression.
+
+## Claim boundary
+
+Do not describe Signal Realms as live until routes, persistence, frontend views, and moderation/safety rules are implemented and verified.

--- a/lwa-backend/app/services/signal_realms_core.py
+++ b/lwa-backend/app/services/signal_realms_core.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+# LWA SIGNAL REALMS FOUNDATION
+# NO BLOCKCHAIN IN THIS PHASE
+# XP CANNOT BE BOUGHT
+# BADGES ARE EARNED
+# RELICS ARE COSMETIC ONLY
+# NO INVESTMENT LANGUAGE
+
+
+class RealmClass(StrEnum):
+    HOOKWRIGHT = "hookwright"
+    CAPTIONEER = "captioneer"
+    REFRAMER = "reframer"
+    TRENDSEER = "trendseer"
+    LOREMASTER = "loremaster"
+    VOICEWRIGHT = "voicewright"
+    IRONFORGER = "ironforger"
+    PRICER = "pricer"
+    AUDITOR = "auditor"
+    DIPLOMAT = "diplomat"
+    CARTOGRAPHER = "cartographer"
+    ORACLE = "oracle"
+
+
+class RealmFaction(StrEnum):
+    CRIMSON_COURT = "crimson_court"
+    BLACK_LOOM = "black_loom"
+    VERDANT_PACT = "verdant_pact"
+    IRON_CHOIR = "iron_choir"
+    SAFFRON_WAKE = "saffron_wake"
+    GLASS_SYNOD = "glass_synod"
+    TIDE_MARSHAL = "tide_marshal"
+    DRIFTBORN = "driftborn"
+    EMBERKIN = "emberkin"
+    CHORUS_OF_THOTH = "chorus_of_thoth"
+    HOUSE_POLIS = "house_polis"
+    OUTER_SIGNAL = "outer_signal"
+
+
+@dataclass(frozen=True)
+class RealmCharacter:
+    id: str
+    user_id: str
+    realm_class: RealmClass
+    faction: RealmFaction
+    total_xp: int = 0
+
+
+@dataclass(frozen=True)
+class XpEvent:
+    character_id: str
+    skill: str
+    amount: int
+    reason: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RealmBadge:
+    code: str
+    name: str
+    description: str
+    soulbound: bool = True
+
+
+@dataclass(frozen=True)
+class RealmRelic:
+    code: str
+    name: str
+    description: str
+    tradeable: bool = True
+    cosmetic_only: bool = True
+
+
+def xp_to_next_level(level: int) -> int:
+    if level < 1:
+        raise ValueError("level must be at least 1")
+    return int(100 * (1.12 ** (level - 1)))
+
+
+def total_xp_for_level(level: int) -> int:
+    if level < 1:
+        raise ValueError("level must be at least 1")
+    return sum(xp_to_next_level(current) for current in range(1, level))
+
+
+def level_for_xp(total_xp: int) -> int:
+    if total_xp < 0:
+        raise ValueError("total_xp cannot be negative")
+    level = 1
+    while level < 99 and total_xp >= total_xp_for_level(level + 1):
+        level += 1
+    return level
+
+
+def create_character(user_id: str, realm_class: RealmClass, faction: RealmFaction) -> RealmCharacter:
+    if not user_id.strip():
+        raise ValueError("user_id is required")
+    return RealmCharacter(id=str(uuid4()), user_id=user_id, realm_class=realm_class, faction=faction)
+
+
+def award_xp(character: RealmCharacter, event: XpEvent) -> RealmCharacter:
+    if event.amount <= 0:
+        raise ValueError("XP amount must be positive")
+    if event.character_id != character.id:
+        raise ValueError("XP event character mismatch")
+    return RealmCharacter(
+        id=character.id,
+        user_id=character.user_id,
+        realm_class=character.realm_class,
+        faction=character.faction,
+        total_xp=character.total_xp + event.amount,
+    )
+
+
+def create_badge(code: str, name: str, description: str) -> RealmBadge:
+    return RealmBadge(code=code.strip().lower().replace(" ", "_"), name=name.strip(), description=description.strip())
+
+
+def create_relic(code: str, name: str, description: str) -> RealmRelic:
+    return RealmRelic(code=code.strip().lower().replace(" ", "_"), name=name.strip(), description=description.strip())
+
+
+def realms_safety_disclosure() -> str:
+    return "Signal Realms items are progression and cosmetic only. XP cannot be bought and no item has investment value."

--- a/lwa-backend/tests/test_signal_realms_core.py
+++ b/lwa-backend/tests/test_signal_realms_core.py
@@ -1,0 +1,61 @@
+import pytest
+
+from app.services.signal_realms_core import (
+    RealmClass,
+    RealmFaction,
+    XpEvent,
+    award_xp,
+    create_badge,
+    create_character,
+    create_relic,
+    level_for_xp,
+    realms_safety_disclosure,
+    total_xp_for_level,
+    xp_to_next_level,
+)
+
+
+def test_xp_curve_starts_at_level_one() -> None:
+    assert xp_to_next_level(1) == 100
+    assert total_xp_for_level(1) == 0
+    assert level_for_xp(0) == 1
+
+
+def test_level_for_xp_advances_after_threshold() -> None:
+    assert level_for_xp(100) >= 2
+    assert level_for_xp(total_xp_for_level(10)) == 10
+
+
+def test_create_character_and_award_xp() -> None:
+    character = create_character("user-1", RealmClass.HOOKWRIGHT, RealmFaction.CRIMSON_COURT)
+    updated = award_xp(
+        character,
+        XpEvent(character_id=character.id, skill="hookwright", amount=125, reason="first clip shipped"),
+    )
+
+    assert updated.total_xp == 125
+    assert updated.realm_class == RealmClass.HOOKWRIGHT
+    assert updated.faction == RealmFaction.CRIMSON_COURT
+
+
+def test_award_xp_rejects_paid_or_invalid_amounts() -> None:
+    character = create_character("user-1", RealmClass.CAPTIONEER, RealmFaction.BLACK_LOOM)
+
+    with pytest.raises(ValueError):
+        award_xp(character, XpEvent(character_id=character.id, skill="captioneer", amount=0, reason="invalid"))
+
+
+def test_badges_are_soulbound_and_relics_cosmetic() -> None:
+    badge = create_badge("First Clip", "First Clip", "Ship one clip.")
+    relic = create_relic("Crimson Caption", "Crimson Caption", "Cosmetic caption relic.")
+
+    assert badge.soulbound is True
+    assert relic.cosmetic_only is True
+    assert relic.tradeable is True
+
+
+def test_realms_disclosure_blocks_investment_framing() -> None:
+    disclosure = realms_safety_disclosure().lower()
+
+    assert "xp cannot be bought" in disclosure
+    assert "no item has investment value" in disclosure


### PR DESCRIPTION
## Summary

Implements a narrow Phase 4 / Issue #54 Signal Realms scaffold.

## Changed

- `lwa-backend/app/services/signal_realms_core.py`
- `lwa-backend/tests/test_signal_realms_core.py`
- `docs/lwa-worlds/signal-realms-scaffold.md`

## Behavior

Adds non-chain progression primitives:

- 12 classes
- 12 factions
- XP curve helpers
- character creation helper
- XP award helper
- soulbound badge helper
- cosmetic relic helper
- safety disclosure helper

## Safety

- no blockchain
- no tokenomics
- no paid XP
- no feature unlocks from relics
- no investment framing
- no frontend changes
- no `lwa-ios` changes

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #54.