### PR TITLE
backend: add social integrations scaffold

### DIFF
--- a/docs/lwa-worlds/social-integrations-scaffold.md
+++ b/docs/lwa-worlds/social-integrations-scaffold.md
@@ -1,0 +1,44 @@
+# Social Integrations Scaffold
+
+## Status
+
+This is a sandbox/read-first foundation for future social and trend integrations.
+
+It does not enable direct posting, does not collect social passwords, and does not claim publishing success.
+
+## Current files
+
+- `lwa-backend/app/services/social_integrations_core.py`
+- `lwa-backend/tests/test_social_integrations_core.py`
+
+## Supported scaffold providers
+
+- YouTube
+- TikTok
+- Instagram
+- Twitch
+- Reddit
+- Polymarket
+- Google Trends
+
+## Rules
+
+- OAuth providers require explicit user authorization.
+- Posting stays disabled until scopes, approvals, token storage, and tests are verified.
+- Polymarket is cultural-attention metadata only.
+- No wagering, trading, or betting advice.
+- No social password collection.
+- No fake posting success.
+
+## Future order
+
+1. Encrypted token storage contract.
+2. OAuth start/callback routes.
+3. Integration status dashboard.
+4. Read-only YouTube/Twitch/Reddit trend reads.
+5. Polymarket read-only trend metadata.
+6. Direct posting only after provider approvals and explicit user action.
+
+## Claim boundary
+
+Do not describe direct TikTok, Instagram, YouTube, or Twitch publishing as live until the provider-specific implementation, approval, scopes, tests, and user consent flow are complete.

--- a/lwa-backend/app/services/social_integrations_core.py
+++ b/lwa-backend/app/services/social_integrations_core.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+from urllib.parse import urlencode
+
+# LWA SOCIAL INTEGRATIONS FOUNDATION
+# SANDBOX FIRST
+# NO PASSWORD COLLECTION
+# NO FAKE POSTING SUCCESS
+# POLYMARKET READ ONLY CULTURAL METADATA
+# DIRECT POSTING DISABLED UNTIL APPROVALS
+
+
+class SocialProvider(StrEnum):
+    YOUTUBE = "youtube"
+    TIKTOK = "tiktok"
+    INSTAGRAM = "instagram"
+    TWITCH = "twitch"
+    REDDIT = "reddit"
+    POLYMARKET = "polymarket"
+    GOOGLE_TRENDS = "google_trends"
+
+
+class IntegrationStatus(StrEnum):
+    AVAILABLE_READ_ONLY = "available_read_only"
+    OAUTH_REQUIRED = "oauth_required"
+    SANDBOX_ONLY = "sandbox_only"
+    APPROVAL_REQUIRED = "approval_required"
+    NOT_CONFIGURED = "not_configured"
+
+
+@dataclass(frozen=True)
+class ProviderCapability:
+    provider: SocialProvider
+    status: IntegrationStatus
+    read_supported: bool
+    publish_supported: bool
+    required_env: tuple[str, ...] = ()
+    required_scopes: tuple[str, ...] = ()
+    safety_note: str = ""
+
+
+@dataclass(frozen=True)
+class OAuthStartRequest:
+    provider: SocialProvider
+    client_id: str
+    redirect_uri: str
+    state: str
+    scopes: tuple[str, ...] = ()
+    auth_base_url: str = ""
+    extra_params: dict[str, str] = field(default_factory=dict)
+
+
+PROVIDER_CAPABILITIES: tuple[ProviderCapability, ...] = (
+    ProviderCapability(
+        provider=SocialProvider.YOUTUBE,
+        status=IntegrationStatus.OAUTH_REQUIRED,
+        read_supported=True,
+        publish_supported=False,
+        required_env=("YT_CLIENT_ID", "YT_CLIENT_SECRET", "YT_REDIRECT_URI"),
+        required_scopes=("youtube.readonly",),
+        safety_note="Read first. Upload/publish requires approval and a separate explicit user action.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.TIKTOK,
+        status=IntegrationStatus.SANDBOX_ONLY,
+        read_supported=True,
+        publish_supported=False,
+        required_env=("TIKTOK_CLIENT_KEY", "TIKTOK_CLIENT_SECRET", "TIKTOK_REDIRECT_URI"),
+        safety_note="Sandbox first. Do not claim direct posting until app review and scopes are approved.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.INSTAGRAM,
+        status=IntegrationStatus.APPROVAL_REQUIRED,
+        read_supported=True,
+        publish_supported=False,
+        required_env=("IG_APP_ID", "IG_APP_SECRET", "IG_REDIRECT_URI"),
+        safety_note="Business/Creator account and app review required before publishing.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.TWITCH,
+        status=IntegrationStatus.OAUTH_REQUIRED,
+        read_supported=True,
+        publish_supported=False,
+        required_env=("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET", "TWITCH_REDIRECT_URI"),
+        required_scopes=("clips:edit",),
+        safety_note="Clip creation requires user authorization. Live ingestion is future worker work.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.REDDIT,
+        status=IntegrationStatus.OAUTH_REQUIRED,
+        read_supported=True,
+        publish_supported=False,
+        required_env=("REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET", "REDDIT_USER_AGENT"),
+        safety_note="Trend reads only unless commercial/API terms are reviewed.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.POLYMARKET,
+        status=IntegrationStatus.AVAILABLE_READ_ONLY,
+        read_supported=True,
+        publish_supported=False,
+        required_env=(),
+        safety_note="Read-only cultural-attention metadata only. No wagering, trading, or betting advice.",
+    ),
+    ProviderCapability(
+        provider=SocialProvider.GOOGLE_TRENDS,
+        status=IntegrationStatus.AVAILABLE_READ_ONLY,
+        read_supported=True,
+        publish_supported=False,
+        required_env=(),
+        safety_note="Trend metadata only. Provider implementation can be swapped later.",
+    ),
+)
+
+
+def list_provider_capabilities() -> list[dict[str, Any]]:
+    return [capability.__dict__.copy() for capability in PROVIDER_CAPABILITIES]
+
+
+def get_provider_capability(provider: SocialProvider | str) -> ProviderCapability | None:
+    normalized = SocialProvider(str(provider).strip().lower())
+    return next((item for item in PROVIDER_CAPABILITIES if item.provider == normalized), None)
+
+
+def build_oauth_authorization_url(request: OAuthStartRequest) -> str:
+    if not request.auth_base_url:
+        raise ValueError("auth_base_url is required for OAuth providers")
+    if not request.client_id.strip():
+        raise ValueError("client_id is required")
+    if not request.redirect_uri.strip():
+        raise ValueError("redirect_uri is required")
+    if not request.state.strip():
+        raise ValueError("state is required")
+
+    params = {
+        "client_id": request.client_id,
+        "redirect_uri": request.redirect_uri,
+        "response_type": "code",
+        "state": request.state,
+        **request.extra_params,
+    }
+    if request.scopes:
+        params["scope"] = " ".join(request.scopes)
+    return f"{request.auth_base_url}?{urlencode(params)}"
+
+
+def posting_allowed(provider: SocialProvider | str) -> bool:
+    capability = get_provider_capability(provider)
+    return bool(capability and capability.publish_supported)
+
+
+def social_integration_disclosure() -> str:
+    return "Social integrations are sandbox/read-first until provider approvals, scopes, token storage, and explicit user actions are verified."

--- a/lwa-backend/tests/test_social_integrations_core.py
+++ b/lwa-backend/tests/test_social_integrations_core.py
@@ -1,0 +1,62 @@
+import pytest
+
+from app.services.social_integrations_core import (
+    OAuthStartRequest,
+    SocialProvider,
+    build_oauth_authorization_url,
+    get_provider_capability,
+    list_provider_capabilities,
+    posting_allowed,
+    social_integration_disclosure,
+)
+
+
+def test_provider_capabilities_include_read_only_polymarket() -> None:
+    capability = get_provider_capability(SocialProvider.POLYMARKET)
+
+    assert capability is not None
+    assert capability.read_supported is True
+    assert capability.publish_supported is False
+    assert "Read-only" in capability.safety_note or "read-only" in capability.safety_note
+
+
+def test_posting_is_disabled_by_default_for_all_scaffold_providers() -> None:
+    for item in list_provider_capabilities():
+        assert posting_allowed(item["provider"]) is False
+
+
+def test_oauth_authorization_url_requires_state() -> None:
+    with pytest.raises(ValueError):
+        build_oauth_authorization_url(
+            OAuthStartRequest(
+                provider=SocialProvider.YOUTUBE,
+                client_id="client",
+                redirect_uri="https://example.com/callback",
+                state="",
+                auth_base_url="https://provider.example/oauth",
+            )
+        )
+
+
+def test_oauth_authorization_url_builds_scopes() -> None:
+    url = build_oauth_authorization_url(
+        OAuthStartRequest(
+            provider=SocialProvider.YOUTUBE,
+            client_id="client",
+            redirect_uri="https://example.com/callback",
+            state="secure-state",
+            scopes=("youtube.readonly",),
+            auth_base_url="https://provider.example/oauth",
+        )
+    )
+
+    assert "client_id=client" in url
+    assert "state=secure-state" in url
+    assert "youtube.readonly" in url
+
+
+def test_social_disclosure_blocks_fake_posting_claims() -> None:
+    disclosure = social_integration_disclosure().lower()
+
+    assert "sandbox" in disclosure
+    assert "explicit user actions" in disclosure


### PR DESCRIPTION
## Summary

Implements a narrow Phase 5 / Issue #56 social integrations scaffold.

## Changed

- `lwa-backend/app/services/social_integrations_core.py`
- `lwa-backend/tests/test_social_integrations_core.py`
- `docs/lwa-worlds/social-integrations-scaffold.md`

## Behavior

Adds sandbox/read-first primitives for future social integrations:

- provider capability definitions
- OAuth authorization URL helper
- explicit posting-disabled scaffold state
- Polymarket read-only cultural metadata boundary
- social integration disclosure helper

## Safety

- no direct posting
- no social password collection
- no token persistence yet
- no fake publishing success
- no frontend changes
- no `lwa-ios` changes
- Polymarket is read-only metadata, not betting/trading advice

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #56.