### PR TITLE
[codex] add Director Brain v0 recommendation rail

### DIFF
--- a/lwa-backend/app/services/clip_service.py
+++ b/lwa-backend/app/services/clip_service.py
@@ -35,6 +35,7 @@ from ..services.attention_compiler import compile_attention
 from ..services.caption_artifacts import create_caption_artifacts
 from ..services.clip_status_store import register_clip_batch
 from ..services.confidence_engine import build_confidence_label, resolve_confidence_score
+from ..services.director_brain import build_director_brain_plan
 from ..services.entitlements import EntitlementContext, UsageStore
 from ..services.event_log import emit_event
 from ..services.intelligence_data_core import get_intelligence_core
@@ -619,6 +620,7 @@ async def apply_director_brain_foundation(
 
     for clip in clips:
         try:
+            director_plan = build_director_brain_plan(clip, target_platform=target_platform)
             shot_plan = build_shot_plan_for_clip(clip, target_platform=target_platform)
             render_result: VisualRenderProviderResult | None = None
             if not clip_has_rendered_media(clip):
@@ -653,6 +655,7 @@ async def apply_director_brain_foundation(
 
             evaluation = evaluate_render_quality(clip=clip, render_result=render_result)
             update: dict[str, object] = {
+                **director_plan.as_clip_update(clip),
                 **shot_plan.as_clip_update(),
                 **evaluation.as_clip_update(),
                 "render_provider": clip.render_provider or RENDER_PROVIDER_PUBLIC_ID,

--- a/lwa-backend/app/services/director_brain.py
+++ b/lwa-backend/app/services/director_brain.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+
+from ..models.schemas import ClipResult
+
+
+@dataclass(frozen=True)
+class PlatformDirectorProfile:
+    platform: str
+    first_seconds: str
+    primary_signal: str
+    secondary_signal: str
+    hook_instruction: str
+    caption_instruction: str
+    title_instruction: str
+    cta_template: str
+    fit_template: str
+
+
+@dataclass(frozen=True)
+class DirectorBrainPlan:
+    platform: str
+    category: str
+    rendered_state: str
+    hook_variants: list[str]
+    caption: str
+    thumbnail_text: str
+    cta_suggestion: str
+    packaging_angle: str
+    platform_fit: str
+    score: int
+    confidence: int
+    explanation: str
+    platform_notes: list[str] = field(default_factory=list)
+
+    def as_clip_update(self, clip: ClipResult) -> dict[str, object]:
+        caption_variants = dict(clip.caption_variants or {})
+        if self.caption and not caption_variants:
+            caption_variants = {"director": self.caption}
+
+        platform_notes = list(clip.platform_notes or [])
+        for note in self.platform_notes:
+            if note not in platform_notes:
+                platform_notes.append(note)
+
+        return {
+            "target_platform": clip.target_platform or self.platform,
+            "platform_fit": clip.platform_fit or self.platform_fit,
+            "thumbnail_text": clip.thumbnail_text or self.thumbnail_text,
+            "cta_suggestion": clip.cta_suggestion or self.cta_suggestion,
+            "packaging_angle": clip.packaging_angle or self.packaging_angle,
+            "hook_variants": clip.hook_variants or self.hook_variants,
+            "caption_variants": caption_variants,
+            "platform_notes": platform_notes,
+            "scoring_explanation": clip.scoring_explanation or self.explanation,
+            "confidence_score": clip.confidence_score or self.confidence,
+        }
+
+
+PLATFORM_PROFILES: dict[str, PlatformDirectorProfile] = {
+    "tiktok": PlatformDirectorProfile(
+        platform="TikTok",
+        first_seconds="1-3 seconds",
+        primary_signal="completion and rewatch",
+        secondary_signal="shares",
+        hook_instruction="Start with a pattern interrupt or direct claim.",
+        caption_instruction="Keep the caption short, persona-specific, and easy to remix.",
+        title_instruction="Use a four-word overlay with the keyword visible.",
+        cta_template="Test this hook first, then cut a tighter loop if retention drops.",
+        fit_template="{category} works on TikTok when the first beat lands in {first_seconds} and the loop is obvious.",
+    ),
+    "instagram reels": PlatformDirectorProfile(
+        platform="Instagram Reels",
+        first_seconds="2 seconds",
+        primary_signal="DM shares",
+        secondary_signal="saves",
+        hook_instruction="Open with a line someone would send to a specific friend.",
+        caption_instruction="Build around send-to-a-friend behavior.",
+        title_instruction="Use polished on-screen text that names the persona.",
+        cta_template="Send this packaging to the persona most likely to share it.",
+        fit_template="{category} fits Reels when the payoff feels shareable in the first {first_seconds}.",
+    ),
+    "reels": PlatformDirectorProfile(
+        platform="Instagram Reels",
+        first_seconds="2 seconds",
+        primary_signal="DM shares",
+        secondary_signal="saves",
+        hook_instruction="Open with a line someone would send to a specific friend.",
+        caption_instruction="Build around send-to-a-friend behavior.",
+        title_instruction="Use polished on-screen text that names the persona.",
+        cta_template="Send this packaging to the persona most likely to share it.",
+        fit_template="{category} fits Reels when the payoff feels shareable in the first {first_seconds}.",
+    ),
+    "youtube shorts": PlatformDirectorProfile(
+        platform="YouTube Shorts",
+        first_seconds="1 second",
+        primary_signal="engaged views",
+        secondary_signal="swipe-away reduction",
+        hook_instruction="Make the first frame the claim, not setup.",
+        caption_instruction="Invite a comment without slowing the clip down.",
+        title_instruction="Use search-readable words over clever phrasing.",
+        cta_template="Make the ending loop back into the opening claim before publishing.",
+        fit_template="{category} fits Shorts when the first frame explains why the viewer should not swipe.",
+    ),
+    "shorts": PlatformDirectorProfile(
+        platform="YouTube Shorts",
+        first_seconds="1 second",
+        primary_signal="engaged views",
+        secondary_signal="swipe-away reduction",
+        hook_instruction="Make the first frame the claim, not setup.",
+        caption_instruction="Invite a comment without slowing the clip down.",
+        title_instruction="Use search-readable words over clever phrasing.",
+        cta_template="Make the ending loop back into the opening claim before publishing.",
+        fit_template="{category} fits Shorts when the first frame explains why the viewer should not swipe.",
+    ),
+    "linkedin": PlatformDirectorProfile(
+        platform="LinkedIn",
+        first_seconds="3 seconds",
+        primary_signal="dwell and comment depth",
+        secondary_signal="saves",
+        hook_instruction="Open with a specific professional claim.",
+        caption_instruction="Make the caption opinion-led and end with a question.",
+        title_instruction="Use a headline-style overlay.",
+        cta_template="Post from a personal profile and ask for one concrete counterpoint.",
+        fit_template="{category} fits LinkedIn when the first {first_seconds} creates dwell and a useful debate.",
+    ),
+}
+
+CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "podcast": ("podcast", "interview", "episode", "conversation", "host"),
+    "gaming": ("game", "gaming", "stream", "twitch", "match", "ranked"),
+    "finance": ("finance", "market", "fed", "stocks", "bitcoin", "crypto", "rate"),
+    "coaching": ("coach", "framework", "lesson", "mistake", "mindset", "client"),
+    "beauty": ("beauty", "skincare", "makeup", "routine", "aesthetic"),
+    "medspa": ("medspa", "clinic", "treatment", "patient", "consultation"),
+    "music": ("music", "song", "artist", "studio", "album", "beat"),
+    "sports": ("sports", "game", "finals", "season", "player", "coach"),
+    "education": ("education", "teach", "learn", "explain", "tutorial", "lesson"),
+    "debate": ("debate", "argument", "wrong", "disagree", "controversial"),
+    "reaction": ("reaction", "react", "commentary", "response", "breakdown"),
+    "product_demo": ("demo", "product", "feature", "launch", "workflow"),
+    "ai_tech": ("ai", "openai", "model", "software", "automation", "tech"),
+    "local_business": ("local", "restaurant", "clinic", "service", "near me"),
+}
+
+
+def build_director_brain_plan(
+    clip: ClipResult,
+    *,
+    target_platform: str | None,
+    category: str | None = None,
+    trends: list[str] | None = None,
+    rendered_state: str | None = None,
+) -> DirectorBrainPlan:
+    profile = profile_for_platform(target_platform or clip.target_platform or clip.platform_fit)
+    detected_category = normalize_category(category or clip.detected_category or clip.category) or infer_category(clip)
+    state = rendered_state or ("rendered" if clip_has_rendered_media(clip) else "strategy_only")
+    base_hook = compact_sentence(clip.hook or clip.title or "Lead with the strongest payoff")
+    hook_variants = build_hook_variants(base_hook=base_hook, profile=profile, category=detected_category)
+    thumbnail_text = build_thumbnail_text(base_hook, profile=profile, category=detected_category)
+    caption = build_caption(clip=clip, profile=profile, category=detected_category, trends=trends or [])
+    packaging_angle = infer_packaging_angle(clip, category=detected_category)
+    platform_fit = profile.fit_template.format(category=detected_category.replace("_", " "), first_seconds=profile.first_seconds)
+    score = score_for_platform(clip=clip, profile=profile, rendered_state=state)
+    confidence = confidence_for_plan(clip=clip, score=score, rendered_state=state)
+    notes = [
+        f"{profile.platform}: optimize for {profile.primary_signal}; secondary signal is {profile.secondary_signal}.",
+        profile.hook_instruction,
+    ]
+    if state != "rendered":
+        notes.append("Strategy-only: packaging is ready, but no playable media should be shown as export-ready.")
+
+    return DirectorBrainPlan(
+        platform=profile.platform,
+        category=detected_category,
+        rendered_state=state,
+        hook_variants=hook_variants,
+        caption=caption,
+        thumbnail_text=thumbnail_text,
+        cta_suggestion=clip.cta_suggestion or profile.cta_template,
+        packaging_angle=clip.packaging_angle or packaging_angle,
+        platform_fit=platform_fit,
+        score=score,
+        confidence=confidence,
+        explanation=(
+            f"Director Brain routed this as {detected_category.replace('_', ' ')} for {profile.platform}; "
+            f"the score favors {profile.primary_signal} and keeps rendered truth as {state}."
+        ),
+        platform_notes=notes,
+    )
+
+
+def profile_for_platform(value: str | None) -> PlatformDirectorProfile:
+    normalized = normalize_platform(value)
+    return PLATFORM_PROFILES.get(normalized, PLATFORM_PROFILES["tiktok"])
+
+
+def normalize_platform(value: str | None) -> str:
+    raw = (value or "").strip().lower()
+    if not raw:
+        return "tiktok"
+    if "linkedin" in raw:
+        return "linkedin"
+    if "reel" in raw or "instagram" in raw:
+        return "instagram reels"
+    if "short" in raw or "youtube" in raw:
+        return "youtube shorts"
+    if "tiktok" in raw:
+        return "tiktok"
+    return raw
+
+
+def normalize_category(value: str | None) -> str | None:
+    raw = (value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if not raw:
+        return None
+    aliases = {
+        "ai": "ai_tech",
+        "tech": "ai_tech",
+        "product": "product_demo",
+        "local": "local_business",
+        "education_explainer": "education",
+    }
+    return aliases.get(raw, raw)
+
+
+def infer_category(clip: ClipResult) -> str:
+    text = " ".join(
+        part
+        for part in [
+            clip.title,
+            clip.hook,
+            clip.caption,
+            clip.transcript_excerpt,
+            clip.reason,
+            clip.why_this_matters,
+            clip.platform_fit,
+        ]
+        if part
+    ).lower()
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        if any(re.search(rf"\b{re.escape(keyword)}\b", text) for keyword in keywords):
+            return category
+    return "education"
+
+
+def build_hook_variants(*, base_hook: str, profile: PlatformDirectorProfile, category: str) -> list[str]:
+    focus = category.replace("_", " ")
+    if profile.platform == "TikTok":
+        return [
+            trim_words(base_hook, 12),
+            trim_words(f"Stop scrolling if this {focus} mistake costs you attention", 12),
+            trim_words(f"Nobody explains the {focus} payoff this directly", 12),
+        ]
+    if profile.platform == "Instagram Reels":
+        return [
+            trim_words(base_hook, 12),
+            trim_words(f"Send this to a {focus} creator who needs the shortcut", 14),
+            trim_words(f"Show this to someone still missing the payoff", 12),
+        ]
+    if profile.platform == "YouTube Shorts":
+        return [
+            trim_words(base_hook, 10),
+            trim_words(f"The {focus} reason starts here", 10),
+            trim_words(f"Watch the first frame before you swipe", 10),
+        ]
+    return [
+        trim_words(base_hook, 15),
+        trim_words(f"The useful {focus} lesson is hiding in the first claim", 15),
+        trim_words(f"Most teams miss this {focus} signal until too late", 15),
+    ]
+
+
+def build_caption(
+    *,
+    clip: ClipResult,
+    profile: PlatformDirectorProfile,
+    category: str,
+    trends: list[str],
+) -> str:
+    focus = category.replace("_", " ")
+    trend = f" Trend angle: {trends[0]}." if trends else ""
+    source = compact_sentence(clip.caption or clip.hook or clip.title or "")
+    if profile.platform == "Instagram Reels":
+        return trim_chars(f"Send this to a {focus} creator who needs the payoff faster. {source}{trend}", 200)
+    if profile.platform == "LinkedIn":
+        return trim_chars(f"{source} The practical question: where would this change your {focus} workflow?", 500)
+    if profile.platform == "YouTube Shorts":
+        return trim_chars(f"{source} Would you watch the loop twice?{trend}", 120)
+    return trim_chars(f"{source} Save the strongest {focus} hook and test the loop first.{trend}", 200)
+
+
+def build_thumbnail_text(base_hook: str, *, profile: PlatformDirectorProfile, category: str) -> str:
+    if profile.platform == "LinkedIn":
+        return title_case_words(trim_words(base_hook, 5))
+    if profile.platform == "YouTube Shorts":
+        return title_case_words(trim_words(base_hook, 4))
+    if profile.platform == "Instagram Reels":
+        return title_case_words(trim_words(f"{category.replace('_', ' ')} payoff", 4))
+    return title_case_words(trim_words(base_hook, 4))
+
+
+def infer_packaging_angle(clip: ClipResult, *, category: str) -> str:
+    text = " ".join(part for part in [clip.hook, clip.title, clip.caption] if part).lower()
+    if any(word in text for word in ("wrong", "mistake", "debate", "disagree")):
+        return "controversy"
+    if any(word in text for word in ("why", "hidden", "secret", "nobody")):
+        return "curiosity"
+    if any(word in text for word in ("story", "before", "after")):
+        return "story"
+    if category in {"product_demo", "education", "coaching", "ai_tech"}:
+        return "value"
+    return "payoff"
+
+
+def score_for_platform(*, clip: ClipResult, profile: PlatformDirectorProfile, rendered_state: str) -> int:
+    base = int(clip.virality_score or clip.confidence_score or clip.score or 70)
+    if profile.platform == "TikTok" and (clip.hook or "").lower().startswith(("stop", "why", "how")):
+        base += 4
+    if profile.platform == "Instagram Reels" and any(word in (clip.caption or "").lower() for word in ("send", "share", "friend")):
+        base += 4
+    if profile.platform == "YouTube Shorts" and (clip.duration or 0) and int(clip.duration or 0) <= 35:
+        base += 3
+    if profile.platform == "LinkedIn" and any(word in (clip.caption or "").lower() for word in ("workflow", "team", "business")):
+        base += 3
+    if rendered_state != "rendered":
+        base -= 3
+    return max(0, min(base, 100))
+
+
+def confidence_for_plan(*, clip: ClipResult, score: int, rendered_state: str) -> int:
+    confidence = int(clip.confidence_score or score)
+    if clip.transcript_excerpt:
+        confidence += 3
+    if rendered_state == "rendered":
+        confidence += 2
+    return max(45, min(confidence, 96))
+
+
+def clip_has_rendered_media(clip: ClipResult) -> bool:
+    return bool(clip.preview_url or clip.edited_clip_url or clip.clip_url or clip.raw_clip_url or clip.download_url)
+
+
+def compact_sentence(value: str) -> str:
+    normalized = re.sub(r"\s+", " ", value or "").strip()
+    return normalized.rstrip(".")
+
+
+def trim_words(value: str, limit: int) -> str:
+    words = compact_sentence(value).split()
+    if len(words) <= limit:
+        return " ".join(words)
+    return " ".join(words[:limit])
+
+
+def trim_chars(value: str, limit: int) -> str:
+    normalized = compact_sentence(value)
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: max(0, limit - 1)].rstrip() + "."
+
+
+def title_case_words(value: str) -> str:
+    return " ".join(word[:1].upper() + word[1:] for word in compact_sentence(value).split())

--- a/lwa-backend/tests/test_director_brain.py
+++ b/lwa-backend/tests/test_director_brain.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+
+from app.models.schemas import ClipResult
+from app.services.director_brain import build_director_brain_plan, profile_for_platform
+
+
+class DirectorBrainTests(unittest.TestCase):
+    def build_clip(self, **overrides) -> ClipResult:
+        payload = {
+            "id": "clip_001",
+            "title": "Stop losing the first three seconds",
+            "hook": "Stop losing the first three seconds",
+            "caption": "This workflow makes the payoff obvious before the viewer scrolls.",
+            "score": 82,
+            "confidence_score": 78,
+            "rank": 1,
+            "duration": 24,
+            "transcript_excerpt": "Stop losing the first three seconds by hiding the payoff after setup.",
+        }
+        payload.update(overrides)
+        return ClipResult(**payload)
+
+    def test_platform_profiles_are_distinct(self) -> None:
+        self.assertEqual(profile_for_platform("TikTok").primary_signal, "completion and rewatch")
+        self.assertEqual(profile_for_platform("Instagram Reels").primary_signal, "DM shares")
+        self.assertEqual(profile_for_platform("YouTube Shorts").primary_signal, "engaged views")
+        self.assertEqual(profile_for_platform("LinkedIn").primary_signal, "dwell and comment depth")
+
+    def test_tiktok_plan_prioritizes_fast_hook_and_strategy_truth(self) -> None:
+        plan = build_director_brain_plan(
+            self.build_clip(clip_url=None, preview_url=None),
+            target_platform="TikTok",
+            category="coaching",
+        )
+
+        self.assertEqual(plan.platform, "TikTok")
+        self.assertEqual(plan.rendered_state, "strategy_only")
+        self.assertIn("completion", plan.explanation)
+        self.assertTrue(any("Strategy-only" in note for note in plan.platform_notes))
+        self.assertGreaterEqual(len(plan.hook_variants), 3)
+
+    def test_reels_plan_uses_dm_share_caption(self) -> None:
+        plan = build_director_brain_plan(
+            self.build_clip(caption="Send this to the creator still burying the payoff."),
+            target_platform="Reels",
+            category="podcast",
+        )
+
+        self.assertEqual(plan.platform, "Instagram Reels")
+        self.assertIn("Send this", plan.caption)
+        self.assertIn("DM shares", plan.platform_notes[0])
+
+    def test_shorts_plan_prefers_swipe_away_reduction(self) -> None:
+        plan = build_director_brain_plan(
+            self.build_clip(),
+            target_platform="YouTube Shorts",
+            category="education",
+        )
+
+        self.assertEqual(plan.platform, "YouTube Shorts")
+        self.assertIn("swipe", plan.platform_notes[0])
+        self.assertLessEqual(len(plan.hook_variants[0].split()), 10)
+
+    def test_linkedin_plan_uses_professional_dwell_prompt(self) -> None:
+        plan = build_director_brain_plan(
+            self.build_clip(caption="This team workflow fixes the review loop."),
+            target_platform="LinkedIn",
+            category="ai_tech",
+        )
+
+        self.assertEqual(plan.platform, "LinkedIn")
+        self.assertIn("workflow", plan.caption.lower())
+        self.assertIn("dwell", plan.platform_notes[0])
+
+    def test_rendered_state_is_derived_from_playable_media_only(self) -> None:
+        rendered = build_director_brain_plan(
+            self.build_clip(preview_url="https://cdn.example.com/clip.mp4"),
+            target_platform="TikTok",
+        )
+        strategy = build_director_brain_plan(
+            self.build_clip(thumbnail_url="https://cdn.example.com/thumb.jpg"),
+            target_platform="TikTok",
+        )
+
+        self.assertEqual(rendered.rendered_state, "rendered")
+        self.assertEqual(strategy.rendered_state, "strategy_only")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lwa-backend/tests/test_director_brain_integration.py
+++ b/lwa-backend/tests/test_director_brain_integration.py
@@ -70,6 +70,81 @@ class DirectorBrainIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(summary["rendered_clip_count"], 1)
         self.assertEqual(summary["strategy_only_clip_count"], 1)
 
+    async def test_missing_visual_key_keeps_strategy_clip_without_fake_media(self) -> None:
+        settings = Settings()
+        settings.visual_engine_enabled = True
+        settings.visual_engine_api_key = ""
+
+        clips = [
+            ClipResult(
+                id="clip_strategy",
+                title="Strategy clip",
+                hook="Make the payoff obvious before you render.",
+                caption="Use the shot plan first, then retry render.",
+                start_time="00:05",
+                end_time="00:20",
+                score=81,
+                confidence_score=77,
+                rank=1,
+                platform_fit="Reels-ready structure with a direct payoff.",
+            ),
+        ]
+
+        enriched, summary = await apply_director_brain_foundation(
+            settings=settings,
+            clips=clips,
+            target_platform="Reels",
+        )
+
+        self.assertIsNone(enriched[0].preview_url)
+        self.assertIsNone(enriched[0].clip_url)
+        self.assertIsNone(enriched[0].download_url)
+        self.assertEqual(enriched[0].visual_engine_status, "strategy_only")
+        self.assertEqual(enriched[0].render_status, "pending")
+        self.assertIsNotNone(enriched[0].strategy_only_reason)
+        self.assertIsNotNone(enriched[0].recovery_recommendation)
+        self.assertEqual(summary["visual_engine_attempted_count"], 0)
+        self.assertEqual(summary["rendered_clip_count"], 0)
+        self.assertEqual(summary["strategy_only_clip_count"], 1)
+
+    async def test_existing_rendered_clip_does_not_call_unwired_provider(self) -> None:
+        settings = Settings()
+        settings.visual_engine_enabled = True
+        settings.visual_engine_api_key = "configured-for-test"
+        settings.visual_engine_max_renders_per_request = 1
+
+        clips = [
+            ClipResult(
+                id="clip_rendered",
+                title="Rendered clip",
+                hook="Show the proof before adding more effects.",
+                caption="This clip already has playable media.",
+                start_time="00:02",
+                end_time="00:17",
+                score=88,
+                confidence_score=84,
+                rank=1,
+                preview_url="https://cdn.example.com/clip.mp4",
+                platform_fit="YouTube Shorts-ready pacing.",
+            ),
+        ]
+
+        enriched, summary = await apply_director_brain_foundation(
+            settings=settings,
+            clips=clips,
+            target_platform="YouTube Shorts",
+        )
+
+        self.assertEqual(enriched[0].preview_url, "https://cdn.example.com/clip.mp4")
+        self.assertEqual(enriched[0].visual_engine_status, "ready_now")
+        self.assertEqual(enriched[0].render_status, "ready")
+        self.assertEqual(enriched[0].rendered_by, "LWA Omega Visual Engine")
+        self.assertEqual(summary["visual_engine_attempted_count"], 0)
+        self.assertEqual(summary["visual_engine_ready_count"], 1)
+        self.assertEqual(summary["visual_engine_failed_count"], 0)
+        self.assertEqual(summary["rendered_clip_count"], 1)
+        self.assertEqual(summary["strategy_only_clip_count"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lwa-web/.eslintrc.json
+++ b/lwa-web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/lwa-web/components/clip-studio.tsx
+++ b/lwa-web/components/clip-studio.tsx
@@ -1178,6 +1178,32 @@ export function ClipStudio({
   const recommendedPlatform = activeResult?.processing_summary?.recommended_platform || activeResult?.processing_summary?.target_platform || null;
   const platformDecision = activeResult?.processing_summary?.platform_decision || (useManualPlatform ? "manual" : "auto");
   const platformRecommendationReason = activeResult?.processing_summary?.platform_recommendation_reason || null;
+  const recommendedContentType = activeResult?.processing_summary?.recommended_content_type || null;
+  const recommendedOutputStyle = activeResult?.processing_summary?.recommended_output_style || null;
+  const recommendationRail = activeResult
+    ? [
+        {
+          label: "Destination",
+          value: recommendedPlatform || effectiveTargetPlatform || "Auto",
+          detail: platformRecommendationReason || "LWA picked the first destination from the source and current pack.",
+        },
+        {
+          label: "Content read",
+          value: recommendedContentType || "Auto read",
+          detail: "Used to shape hook angle, packaging, and review order without changing the API contract.",
+        },
+        {
+          label: "Output style",
+          value: recommendedOutputStyle ? "Style locked" : "Auto package",
+          detail: recommendedOutputStyle || "Hook, caption, thumbnail, CTA, and post order are generated as a pack.",
+        },
+        {
+          label: "Truth layer",
+          value: activeResult.processing_summary?.ai_provider || "Fallback-safe",
+          detail: `${planSurface.name}${typeof creditsRemaining === "number" ? ` with ${creditsRemaining} credits left` : ""}; rendered clips stay separate from strategy-only ideas.`,
+        },
+      ]
+    : [];
   const renderedClipCount = renderedClips.length;
   const strategyOnlyClipCount = strategyOnlyClips.length;
   const shotPlanReadyCount = orderedClips.filter((clip) => clipHasShotPlan(clip)).length;
@@ -2081,6 +2107,25 @@ export function ClipStudio({
         <InlineAlert tone="violet" title="Rendered lane is partial">
           Some clips came back without a playable preview. Export the ready cuts first, then use the strategy lane to decide what is worth recovering.
         </InlineAlert>
+      ) : null}
+
+      {recommendationRail.length ? (
+        <section className="glass-panel rounded-[28px] p-5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="section-kicker">LWA recommendation rail</p>
+              <h4 className="mt-2 text-2xl font-semibold text-ink">The first move, the content read, and the safety truth.</h4>
+            </div>
+            <StatPill tone={platformDecision === "manual" ? "neutral" : "signal"}>
+              {platformDecision === "manual" ? "Manual override" : "Auto routed"}
+            </StatPill>
+          </div>
+          <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {recommendationRail.map((item) => (
+              <MetricTile key={item.label} label={item.label} value={item.value} detail={item.detail} />
+            ))}
+          </div>
+        </section>
       ) : null}
 
       {leadClip ? (

--- a/lwa-web/components/results/StudioRail.tsx
+++ b/lwa-web/components/results/StudioRail.tsx
@@ -105,7 +105,7 @@ export function StudioRail({ clips, onClipSelect, onRetryClip, onDownloadClip, s
                 {/* Hook/CTA */}
                 {clip.hook && (
                   <div className="text-sm text-ink/80 italic">
-                    "{clip.hook}"
+                    &ldquo;{clip.hook}&rdquo;
                   </div>
                 )}
                 

--- a/lwa-web/src/components/ClipCard.tsx
+++ b/lwa-web/src/components/ClipCard.tsx
@@ -167,7 +167,7 @@ export function ClipCard({ clip, index }: ClipCardProps) {
               Transcript excerpt
             </summary>
             <blockquote className="mt-2 rounded-xl border border-white/6 bg-surface-600/50 px-4 py-3 text-xs text-slate-400 italic leading-relaxed">
-              "{clip.transcript_excerpt}"
+              &ldquo;{clip.transcript_excerpt}&rdquo;
             </blockquote>
           </details>
         )}


### PR DESCRIPTION
## Summary

Adds the deterministic Director Brain v0 slice and the first frontend recommendation rail without touching iOS or broadening backend scope.

## Changes

- Adds `app/services/director_brain.py` for deterministic per-platform clip planning.
- Wires Director Brain output into existing clip service result enrichment.
- Adds backend tests for platform profiles, rendered/strategy-only state, and integration behavior.
- Adds a minimal Next lint config and fixes two existing lint quote escapes.
- Adds the clip studio recommendation rail that surfaces destination, content read, output style, and provider/plan truth while preserving rendered vs strategy-only separation.

## Verification

- `python3 -m compileall lwa-backend/app lwa-backend/scripts`
- `cd lwa-backend && python3 -m py_compile $(git ls-files '*.py')`
- `cd lwa-backend && python3 -m unittest tests/test_director_brain.py tests/test_director_brain_integration.py`
- `cd lwa-backend && python3 -m unittest discover -s tests`
- `cd lwa-web && npm run type-check`
- `cd lwa-web && npm run lint`
- `cd lwa-web && npm run build`
- `git diff --check`

## Notes

The original worktree contains unrelated dirty files from prior Worlds/launch work. This branch was created from the latest `origin/feat/source-poc-matrix` in a clean temporary worktree and contains only the two scoped commits.