### PR TITLE
backend: add off-chain proof scaffold

### DIFF
--- a/docs/lwa-worlds/proof-scaffold.md
+++ b/docs/lwa-worlds/proof-scaffold.md
@@ -1,0 +1,40 @@
+# Off-Chain Proof Scaffold
+
+## Status
+
+This is an off-chain provenance scaffold. It is not a token launch, chain deployment, wallet feature, or investment product.
+
+## Current files
+
+- `lwa-backend/app/services/proof_core.py`
+- `lwa-backend/tests/test_proof_core.py`
+
+## Current primitives
+
+- deterministic proof records
+- canonical JSON hashing
+- proof leaves
+- deterministic Merkle root helper
+- daily proof snapshot helper
+- provenance-only disclosure helper
+
+## Rules
+
+- Proof records are provenance only.
+- No investment language.
+- No yield or payout language.
+- No tokenomics.
+- No app feature unlocks.
+- No blockchain deployment in this phase.
+
+## Future order
+
+1. Store proof records durably.
+2. Emit daily snapshots.
+3. Add proof lookup routes.
+4. Add frontend proof display.
+5. Evaluate optional chain anchoring later in a separate phase.
+
+## Claim boundary
+
+Do not describe badges, relics, or proof records as financial assets. Do not describe this scaffold as deployed on-chain.

--- a/lwa-backend/app/services/proof_core.py
+++ b/lwa-backend/app/services/proof_core.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha256
+import json
+from typing import Any
+
+# LWA PROOF FOUNDATION
+# OFF-CHAIN ONLY
+# PROVENANCE ONLY
+# NO TOKENOMICS
+# NO INVESTMENT LANGUAGE
+# NO FEATURE UNLOCKS
+
+
+@dataclass(frozen=True)
+class ProofRecord:
+    record_type: str
+    subject_id: str
+    owner_id: str
+    issued_at: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def hash_payload(payload: dict[str, Any]) -> str:
+    return sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def proof_leaf(record: ProofRecord) -> str:
+    return hash_payload(
+        {
+            "record_type": record.record_type,
+            "subject_id": record.subject_id,
+            "owner_id": record.owner_id,
+            "issued_at": record.issued_at,
+            "evidence": record.evidence,
+        }
+    )
+
+
+def merkle_parent(left: str, right: str) -> str:
+    ordered = sorted([left, right])
+    return sha256((ordered[0] + ordered[1]).encode("utf-8")).hexdigest()
+
+
+def merkle_root(leaves: list[str]) -> str | None:
+    if not leaves:
+        return None
+    level = sorted(leaves)
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])
+        level = [merkle_parent(level[index], level[index + 1]) for index in range(0, len(level), 2)]
+    return level[0]
+
+
+def build_proof_snapshot(records: list[ProofRecord], day: str) -> dict[str, Any]:
+    leaves = [proof_leaf(record) for record in records]
+    return {
+        "day": day,
+        "root": merkle_root(leaves),
+        "leaf_count": len(leaves),
+        "leaves": leaves,
+        "provenance_only": True,
+        "disclosure": proof_disclosure(),
+    }
+
+
+def proof_disclosure() -> str:
+    return "Proof records are provenance-only. They are not investments, payouts, tokens, or app-feature unlocks."

--- a/lwa-backend/tests/test_proof_core.py
+++ b/lwa-backend/tests/test_proof_core.py
@@ -1,0 +1,45 @@
+from app.services.proof_core import ProofRecord, build_proof_snapshot, merkle_root, proof_disclosure, proof_leaf
+
+
+def test_proof_leaf_is_deterministic_for_same_record() -> None:
+    record = ProofRecord(
+        record_type="badge_award",
+        subject_id="first_clip",
+        owner_id="user-1",
+        issued_at="2026-04-30",
+        evidence={"clip_id": "clip-1"},
+    )
+
+    assert proof_leaf(record) == proof_leaf(record)
+
+
+def test_merkle_root_is_stable_with_unsorted_leaves() -> None:
+    leaves = ["b" * 64, "a" * 64, "c" * 64]
+
+    assert merkle_root(leaves) == merkle_root(list(reversed(leaves)))
+
+
+def test_build_proof_snapshot_is_provenance_only() -> None:
+    snapshot = build_proof_snapshot(
+        [
+            ProofRecord(
+                record_type="relic_holding",
+                subject_id="crimson_caption",
+                owner_id="user-1",
+                issued_at="2026-04-30",
+            )
+        ],
+        day="2026-04-30",
+    )
+
+    assert snapshot["leaf_count"] == 1
+    assert snapshot["root"]
+    assert snapshot["provenance_only"] is True
+
+
+def test_proof_disclosure_blocks_investment_claims() -> None:
+    disclosure = proof_disclosure().lower()
+
+    assert "provenance-only" in disclosure
+    assert "not investments" in disclosure
+    assert "app-feature unlocks" in disclosure


### PR DESCRIPTION
## Summary

Implements a narrow Phase 6 / Issue #57 off-chain proof scaffold.

## Changed

- `lwa-backend/app/services/proof_core.py`
- `lwa-backend/tests/test_proof_core.py`
- `docs/lwa-worlds/proof-scaffold.md`

## Behavior

Adds provenance-only primitives:

- deterministic proof records
- canonical JSON hashing
- proof leaves
- deterministic Merkle root helper
- daily proof snapshot helper
- safety disclosure helper

## Safety

- off-chain only
- no tokenomics
- no wallet requirement
- no feature unlocks
- no investment framing
- no chain deployment
- no frontend changes
- no `lwa-ios` changes

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #57.