### PR TITLE
docs: add growth sales investor pack

### DIFF
--- a/docs/lwa-worlds/growth-sales-investor-pack.md
+++ b/docs/lwa-worlds/growth-sales-investor-pack.md
@@ -1,0 +1,87 @@
+# LWA Growth, Sales, and Investor Pack
+
+## Status
+
+This is a repo-safe operating artifact for sales, demos, and investor conversations.
+
+It is not a private investor list, compensation plan, or legal document.
+
+## Product truth
+
+LWA is a working clipping MVP and review console. It can generate ranked clip packages with titles, hooks, captions, timestamps, scores, strategy metadata, and available asset links.
+
+LWA is not yet a full video editor, full direct-posting system, full marketplace, full Signal Realms system, or blockchain product.
+
+## One-line pitch
+
+LWA turns creator source content into ranked short-form clip packages with hooks, captions, scores, and post-order guidance.
+
+## 30-second pitch
+
+LWA helps creators and operators move faster from long-form source content to short-form clip packages. The current MVP focuses on clipping intelligence, packaging, rendered-vs-strategy separation, and export-ready guidance. The roadmap expands into marketplace workflows, social integrations, operator dashboards, and Signal Realms retention systems, but those are staged carefully and should not be sold as live until verified.
+
+## Customer pitch
+
+Bring one public source or upload-supported input into LWA. The system ranks the strongest short-form opportunities, suggests hooks and captions, separates playable output from strategy-only output, and tells you what to post first.
+
+## Agency pitch
+
+For agencies, LWA is meant to become a command center for turning client source content into organized clip packages. The current MVP is useful for faster review and packaging. Full multi-account workflow, social posting, and marketplace operations are roadmap items.
+
+## Investor pitch
+
+The wedge is AI clipping. The larger opportunity is a creator operating system: Director Brain intelligence, campaign packaging, marketplace primitives, social/trend integrations, operator dashboards, and optional provenance-only proof. The current product is an MVP with real clipping and packaging foundations, not a finished all-in-one platform.
+
+## Demo flow
+
+1. Explain the current MVP truth.
+2. Paste or select a supported source.
+3. Generate a clip package.
+4. Show best clip first.
+5. Show rendered/playable output where available.
+6. Show strategy-only output separately.
+7. Copy hooks, captions, CTA, and package.
+8. Explain what is live versus planned.
+
+## Objection handling
+
+### Is this just another clipper?
+
+No. The first wedge is clipping, but LWA is being built around ranked packages, Director Brain explanation, campaign readiness, marketplace primitives, and an operator workflow.
+
+### Can it guarantee views or sales?
+
+No. LWA helps package clips more intelligently. It does not guarantee views, revenue, sales, followers, or virality.
+
+### Is direct social posting live?
+
+No. Social integrations are scaffolded as sandbox/read-first foundations. Direct posting requires provider approvals, scopes, and explicit user action.
+
+### Is the marketplace live?
+
+No. Marketplace primitives are scaffolded. Live seller onboarding, payments, ledgers, disputes, and payout flows require dedicated implementation and verification.
+
+### Are NFTs or blockchain part of the MVP?
+
+No. Proof work is off-chain and provenance-only. No investment framing, no tokens, and no feature unlocks.
+
+## What sales can say now
+
+- Working MVP clipping and packaging foundations exist.
+- Director Brain and quality-gate foundations exist.
+- Rendered and strategy-only output should be separated honestly.
+- The roadmap includes marketplace, social integrations, operator dashboard, Realms, and proof systems.
+
+## What sales must not say yet
+
+- guaranteed viral results
+- guaranteed income
+- direct posting is live
+- marketplace payouts are live
+- Signal Realms is live
+- blockchain/NFT features are live
+- the app replaces a human editor end to end
+
+## Follow-up message
+
+Thanks for checking out LWA. The current MVP focuses on turning source content into ranked short-form clip packages with hooks, captions, and posting guidance. The bigger roadmap is a creator operating system, but we are careful to separate what is live today from what is coming next.


### PR DESCRIPTION
## Summary

Implements a repo-safe Phase 8 / Issue #59 growth, sales, and investor artifact.

## Changed

- `docs/lwa-worlds/growth-sales-investor-pack.md`

## Scope

Adds claim-safe language for:

- product truth
- one-line pitch
- 30-second pitch
- customer pitch
- agency pitch
- investor pitch
- demo flow
- objection handling
- what sales can and cannot say

## Safety

- no private investor list
- no compensation promises
- no guaranteed views, revenue, or virality
- separates current MVP from roadmap
- does not claim marketplace, direct posting, Signal Realms, or blockchain are live

## Verification

Docs-only PR.

Closes #59.