### PR TITLE
backend: add operator dashboard scaffold

### DIFF
--- a/docs/lwa-worlds/operator-dashboard-scaffold.md
+++ b/docs/lwa-worlds/operator-dashboard-scaffold.md
@@ -1,0 +1,41 @@
+# Operator Dashboard Scaffold
+
+## Status
+
+This is a backend scaffold for a future operator dashboard. It summarizes existing LWA run data only.
+
+It does not create fake social analytics, fake posting status, fake marketplace payouts, or unverified external metrics.
+
+## Current files
+
+- `lwa-backend/app/services/operator_dashboard_core.py`
+- `lwa-backend/tests/test_operator_dashboard_core.py`
+
+## Current primitives
+
+- run summary helper
+- rendered versus strategy-only counts
+- best-score summary
+- attention-needed card builder
+- operator disclosure helper
+
+## Rules
+
+- Use real LWA run/result data only.
+- Do not invent external social performance.
+- Do not imply direct social posting is live.
+- Do not imply marketplace payouts are live.
+- Empty states must be honest.
+
+## Future order
+
+1. Connect to durable run history.
+2. Add read-only dashboard route.
+3. Add frontend operator page.
+4. Add admin gating.
+5. Add social metrics only after verified integrations are live.
+6. Add trust and safety queue after marketplace routes exist.
+
+## Claim boundary
+
+Do not describe the operator dashboard as a full multi-account social dashboard until social integrations, durable account links, scheduled posts, and real metrics exist.

--- a/lwa-backend/app/services/operator_dashboard_core.py
+++ b/lwa-backend/app/services/operator_dashboard_core.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# LWA OPERATOR DASHBOARD FOUNDATION
+# REAL SYSTEM STATE ONLY
+# NO FAKE SOCIAL METRICS
+# NO FAKE DIRECT POSTING
+# NO MARKETPLACE PAYOUT CLAIMS
+
+
+@dataclass(frozen=True)
+class OperatorDashboardSummary:
+    total_runs: int
+    total_clips: int
+    rendered_clips: int
+    strategy_only_clips: int
+    attention_needed_count: int
+    best_score: int | None
+
+
+READY_KEYS = ("preview_url", "clip_url", "edited_clip_url", "download_url", "raw_clip_url")
+
+
+def _clip_score(clip: dict[str, Any]) -> int:
+    value = clip.get("score") or clip.get("virality_score") or clip.get("confidence_score") or 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _has_asset(clip: dict[str, Any]) -> bool:
+    return any(isinstance(clip.get(key), str) and bool(str(clip.get(key)).strip()) for key in READY_KEYS)
+
+
+def _is_strategy_only(clip: dict[str, Any]) -> bool:
+    return bool(
+        clip.get("strategy_only")
+        or clip.get("is_strategy_only")
+        or str(clip.get("visual_engine_status") or "").lower() == "strategy_only"
+        or not _has_asset(clip)
+    )
+
+
+def summarize_operator_runs(runs: list[dict[str, Any]]) -> OperatorDashboardSummary:
+    clips: list[dict[str, Any]] = []
+    for run in runs:
+        clips.extend([clip for clip in run.get("clips", []) if isinstance(clip, dict)])
+
+    rendered = [clip for clip in clips if _has_asset(clip) and not _is_strategy_only(clip)]
+    strategy = [clip for clip in clips if _is_strategy_only(clip)]
+    attention_needed = [
+        clip
+        for clip in clips
+        if clip.get("quality_gate_status") in {"warning", "fail"}
+        or clip.get("visual_engine_status") in {"recoverable", "render_failed"}
+    ]
+    scores = [_clip_score(clip) for clip in clips]
+    return OperatorDashboardSummary(
+        total_runs=len(runs),
+        total_clips=len(clips),
+        rendered_clips=len(rendered),
+        strategy_only_clips=len(strategy),
+        attention_needed_count=len(attention_needed),
+        best_score=max(scores) if scores else None,
+    )
+
+
+def build_attention_cards(runs: list[dict[str, Any]], limit: int = 10) -> list[dict[str, Any]]:
+    cards: list[dict[str, Any]] = []
+    for run in runs:
+        request_id = run.get("request_id") or run.get("id") or "unknown-run"
+        for clip in run.get("clips", []):
+            if not isinstance(clip, dict):
+                continue
+            reason = None
+            if clip.get("quality_gate_status") == "fail":
+                reason = "quality gate failed"
+            elif clip.get("quality_gate_status") == "warning":
+                reason = "quality gate warning"
+            elif clip.get("visual_engine_status") == "recoverable":
+                reason = "render recoverable"
+            elif clip.get("visual_engine_status") == "render_failed":
+                reason = "render failed"
+            elif _is_strategy_only(clip):
+                reason = "strategy-only output"
+            if reason:
+                cards.append(
+                    {
+                        "request_id": request_id,
+                        "clip_id": clip.get("id") or clip.get("clip_id"),
+                        "title": clip.get("title") or clip.get("hook") or "Untitled clip",
+                        "reason": reason,
+                        "score": _clip_score(clip),
+                    }
+                )
+    return sorted(cards, key=lambda item: item.get("score", 0), reverse=True)[:limit]
+
+
+def operator_disclosure() -> str:
+    return "Operator metrics summarize available LWA run data only. External social performance metrics require verified integrations."

--- a/lwa-backend/tests/test_operator_dashboard_core.py
+++ b/lwa-backend/tests/test_operator_dashboard_core.py
@@ -1,0 +1,50 @@
+from app.services.operator_dashboard_core import (
+    build_attention_cards,
+    operator_disclosure,
+    summarize_operator_runs,
+)
+
+
+def test_operator_summary_counts_real_run_data() -> None:
+    summary = summarize_operator_runs(
+        [
+            {
+                "request_id": "run-1",
+                "clips": [
+                    {"id": "clip-1", "score": 90, "preview_url": "https://cdn.example.com/a.mp4"},
+                    {"id": "clip-2", "score": 72, "strategy_only": True},
+                ],
+            }
+        ]
+    )
+
+    assert summary.total_runs == 1
+    assert summary.total_clips == 2
+    assert summary.rendered_clips == 1
+    assert summary.strategy_only_clips == 1
+    assert summary.best_score == 90
+
+
+def test_attention_cards_include_quality_and_recovery_items() -> None:
+    cards = build_attention_cards(
+        [
+            {
+                "request_id": "run-1",
+                "clips": [
+                    {"id": "clip-1", "title": "Needs review", "score": 81, "quality_gate_status": "warning"},
+                    {"id": "clip-2", "title": "Ready", "score": 91, "preview_url": "https://cdn.example.com/a.mp4"},
+                ],
+            }
+        ]
+    )
+
+    assert len(cards) == 1
+    assert cards[0]["clip_id"] == "clip-1"
+    assert cards[0]["reason"] == "quality gate warning"
+
+
+def test_operator_disclosure_blocks_fake_external_metrics() -> None:
+    disclosure = operator_disclosure().lower()
+
+    assert "available lwa run data" in disclosure
+    assert "verified integrations" in disclosure


### PR DESCRIPTION
## Summary

Implements a narrow Phase 9 / Issue #60 operator dashboard scaffold.

## Changed

- `lwa-backend/app/services/operator_dashboard_core.py`
- `lwa-backend/tests/test_operator_dashboard_core.py`
- `docs/lwa-worlds/operator-dashboard-scaffold.md`

## Behavior

Adds backend-only primitives for future operator dashboard work:

- summary of available LWA run data
- rendered vs strategy-only counts
- best-score summary
- attention-needed cards
- operator disclosure helper

## Safety

- no fake social metrics
- no fake direct posting
- no fake marketplace payout status
- no frontend changes
- no `lwa-ios` changes
- uses existing run/result shapes only

## Verification

Not run in connector session. Suggested:

```bash
python3 -m compileall lwa-backend/app
cd lwa-backend && python3 -m unittest discover -s tests
```

Closes #60.