### PR TITLE
docs: add creative command center pack

### DIFF
--- a/docs/lwa-worlds/creative-command-center-pack.md
+++ b/docs/lwa-worlds/creative-command-center-pack.md
@@ -1,0 +1,85 @@
+# LWA Creative Command Center Pack
+
+## Status
+
+This is a repo-safe creative execution guide for Phase 10. It does not create production code or claim a live prototype.
+
+## Purpose
+
+Turn the LWA Worlds roadmap into editable creative assets and external operating materials while keeping product truth separate from roadmap vision.
+
+## Channels and owners
+
+| Channel | Owner council | Output | Repo role |
+|---|---|---|---|
+| Figma | Product / UX / Creative Council | architecture diagrams, roadmap visuals, UI flows | reference only |
+| Canva | Growth / Sales / Investor Council | launch one-pagers, social assets, demo graphics | reference only |
+| Lovable | Product / UX / Creative Council | clickable command-center prototype | non-production prototype |
+| Google Drive | Founder / CEO Council | operating docs, outreach trackers, private docs | private source, not public repo |
+| Gmail | Growth / Sales / Investor Council | outreach drafts, labels, follow-ups | private execution |
+| GitHub | Principal Engineering Council | source truth, code, docs, issues, PRs | production/source-control |
+
+## Creative package to build
+
+1. Roadmap diagram.
+2. Launch one-pager.
+3. Council deck.
+4. Command-center prototype shell.
+5. Social launch asset set.
+6. Founder/team outreach templates.
+7. Demo walkthrough script.
+
+## Product truth rules
+
+- Separate live MVP capabilities from roadmap plans.
+- Do not claim direct social posting is live.
+- Do not claim marketplace payouts are live.
+- Do not claim Signal Realms is live.
+- Do not claim blockchain/proof is on-chain.
+- Do not guarantee views, income, virality, payouts, or sales.
+
+## Lovable prototype rule
+
+The Lovable prototype should be labeled as a prototype shell. It can show the intended command-center layout, but it must not imply production integrations or working automation.
+
+## Figma roadmap rule
+
+Figma diagrams should show:
+
+- live MVP wedge
+- backend intelligence foundations
+- marketplace scaffold
+- Signal Realms scaffold
+- social integrations scaffold
+- proof scaffold
+- operator dashboard scaffold
+- future implementation phases
+
+## Canva launch asset rule
+
+Canva assets should say:
+
+- LWA helps turn source content into ranked clip packages.
+- LWA separates playable output from strategy-only output.
+- LWA is building toward a creator operating system.
+
+They should not say:
+
+- guaranteed viral clips
+- guaranteed revenue
+- direct posting is live
+- marketplace payouts are live
+- NFTs or blockchain are live
+
+## Gmail outreach rule
+
+Outreach should be private and targeted. Do not commit private lists, personal emails, candidate names, investor targets, or negotiation terms to the public repo.
+
+## Acceptance checklist
+
+- [ ] roadmap diagram exists outside repo
+- [ ] launch one-pager exists outside repo
+- [ ] prototype is labeled non-production
+- [ ] no private lists committed
+- [ ] all external copy matches product truth
+- [ ] all claims align with `docs/company/lwa-capability-roadmap.md`


### PR DESCRIPTION
## Summary

Implements repo-safe Phase 10 / Issue #61 creative command-center guidance.

## Changed

- `docs/lwa-worlds/creative-command-center-pack.md`

## Scope

Defines how LWA should use:

- Figma
- Canva
- Lovable
- Google Drive
- Gmail
- GitHub

without confusing prototypes, outreach, private docs, or collateral with production features.

## Safety

- docs-only
- no private investor or candidate lists
- no production-code changes
- no fake prototype claims
- no guaranteed revenue/views/virality
- keeps product truth separate from roadmap vision

## Verification

Docs-only PR.

Closes #61.