### PR TITLE
fix: polish LWA showcase, guest UX, and full-stack readiness [superseded by #80]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 .env
 .env.local
 .env.*.local
+.env.production
+.env.staging
+.env.development
 /package-lock.json
 node_modules/
 .next/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this repository, **do not open a public issue**.
+
+Contact the team directly at: security@lwa.app
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested remediation
+
+We will acknowledge your report within 72 hours and aim to resolve confirmed vulnerabilities within 14 days.
+
+## Secret Handling
+
+- All secrets and API keys must be stored in `.env` files, never committed to git
+- `.env`, `.env.local`, `.env.production`, `.env.staging` are all gitignored
+- Use `.env.example` (with placeholder values only) to document required variables
+- No API keys, tokens, or credentials may appear in frontend bundles or client-side code
+- The `NEXT_PUBLIC_` prefix exposes variables to the browser — use it only for non-sensitive public config
+
+## Scope
+
+- No crypto wallet addresses are live in this codebase
+- No securities are offered, sold, or solicited through this platform
+- Investment and equity discussions require legal review before any communication
+- The Whop integration is the only live payment pathway; all others are in development
+
+## Dependencies
+
+Run `npm audit` in `lwa-web/` regularly. Address high and critical findings before deployment.

--- a/docs/runbooks/LWA_CONTEST_POLISH_SPRINT.md
+++ b/docs/runbooks/LWA_CONTEST_POLISH_SPRINT.md
@@ -1,0 +1,53 @@
+# LWA Contest Polish Sprint — PR Summary
+
+## What this PR fixed
+
+### Phase 1 — Homepage CTA fallback
+- All action cards now have fallback chains ending at `getPrimaryMoneyLink()`
+- "Request custom clip pack" → demoForm || contact || booking || primary
+- "Book demo" → booking || demoForm || contact || primary
+- "Join creator/referral program" → affiliateForm || contact || primary
+- "Add path when configured" placeholder state is now unreachable when env vars are missing
+- Verified `DEFAULT_WHOP_URL` is correct: `https://whop.com/lwa-app/lwa-ai-content-repurposer/`
+
+### Phase 2 — Guest generate UX
+- **Live stream preflight**: URLs matching twitch.tv/, youtube.com/live, or /live/ now show a non-blocking amber notice with "Continue anyway" and "Upload file instead" before submitting
+- **Strategy-only card**: Updated to show structured "Strategy-only package" title, "No playable preview was created for this source." subtext, body copy, and "Upload source file for rendered clips" button — no fake thumbnail, no video player frame
+- **Export bundle**: Now forces real file download via Blob when backend returns JSON; filename is `lwa-clip-package-{request_id}.json` (rendered) or `lwa-strategy-bundle-{request_id}.json` (strategy-only)
+- **Button label**: Export button shows "Download Clip Package" or "Download Strategy Bundle" depending on rendered clip presence
+- **Result ordering**: Clip cards now show Hook → Caption → Score → Timestamp → Recovery guidance (degraded only) → Platform recommendation (available only)
+- **402 paywall card**: Shows "You have used your free launch credits." with "Join Waitlist" and "Save my work" buttons; no raw error strings
+
+### Phase 3 — Agent and council registries
+- Created `lwa-web/lib/lwa-agents.ts` with 7 agents (omega-prime, jackal-warden, veil-oracle, iron-seraph, horned-sentinel, shadow-scribe, grave-monk)
+- Created `lwa-web/lib/production-council.ts` with 9 council roles
+- Added homepage council line: "The Council builds the system. The characters guide the world." with "How LWA is built" eyebrow
+
+### Phase 4 — Contrast
+- Strategy-only card text bumped from `text-ink/62` to `text-ink/80` for body copy readability
+
+### Phase 5 — Docs
+- `docs/showcase/LWA_AI_SHOWCASE_SUBMISSION.md` — contest submission template
+- `docs/runbooks/LWA_LIVE_SMOKE_TEST.md` — smoke test checklist with API spending decision tree
+- `docs/runbooks/LWA_CONTEST_POLISH_SPRINT.md` — this file
+
+## What was NOT changed
+- iOS (lwa-ios/) — untouched
+- Backend business logic — untouched
+- Marketplace payout logic — untouched
+- Blockchain or social posting claims — untouched
+- Pricing copy — untouched
+- Safety language — untouched
+- Route shapes or status codes — untouched
+
+## What remains
+- Auth and ownership (Issue 72) — next sprint
+- Director Brain deeper wiring — queued
+- Live smoke test against production Railway deployment — required before claiming submission ready
+- Screenshot capture for showcase submission
+- Final readiness score (fill in after smoke test)
+
+## Verification
+- Backend compile: `python3 -m compileall lwa-backend/app lwa-backend/scripts`
+- Frontend type-check: `cd lwa-web && npm run type-check`
+- Frontend build: `cd lwa-web && npm run build`

--- a/docs/runbooks/LWA_LIVE_SMOKE_TEST.md
+++ b/docs/runbooks/LWA_LIVE_SMOKE_TEST.md
@@ -1,0 +1,79 @@
+# LWA Live Smoke Test Runbook
+
+## Pages to test
+| Page | URL | Pass |
+|------|-----|------|
+| Homepage | https://lwa-the-god-app-production.up.railway.app/ | |
+| Generate | https://lwa-the-god-app-production.up.railway.app/generate | |
+| Marketplace | https://lwa-the-god-app-production.up.railway.app/marketplace | |
+| Operator | https://lwa-the-god-app-production.up.railway.app/operator | |
+| Proof | https://lwa-the-god-app-production.up.railway.app/proof | |
+| Realm | https://lwa-the-god-app-production.up.railway.app/realm | |
+| Social | https://lwa-the-god-app-production.up.railway.app/social | |
+| Whop | https://whop.com/lwa-app/lwa-ai-content-repurposer/ | |
+
+## Backend health check
+```
+GET https://lwa-backend-production-c9cc.up.railway.app/health
+```
+Expected: 200 OK with status message.
+
+## Generate smoke test — URL path
+1. Go to /generate
+2. Paste a public YouTube URL (non-live, non-private)
+3. Click Generate Clips
+4. Verify result cards show hook first, then caption, score, timestamp
+5. Verify strategy-only cards show "Strategy-only package" title and upload CTA
+6. Click "Download Clip Package" or "Download Strategy Bundle"
+7. Verify file downloads (not opened in browser tab)
+
+## Generate smoke test — upload path
+1. Go to /generate
+2. Click "Upload file" and upload a short .mp4
+3. Click Generate Clips
+4. Verify same result structure as URL path test
+
+## Live stream preflight test
+1. Go to /generate
+2. Paste a twitch.tv or youtube.com/live URL
+3. Click Generate Clips
+4. Verify preflight notice appears with "Continue anyway" and "Upload file instead"
+5. Verify clicking "Continue anyway" proceeds to generation
+
+## Whop access path test
+1. Go to https://whop.com/lwa-app/lwa-ai-content-repurposer/
+2. Verify page loads and product is listed
+3. Verify homepage "Support the build" CTA points to Whop
+
+## Railway env vars to verify
+| Variable | Required | Note |
+|----------|----------|------|
+| FREE_LAUNCH_MODE | Backend | Enables free guest generation |
+| NEXT_PUBLIC_FREE_LAUNCH_MODE | Frontend | Enables free launch UI mode |
+| OPENAI_API_KEY | Backend | Primary intelligence provider |
+| ANTHROPIC_API_KEY | Backend | Secondary intelligence provider |
+| NEXT_PUBLIC_API_BASE_URL | Frontend | Must point to live backend URL |
+| NEXT_PUBLIC_LWA_WHOP_URL | Frontend | Whop product page URL |
+
+## Error decoding
+| Symptom | Likely cause |
+|---------|-------------|
+| Backend 500 on /generate | Missing OPENAI_API_KEY or ANTHROPIC_API_KEY |
+| Frontend cannot reach backend | NEXT_PUBLIC_API_BASE_URL missing or wrong |
+| CORS error in browser console | API base URL mismatch or CORS not configured |
+| All results are strategy-only | Video provider cannot access source URL |
+| Backend 422 on generate | Request payload shape mismatch |
+
+## Screenshots to capture
+- [ ] Homepage hero (full width, dark background)
+- [ ] /generate with a result loaded (hook-first card visible)
+- [ ] Strategy-only card with "Upload source file for rendered clips" button
+- [ ] Whop product page
+
+## API spending decision tree
+
+1. **Spend zero dollars** until live smoke testing identifies the missing provider.
+2. If the intelligence provider key is missing, **spend $5–$10 on Anthropic first** (not OpenAI, not Seedance).
+3. **Do not spend on Seedance video first** — strategy-only is acceptable for the launch run.
+4. Keep **$10–$15 in reserve** for the post-smoke-test generation sprint.
+5. Only add a video rendering provider after the text intelligence layer is confirmed working.

--- a/docs/showcase/LWA_AI_SHOWCASE_SUBMISSION.md
+++ b/docs/showcase/LWA_AI_SHOWCASE_SUBMISSION.md
@@ -1,0 +1,50 @@
+# LWA / IWA — AI Showcase Submission
+
+## Recommended project title
+LWA / IWA
+
+## Recommended URL
+https://lwa-the-god-app-production.up.railway.app
+
+## Recommended preview screenshot
+Homepage hero plus one /generate result showing hook-first clip card with strategy-only package card visible.
+
+## Submission description
+LWA/IWA is a deployed AI clipping engine that turns long-form videos, uploads, and creator sources into short-form content packages with hooks, captions, timestamps, scores, and platform strategy. I built it with AI/Codex support across a Next.js frontend, FastAPI backend, Railway deployment, Whop monetization path, Director Brain recommendation logic, and marketplace/creator workflow scaffolds.
+
+## What to say
+- Deployed product with real backend
+- Director Brain recommendation logic
+- Upload-first pipeline with strategy-only fallback
+- Hook-first result ordering
+- Free launch mode for guest access
+- Operator command center for internal QA
+
+## What not to say
+- Guaranteed virality
+- Guaranteed income
+- Live marketplace payouts
+- Live social provider posting
+- NFT economy or live blockchain economy
+
+## Live page checklist
+- [ ] / (homepage)
+- [ ] /generate (guest clip engine)
+- [ ] /marketplace (preview layer)
+- [ ] /operator (internal command center)
+- [ ] /proof (provenance layer preview)
+- [ ] /realm (Signal Realms preview)
+- [ ] /social (social provider status)
+- [ ] Whop product page: https://whop.com/lwa-app/lwa-ai-content-repurposer/
+
+## Screenshot checklist
+- [ ] Hero section with product description
+- [ ] /generate result with hook first in clip card
+- [ ] Strategy-only card showing correct structure
+- [ ] Whop product page
+
+## Competitor positioning
+A deployed AI creator business, not just a demo. LWA ships a real backend, real clip logic, a real Whop access path, and a real operator layer — not a pitch deck or mockup.
+
+## Final readiness score
+Fill in after live smoke test. See LWA_LIVE_SMOKE_TEST.md.

--- a/lwa-web/app/batches/page.tsx
+++ b/lwa-web/app/batches/page.tsx
@@ -1,4 +1,13 @@
+import type { Metadata } from "next";
 import { ClipStudio } from "../../components/clip-studio";
+import { buildPageMetadata } from "../../lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Batch Queue",
+  description: "Group multiple sources into repeatable batch runs and track processing state.",
+  path: "/batches",
+  keywords: ["batch clipping", "multi-source queue", "creator batch workflow", "clip batch"],
+});
 
 export default function BatchesPage() {
   return <ClipStudio initialSection="batches" />;

--- a/lwa-web/app/campaigns/page.tsx
+++ b/lwa-web/app/campaigns/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { RoutePlaceholder } from "../../components/RoutePlaceholder";
+import { ClipStudio } from "../../components/clip-studio";
 import { buildPageMetadata } from "../../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -10,5 +10,5 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default function CampaignsPage() {
-  return <RoutePlaceholder title="Campaigns" />;
+  return <ClipStudio initialSection="campaigns" />;
 }

--- a/lwa-web/app/dashboard/page.tsx
+++ b/lwa-web/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { RoutePlaceholder } from "../../components/RoutePlaceholder";
+import { ClipStudio } from "../../components/clip-studio";
 import { buildPageMetadata } from "../../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -10,5 +10,5 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default function DashboardPage() {
-  return <RoutePlaceholder title="Dashboard" />;
+  return <ClipStudio initialSection="dashboard" />;
 }

--- a/lwa-web/app/operator/page.tsx
+++ b/lwa-web/app/operator/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getAllCouncilRoles, COUNCIL_BRAND_LINE } from "../../lib/production-council";
 import { buildPageMetadata } from "../../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -66,6 +67,8 @@ const lanes = [
     items: ["Backend health", "Frontend deploy", "Generate smoke test", "Whop event smoke test"],
   },
 ];
+
+const councilRoles = getAllCouncilRoles();
 
 const councilRoutes = [
   { label: "Generator", href: "/generate", detail: "Run the main source-to-package flow." },
@@ -152,6 +155,27 @@ export default function OperatorPage() {
                 <p className="text-sm font-semibold text-ink">{route.label}</p>
                 <p className="mt-2 text-sm leading-6 text-ink/62">{route.detail}</p>
               </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-6 rounded-[30px] border border-white/12 bg-white/[0.04] p-6">
+          <p className="section-kicker">Production council</p>
+          <div className="mt-2 flex items-end justify-between gap-3">
+            <h2 className="text-2xl font-semibold text-ink">Who builds this</h2>
+            <p className="text-xs font-semibold text-ink/42">{COUNCIL_BRAND_LINE}</p>
+          </div>
+          <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {councilRoles.map((role) => (
+              <div key={role.id} className="rounded-[20px] border border-white/10 bg-black/10 p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-ink">{role.realTitle}</p>
+                    <p className="mt-0.5 text-[11px] font-medium text-[var(--gold)]">{role.mythicTitle}</p>
+                  </div>
+                </div>
+                <p className="mt-3 text-xs leading-5 text-ink/55">{role.owns}</p>
+              </div>
             ))}
           </div>
         </section>

--- a/lwa-web/app/opportunities/page.tsx
+++ b/lwa-web/app/opportunities/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { buildPageMetadata } from "../../lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "LWA Opportunities",
+  description:
+    "Support, advertise, partner, invest, or apply to sell with LWA. Every opportunity starts with a compliant inquiry so we can protect both sides and build trust first.",
+  path: "/opportunities",
+  keywords: [
+    "LWA opportunities",
+    "LWA sponsorship",
+    "LWA advertising",
+    "LWA investor inquiry",
+    "LWA marketplace seller",
+    "support LWA",
+  ],
+});
+
+type OpportunityCard = {
+  id: string;
+  title: string;
+  badge: string;
+  badgeColor: string;
+  description: string;
+  legalNote?: string;
+  cta: string;
+  href: string;
+  accentStyle: string;
+};
+
+const opportunities: OpportunityCard[] = [
+  {
+    id: "support",
+    title: "Support LWA",
+    badge: "Open",
+    badgeColor: "border-emerald-300/30 bg-emerald-300/15 text-emerald-100",
+    description:
+      "Back the mission directly. Every contribution funds infrastructure, tooling, and the team building the signal engine.",
+    cta: "Support Now",
+    href: "#inquiry-support",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(16,185,129,0.22), transparent 55%)",
+  },
+  {
+    id: "sponsorship",
+    title: "Sponsorship Inquiry",
+    badge: "Inquiry",
+    badgeColor: "border-amber-300/30 bg-amber-300/15 text-amber-100",
+    description:
+      "Align your brand with LWA's creator audience. Placement opportunities exist across the platform, content packages, and launch events.",
+    legalNote:
+      "Sponsorship terms reviewed internally before confirmation. No binding agreement until countersigned.",
+    cta: "Submit Sponsorship Inquiry",
+    href: "#inquiry-sponsorship",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(245,158,11,0.22), transparent 55%)",
+  },
+  {
+    id: "advertising",
+    title: "Ad Placement Inquiry",
+    badge: "Inquiry",
+    badgeColor: "border-amber-300/30 bg-amber-300/15 text-amber-100",
+    description:
+      "Reach creators at the clip engine. Placement options include featured surfaces, notification slots, and co-branded packages.",
+    legalNote:
+      "Ad placements are approved on a case-by-case basis. Rates confirmed only after internal review.",
+    cta: "Submit Ad Inquiry",
+    href: "#inquiry-advertising",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(245,158,11,0.20), transparent 55%)",
+  },
+  {
+    id: "invest",
+    title: "Investor Portal",
+    badge: "Legal Review",
+    badgeColor: "border-purple-300/30 bg-purple-300/15 text-purple-100",
+    description:
+      "Investment, share interest, and equity inquiries. No securities are offered or sold through this website. Legal review is required before any substantive discussion takes place.",
+    legalNote:
+      "This is an inquiry form only. Nothing on this page constitutes an offer to sell, a solicitation of an offer to buy, or a recommendation of any security. All investment discussions require legal counsel on both sides.",
+    cta: "Submit Investor Inquiry",
+    href: "#inquiry-invest",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(139,92,246,0.22), transparent 55%)",
+  },
+  {
+    id: "crypto",
+    title: "Crypto Support Interest",
+    badge: "Legal Review",
+    badgeColor: "border-purple-300/30 bg-purple-300/15 text-purple-100",
+    description:
+      "Interest in supporting LWA via cryptocurrency. No wallet address is live on this page. All crypto support pathways require legal and compliance review before activation.",
+    legalNote:
+      "No crypto payment is collected here. This is an interest-capture form only. No blockchain economy, token, or NFT is offered by LWA at this time.",
+    cta: "Register Interest",
+    href: "#inquiry-crypto",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(109,92,255,0.22), transparent 55%)",
+  },
+  {
+    id: "buy-services",
+    title: "Buy Services from LWA",
+    badge: "Open",
+    badgeColor: "border-emerald-300/30 bg-emerald-300/15 text-emerald-100",
+    description:
+      "Content packages, clip engine runs, strategy consulting, and done-for-you production available through approved service agreements.",
+    cta: "Inquire About Services",
+    href: "#inquiry-services",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(16,185,129,0.18), transparent 55%)",
+  },
+  {
+    id: "marketplace",
+    title: "Sell Through LWA Marketplace",
+    badge: "Apply",
+    badgeColor: "border-amber-300/30 bg-amber-300/15 text-amber-100",
+    description:
+      "Apply to become a verified LWA seller. Reach an audience of active creators. LWA collects a platform percentage only through approved, signed terms.",
+    legalNote:
+      "Seller approval is not guaranteed. Terms are set per seller. No commissions are collected until a seller agreement is signed.",
+    cta: "Apply to Sell",
+    href: "#inquiry-marketplace",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(236,72,153,0.22), transparent 55%)",
+  },
+];
+
+export default function OpportunitiesPage() {
+  return (
+    <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
+      <section className="mx-auto max-w-7xl">
+        {/* Hero */}
+        <div className="rounded-[36px] border border-white/12 bg-[radial-gradient(circle_at_top_left,rgba(109,92,255,0.18),transparent_32%),linear-gradient(180deg,var(--bg-card),var(--bg))] p-6 shadow-card sm:p-10">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">
+            Compliant by design
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold leading-tight text-ink sm:text-6xl">
+            LWA Opportunities
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-ink/70 sm:text-lg">
+            Support, advertise, partner, invest, or apply to sell with LWA.
+            Every opportunity starts with a compliant inquiry so we can protect
+            both sides and build trust first.
+          </p>
+          <p className="mt-4 text-sm leading-6 text-ink/48">
+            No income guarantees. No securities sold through this website. No
+            live crypto collection. No binding agreement until documented and
+            countersigned.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/generate"
+              className="primary-button rounded-full px-5 py-3 text-sm font-semibold"
+            >
+              Enter Clip Engine
+            </Link>
+            <Link
+              href="/"
+              className="secondary-button rounded-full px-5 py-3 text-sm font-medium"
+            >
+              Back to Portal
+            </Link>
+          </div>
+        </div>
+
+        {/* Opportunity cards */}
+        <section className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3" id="opportunities-grid">
+          {opportunities.map((opp) => (
+            <article
+              key={opp.id}
+              id={opp.id}
+              className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] p-6"
+            >
+              <div
+                className="pointer-events-none absolute inset-0 rounded-[28px]"
+                style={{ background: opp.accentStyle }}
+              />
+              <div className="relative">
+                <div className="flex items-start justify-between gap-3">
+                  <h2 className="text-lg font-semibold text-ink">
+                    {opp.title}
+                  </h2>
+                  <span
+                    className={`shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${opp.badgeColor}`}
+                  >
+                    {opp.badge}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-ink/68">
+                  {opp.description}
+                </p>
+                {opp.legalNote && (
+                  <p className="mt-3 rounded-[14px] border border-white/8 bg-black/20 px-3 py-2 text-xs leading-5 text-ink/48">
+                    {opp.legalNote}
+                  </p>
+                )}
+                <a
+                  href={`mailto:opportunities@lwa.app?subject=${encodeURIComponent(opp.title)}`}
+                  className="mt-4 inline-flex items-center justify-center rounded-full bg-[var(--gold)] px-5 py-2.5 text-sm font-semibold text-black transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--gold)]"
+                >
+                  {opp.cta} →
+                </a>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        {/* Legal footer */}
+        <section className="mt-8 rounded-[24px] border border-white/8 bg-white/[0.02] p-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-ink/38">
+            Legal disclosure
+          </p>
+          <p className="mt-3 text-xs leading-6 text-ink/48">
+            Nothing on this page constitutes an offer to sell securities, an
+            investment contract, a guarantee of return, or a binding service
+            agreement. All inquiries are acknowledged only — no transaction,
+            commitment, or obligation is created until a separate written
+            agreement is signed by both parties. LWA does not collect payments,
+            donations, crypto, or investment funds through this page. Equity and
+            securities discussions require independent legal counsel. LWA
+            reserves the right to decline any inquiry without explanation.
+          </p>
+          <p className="mt-3 text-xs leading-6 text-ink/38">
+            Whop is the live and approved access path for LWA product purchases.
+            All other commercial relationships are in active development and
+            subject to internal review.
+          </p>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/lwa-web/app/page.tsx
+++ b/lwa-web/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Logo } from "../components/brand/Logo";
 import { buildUtmUrl, getMoneyLinkByKey, getPrimaryMoneyLink, type MoneyLink } from "../lib/money-links";
+import { COUNCIL_BRAND_LINE } from "../lib/production-council";
 import { buildPageMetadata } from "../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -119,7 +120,7 @@ const actionPaths: ActionPath[] = [
   {
     label: "Request custom clip pack",
     detail: "Use a custom workflow or creator brief when direct generation is not the right first step.",
-    href: getMoneyLinkByKey("demoForm") || getMoneyLinkByKey("contact") || getMoneyLinkByKey("booking"),
+    href: getMoneyLinkByKey("demoForm") || getMoneyLinkByKey("contact") || getMoneyLinkByKey("booking") || getPrimaryMoneyLink(),
     source: "homepage_custom_clip_pack",
   },
   {
@@ -131,13 +132,13 @@ const actionPaths: ActionPath[] = [
   {
     label: "Book demo",
     detail: "Use a guided walkthrough when a human operator path fits better.",
-    href: getMoneyLinkByKey("booking") || getMoneyLinkByKey("demoForm"),
+    href: getMoneyLinkByKey("booking") || getMoneyLinkByKey("demoForm") || getMoneyLinkByKey("contact") || getPrimaryMoneyLink(),
     source: "homepage_book_demo",
   },
   {
     label: "Join creator/referral program",
     detail: "Keep partner and early-operator lanes visible before every external form is configured.",
-    href: getMoneyLinkByKey("affiliateForm"),
+    href: getMoneyLinkByKey("affiliateForm") || getMoneyLinkByKey("contact") || getPrimaryMoneyLink(),
     source: "homepage_referral",
   },
 ];
@@ -276,6 +277,11 @@ export default function HomePage() {
             <p className="mt-2 text-sm leading-6 text-subtext">{mode.detail}</p>
           </div>
         ))}
+      </section>
+
+      <section className="mx-auto mt-8 max-w-6xl pb-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">How LWA is built</p>
+        <p className="mt-2 text-base font-semibold text-ink sm:text-lg">{COUNCIL_BRAND_LINE}</p>
       </section>
 
       <section className="mx-auto mt-2 grid w-full max-w-6xl gap-4 pb-10 md:grid-cols-2 xl:grid-cols-5">

--- a/lwa-web/app/page.tsx
+++ b/lwa-web/app/page.tsx
@@ -1,20 +1,22 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Logo } from "../components/brand/Logo";
-import { buildUtmUrl, getMoneyLinkByKey, getPrimaryMoneyLink, type MoneyLink } from "../lib/money-links";
+import { PathPortal } from "../components/PathPortal";
+import { buildUtmUrl, getPrimaryMoneyLink } from "../lib/money-links";
 import { COUNCIL_BRAND_LINE } from "../lib/production-council";
 import { buildPageMetadata } from "../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "Any-Source AI Content Engine",
-  description: "Give LWA video, audio, streams, prompts, campaigns, or files and build ranked creator-ready packages.",
+  title: "LWA — AI Content Engine",
+  description:
+    "LWA turns long-form videos, uploads, and creator sources into short-form content packages with hooks, captions, timestamps, scores, and platform strategy.",
   path: "/",
   keywords: [
-    "any source ai content engine",
-    "ranked clip packages",
-    "audio repurposing",
-    "twitch stream clipping",
+    "LWA ai content engine",
+    "viral clip packages",
+    "hooks captions timestamps",
     "creator workflow",
+    "twitch stream clipping",
   ],
 });
 
@@ -27,296 +29,136 @@ const proofPoints = [
   "Copy-ready package",
 ];
 
-const sourceModes = [
-  {
-    label: "Video",
-    status: "Live now",
-    detail: "Clip-ready packages from public links and owned media workflows when they are enabled.",
-    tone: "from-[rgba(109,92,255,0.14)] to-white",
-  },
-  {
-    label: "Audio",
-    status: "Expanding",
-    detail: "Turn podcasts, voice notes, and sound-led sources into captions, scripts, and packaging angles.",
-    tone: "from-[rgba(49,130,246,0.14)] to-white",
-  },
-  {
-    label: "Music",
-    status: "Expanding",
-    detail: "Shape music ideas into promo hooks, visual direction, and posting packages without pretending a full editor already exists.",
-    tone: "from-[rgba(236,72,153,0.14)] to-white",
-  },
-  {
-    label: "Prompt",
-    status: "In studio",
-    detail: "Start from an idea when no finished media exists yet and build the package from intent first.",
-    tone: "from-[rgba(16,185,129,0.14)] to-white",
-  },
-  {
-    label: "Twitch / Stream",
-    status: "Foundation",
-    detail: "Keep VOD and stream highlight workflows visible so the product does not collapse back into a YouTube-only tool.",
-    tone: "from-[rgba(245,158,11,0.16)] to-white",
-  },
-  {
-    label: "Campaign / Objective",
-    status: "Manual prep",
-    detail: "Translate goals into hooks, captions, thumbnails, and manual-review briefs without fake submission automation.",
-    tone: "from-[rgba(139,92,246,0.14)] to-white",
-  },
-  {
-    label: "Upload / File",
-    status: "When enabled",
-    detail: "Use owned source files when the active workflow can actually process them.",
-    tone: "from-[rgba(20,184,166,0.14)] to-white",
-  },
-];
-
-type ActionPath = {
-  label: string;
-  detail: string;
-  href: string | MoneyLink | null;
-  source?: string;
-  external?: boolean;
-};
-
-const actionPaths: ActionPath[] = [
-  {
-    label: "Generate from source",
-    detail: "Open the live source engine and move into clip review.",
-    href: "/generate",
-    external: false,
-  },
-  {
-    label: "Open workspace",
-    detail: "Review saved clip packs, queue state, campaigns, and account controls.",
-    href: "/dashboard",
-    external: false,
-  },
-  {
-    label: "Operator command center",
-    detail: "Open the internal launch checklist for quality, reliability, and Director Brain readiness.",
-    href: "/operator",
-    external: false,
-  },
-  {
-    label: "Signal Realms",
-    detail: "Preview the future creator progression layer: classes, factions, quests, badges, and cosmetic identity.",
-    href: "/realm",
-    external: false,
-  },
-  {
-    label: "Marketplace preview",
-    detail: "See the future template, hook, caption, brand kit, and campaign asset layer.",
-    href: "/marketplace",
-    external: false,
-  },
-  {
-    label: "Social status",
-    detail: "Track future provider readiness without pretending direct posting is already approved.",
-    href: "/social",
-    external: false,
-  },
-  {
-    label: "Proof layer",
-    detail: "Review the future off-chain provenance plan without wallet, token, or unlock claims.",
-    href: "/proof",
-    external: false,
-  },
-  {
-    label: "Request custom clip pack",
-    detail: "Use a custom workflow or creator brief when direct generation is not the right first step.",
-    href: getMoneyLinkByKey("demoForm") || getMoneyLinkByKey("contact") || getMoneyLinkByKey("booking") || getPrimaryMoneyLink(),
-    source: "homepage_custom_clip_pack",
-  },
-  {
-    label: "Support the build",
-    detail: "Use the live support path without making checkout the whole product story.",
-    href: getPrimaryMoneyLink(),
-    source: "homepage_support_the_build",
-  },
-  {
-    label: "Book demo",
-    detail: "Use a guided walkthrough when a human operator path fits better.",
-    href: getMoneyLinkByKey("booking") || getMoneyLinkByKey("demoForm") || getMoneyLinkByKey("contact") || getPrimaryMoneyLink(),
-    source: "homepage_book_demo",
-  },
-  {
-    label: "Join creator/referral program",
-    detail: "Keep partner and early-operator lanes visible before every external form is configured.",
-    href: getMoneyLinkByKey("affiliateForm") || getMoneyLinkByKey("contact") || getPrimaryMoneyLink(),
-    source: "homepage_referral",
-  },
-];
-
-function ActionCard({
-  label,
-  detail,
-  href,
-  source,
-  external = true,
-}: {
-  label: string;
-  detail: string;
-  href: string | MoneyLink | null;
-  source?: string;
-  external?: boolean;
-}) {
-  const className =
-    "rounded-[24px] border border-white/66 bg-white/78 px-5 py-5 shadow-sm transition hover:-translate-y-0.5 hover:border-[var(--gold-border)] hover:shadow-[var(--shadow-card)]";
-
-  if (!href) {
-    return (
-      <div className={[className, "opacity-80"].join(" ")}>
-        <p className="text-sm font-semibold text-ink">{label}</p>
-        <p className="mt-2 text-sm leading-6 text-subtext">{detail}</p>
-        <p className="mt-4 text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-wine)]">
-          Add path when configured
-        </p>
-      </div>
-    );
-  }
-
-  if (!external && typeof href === "string") {
-    return (
-      <Link href={href} className={className}>
-        <p className="text-sm font-semibold text-ink">{label}</p>
-        <p className="mt-2 text-sm leading-6 text-subtext">{detail}</p>
-        <p className="mt-4 text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-wine)]">
-          Open now
-        </p>
-      </Link>
-    );
-  }
-
-  const link = typeof href === "string" ? href : buildUtmUrl(href, source || "homepage");
-
-  return (
-    <a href={link} target="_blank" rel="noreferrer" className={className}>
-      <p className="text-sm font-semibold text-ink">{label}</p>
-      <p className="mt-2 text-sm leading-6 text-subtext">{detail}</p>
-      <p className="mt-4 text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-wine)]">
-        Open path
-      </p>
-    </a>
-  );
-}
-
 export default function HomePage() {
+  const primaryLink = getPrimaryMoneyLink();
+  const primaryLinkUrl = buildUtmUrl(primaryLink, "homepage_hero");
+
   return (
-    <section className="px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mx-auto grid min-h-[calc(100vh-3rem)] w-full max-w-6xl items-center gap-10 py-10 lg:grid-cols-[minmax(0,1fr),420px]">
-        <div className="text-center lg:text-left">
+    <section className="relative min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      {/* Cinematic background radial layers */}
+      <div
+        className="pointer-events-none fixed inset-0 -z-10"
+        aria-hidden="true"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 50% -10%, rgba(109,92,255,0.22), transparent 70%), radial-gradient(ellipse 60% 50% at 90% 80%, rgba(185,28,28,0.18), transparent 60%), radial-gradient(ellipse 50% 40% at 10% 90%, rgba(16,185,129,0.12), transparent 60%)",
+        }}
+      />
+
+      {/* Header */}
+      <header className="mx-auto flex max-w-7xl items-center justify-between gap-4 pb-6">
+        <Link href="/" aria-label="LWA home">
           <Logo animated />
+        </Link>
+        <nav className="hidden items-center gap-2 sm:flex">
+          <Link
+            href="/generate"
+            className="primary-button rounded-full px-5 py-2.5 text-sm font-semibold"
+          >
+            Enter Clip Engine
+          </Link>
+          <a
+            href={primaryLinkUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="secondary-button rounded-full px-5 py-2.5 text-sm font-medium"
+          >
+            Support LWA
+          </a>
+        </nav>
+      </header>
 
-          <p className="mt-10 text-[11px] font-semibold uppercase tracking-[0.32em] text-[var(--accent-wine)]">
-            Any source in. Creator-ready content out.
-          </p>
-          <h1 className="mt-10 text-4xl font-semibold leading-tight text-ink sm:text-6xl">
-            Give LWA the source, stream, prompt, music idea, or objective. It builds the content package.
-          </h1>
-          <p className="mt-4 max-w-2xl text-base leading-8 text-subtext sm:text-lg">
-            LWA is the any-source creator engine: video, audio, music, Twitch or stream material, prompt-led ideas, campaign objectives, and owned files when the workflow supports them. Ranked hooks, captions, visuals, post order, and rendered proof stay in one path.
-          </p>
+      {/* Hero */}
+      <section className="mx-auto max-w-7xl pt-10 pb-14 text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-[var(--accent-wine)]">
+          Any source in. Creator-ready content out.
+        </p>
+        <h1 className="mx-auto mt-6 max-w-4xl text-5xl font-semibold leading-[0.96] text-ink sm:text-7xl lg:text-[5.5rem]">
+          LWA
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-base leading-8 text-subtext sm:text-lg">
+          A deployed AI clipping engine that turns long-form videos, uploads,
+          and creator sources into short-form content packages — hooks,
+          captions, timestamps, scores, and platform strategy.
+        </p>
 
-          <form action="/generate" method="get" className="mt-10 w-full space-y-4">
-            <input
-              type="text"
-              inputMode="text"
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              name="url"
-              placeholder="Drop a video, audio file, stream link, Twitch VOD, music idea, campaign, or prompt..."
-              className="source-command-input input-surface input-command w-full rounded-[28px] px-5 py-5 text-base"
-              aria-label="Source, campaign, or prompt"
-            />
-            <div className="flex flex-col gap-3 sm:flex-row">
-              <button type="submit" className="primary-button w-full rounded-full px-6 py-4 text-base font-semibold sm:w-auto sm:min-w-[220px]">
-                Generate from source
-              </button>
-              <Link
-                href="/generate"
-                className="inline-flex w-full items-center justify-center rounded-full border border-[var(--gold-border)] bg-white/72 px-6 py-4 text-base font-semibold text-ink transition hover:bg-[var(--surface-gold-ghost)] sm:w-auto"
-              >
-                Open source engine
-              </Link>
-            </div>
-          </form>
-
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-subtext">
-            Public links work now. Prompt, upload, audio, stream, and campaign lanes keep expanding inside the same studio without pretending every backend path is already fully finished.
-          </p>
-        </div>
-
-        <aside className="relative overflow-hidden rounded-[38px] border border-white/70 bg-white/74 p-4 shadow-[0_28px_90px_rgba(88,70,140,0.16)] backdrop-blur-xl">
+        {/* Cinematic character visual */}
+        <div className="relative mx-auto mt-10 max-w-xs overflow-hidden rounded-[38px] border border-white/14 shadow-[0_28px_90px_rgba(88,70,140,0.22)]">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(236,72,153,0.20),transparent_30%),radial-gradient(circle_at_78%_24%,rgba(109,92,255,0.18),transparent_34%),radial-gradient(circle_at_56%_86%,rgba(16,185,129,0.18),transparent_30%)]" />
-          <div className="relative overflow-hidden rounded-[30px] border border-white/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.72),rgba(255,255,255,0.42))]">
+          <div className="relative overflow-hidden rounded-[38px] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))]">
             <img
               src="/brand-source/chars/athena.png"
-              alt="LWA character command interface"
-              className="h-full min-h-[320px] w-full object-cover object-center"
+              alt="LWA — the signal engine"
+              className="h-full min-h-[280px] w-full object-cover object-center"
             />
-            <div className="absolute inset-x-4 bottom-4 rounded-[24px] border border-white/62 bg-white/78 p-4 shadow-[0_18px_50px_rgba(41,31,68,0.18)] backdrop-blur-md">
-              <p className="section-kicker">Muse source engine</p>
-              <p className="mt-2 text-lg font-semibold text-ink">Signal scan, package, render when possible.</p>
-              <p className="mt-2 text-sm leading-6 text-subtext">
-                Existing Athena art is the current hero signature while the dedicated character-girl system is tightened further.
+            <div className="absolute inset-x-4 bottom-4 rounded-[22px] border border-white/12 bg-black/58 p-4 backdrop-blur-md">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[var(--gold)]">
+                Signal engine active
+              </p>
+              <p className="mt-1 text-sm font-semibold text-ink">
+                The characters guide the world.
               </p>
             </div>
           </div>
-        </aside>
-      </div>
+        </div>
 
-      <section className="mx-auto mt-8 grid w-full max-w-6xl gap-3 pb-8 sm:grid-cols-2 lg:grid-cols-4">
-        {sourceModes.map((mode) => (
-          <div
-            key={mode.label}
-            className={`rounded-[24px] border border-white/66 bg-gradient-to-br ${mode.tone} px-5 py-5 shadow-sm`}
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/generate"
+            className="primary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-semibold"
           >
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-sm font-semibold text-ink">{mode.label}</p>
-              <span className="rounded-full border border-[var(--gold-border)] bg-white/72 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-wine)]">
-                {mode.status}
-              </span>
-            </div>
-            <p className="mt-2 text-sm leading-6 text-subtext">{mode.detail}</p>
-          </div>
-        ))}
+            Enter Clip Engine
+          </Link>
+          <Link
+            href="/operator"
+            className="secondary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-medium"
+          >
+            Operator Center
+          </Link>
+        </div>
       </section>
 
-      <section className="mx-auto mt-8 max-w-6xl pb-4">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">How LWA is built</p>
-        <p className="mt-2 text-base font-semibold text-ink sm:text-lg">{COUNCIL_BRAND_LINE}</p>
+      {/* Path portal */}
+      <section className="mx-auto max-w-7xl pb-10">
+        <div className="mb-6 text-center">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">
+            Choose your path
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink sm:text-3xl">
+            Where do you want to go?
+          </h2>
+          <p className="mt-2 text-sm text-ink/52">
+            Hover or focus a card to see what each path takes you to.
+          </p>
+        </div>
+        <PathPortal />
       </section>
 
-      <section className="mx-auto mt-2 grid w-full max-w-6xl gap-4 pb-10 md:grid-cols-2 xl:grid-cols-5">
-        {actionPaths.map((path) => (
-          <ActionCard
-            key={path.label}
-            label={path.label}
-            detail={path.detail}
-            href={path.href}
-            source={path.source}
-            external={path.external}
-          />
-        ))}
+      {/* Council line */}
+      <section className="mx-auto max-w-7xl pb-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">
+          How LWA is built
+        </p>
+        <p className="mt-2 text-base font-semibold text-ink sm:text-lg">
+          {COUNCIL_BRAND_LINE}
+        </p>
       </section>
 
-      <p className="mx-auto max-w-6xl pb-10 text-xs leading-6 text-subtext/80">
-        Whop stays available as one live access path today. Demo, booking, support, referral, operator, marketplace, social, proof, and Realms routes appear as they are configured, without changing the product identity.
-      </p>
-
-      <section className="mx-auto grid w-full max-w-5xl gap-4 pb-16 sm:grid-cols-2 lg:grid-cols-3">
+      {/* Proof points */}
+      <section className="mx-auto grid w-full max-w-7xl gap-3 pb-16 sm:grid-cols-3 lg:grid-cols-6">
         {proofPoints.map((item) => (
           <div
             key={item}
-            className="metric-tile rounded-[24px] px-5 py-5 text-sm font-medium text-ink/84 backdrop-blur-sm"
+            className="metric-tile rounded-[22px] px-4 py-4 text-sm font-medium text-ink/80 backdrop-blur-sm"
           >
             {item}
           </div>
         ))}
       </section>
+
+      <p className="mx-auto max-w-7xl pb-10 text-xs leading-6 text-subtext/70">
+        No guaranteed virality or income claims. No live marketplace payouts, live social posting, or blockchain economy. Whop is the live access path. All other features are in active development.
+      </p>
     </section>
   );
 }

--- a/lwa-web/app/page.tsx
+++ b/lwa-web/app/page.tsx
@@ -88,6 +88,12 @@ const actionPaths: ActionPath[] = [
     external: false,
   },
   {
+    label: "Open workspace",
+    detail: "Review saved clip packs, queue state, campaigns, and account controls.",
+    href: "/dashboard",
+    external: false,
+  },
+  {
     label: "Operator command center",
     detail: "Open the internal launch checklist for quality, reliability, and Director Brain readiness.",
     href: "/operator",

--- a/lwa-web/app/realm/page.tsx
+++ b/lwa-web/app/realm/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getAllLwaAgents } from "../../lib/lwa-agents";
+import { COUNCIL_BRAND_LINE } from "../../lib/production-council";
 import { buildPageMetadata } from "../../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -13,6 +15,8 @@ const classes = ["Hookwright", "Captioneer", "Reframer", "Trendseer", "Loremaste
 const factions = ["Crimson Court", "Black Loom", "Verdant Pact", "Iron Choir", "Saffron Wake", "Glass Synod", "Tide Marshal", "Driftborn", "Emberkin", "Chorus of Thoth", "House Polis", "Outer Signal"];
 const principles = ["XP cannot be bought", "Badges are earned", "Relics are cosmetic only", "No investment language", "No feature unlocks from NFTs", "Web-first before chain"];
 
+const agents = getAllLwaAgents();
+
 export default function RealmPage() {
   return (
     <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
@@ -23,11 +27,43 @@ export default function RealmPage() {
           <p className="mt-4 max-w-3xl text-base leading-8 text-ink/66">
             Signal Realms is the future creator identity system for LWA. This page is a static shell: no XP purchases, no blockchain requirement, no marketplace money movement, and no feature unlocks from relics.
           </p>
+          <p className="mt-4 text-sm font-semibold text-ink/50">{COUNCIL_BRAND_LINE}</p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link href="/generate" className="primary-button rounded-full px-5 py-3 text-sm font-semibold">Generate clips</Link>
             <Link href="/operator" className="secondary-button rounded-full px-5 py-3 text-sm font-medium">Operator center</Link>
           </div>
         </div>
+
+        <section className="mt-6">
+          <div className="mb-4">
+            <p className="section-kicker">AI guides</p>
+            <h2 className="mt-2 text-2xl font-semibold text-ink">The Seven Agents</h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-ink/58">
+              Each agent is an in-world AI guide assigned to a product area. They advise, flag, and assist — they do not publish, deploy, or act without human review.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {agents.map((agent) => (
+              <article
+                key={agent.id}
+                className="rounded-[28px] border border-white/12 bg-[radial-gradient(circle_at_top_left,rgba(109,92,255,0.10),transparent_40%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] p-5"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--accent-wine)]">{agent.productArea}</p>
+                    <h3 className="mt-2 text-lg font-semibold text-ink">{agent.name}</h3>
+                    <p className="mt-0.5 text-xs text-ink/52">{agent.title}</p>
+                  </div>
+                  <span className="rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-ink/50">
+                    Review required
+                  </span>
+                </div>
+                <p className="mt-4 text-sm italic leading-6 text-ink/70">&ldquo;{agent.tagline}&rdquo;</p>
+                <p className="mt-3 text-sm leading-6 text-ink/55">{agent.aiRole}</p>
+              </article>
+            ))}
+          </div>
+        </section>
 
         <section className="mt-6 grid gap-4 lg:grid-cols-2">
           <article className="rounded-[30px] border border-white/12 bg-white/[0.04] p-6">

--- a/lwa-web/app/wallet/page.tsx
+++ b/lwa-web/app/wallet/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { RoutePlaceholder } from "../../components/RoutePlaceholder";
+import { ClipStudio } from "../../components/clip-studio";
 import { buildPageMetadata } from "../../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -10,5 +10,5 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default function WalletPage() {
-  return <RoutePlaceholder title="Wallet" />;
+  return <ClipStudio initialSection="wallet" />;
 }

--- a/lwa-web/components/Navbar.tsx
+++ b/lwa-web/components/Navbar.tsx
@@ -27,7 +27,7 @@ export default function Navbar({
   variant = "workspace",
 }: NavbarProps) {
   const pathname = usePathname();
-  const primaryItems = ["/generate", "/dashboard", "/campaigns", "/wallet"]
+  const primaryItems = ["/generate", "/dashboard", "/history", "/campaigns", "/wallet"]
     .map((href) => items.find((item) => item.href === href))
     .filter(Boolean) as NavItem[];
   const visibleItems = primaryItems.length ? primaryItems : items.slice(0, 4);
@@ -45,7 +45,7 @@ export default function Navbar({
         <nav className="order-3 flex w-full gap-1.5 overflow-x-auto pb-1 md:order-2 md:w-auto md:flex-1 md:justify-center md:pb-0">
           {visibleItems.map((item) => {
             const active = pathname === item.href;
-            const label = item.href === "/dashboard" ? "Queue" : rewriteSurfaceLabel(item.label);
+            const label = rewriteSurfaceLabel(item.label);
             return (
               <Link
                 key={item.href}

--- a/lwa-web/components/PathPortal.tsx
+++ b/lwa-web/components/PathPortal.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+type PathCard = {
+  id: string;
+  title: string;
+  badge: string;
+  badgeTone: "live" | "soon" | "inquiry" | "open";
+  tagline: string;
+  description: string;
+  cta: string;
+  href: string;
+  accentStyle: string;
+  external?: boolean;
+};
+
+const paths: PathCard[] = [
+  {
+    id: "clip-engine",
+    title: "Clip Engine",
+    badge: "Live",
+    badgeTone: "live",
+    tagline: "Turn long-form content into viral-ready clips.",
+    description:
+      "Drop any video, audio, stream, or prompt. Get ranked hooks, captions, timestamps, scores, and a copy-ready posting package.",
+    cta: "Enter Clip Engine",
+    href: "/generate",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(109,92,255,0.34), transparent 60%)",
+  },
+  {
+    id: "creator-mode",
+    title: "Creator Mode",
+    badge: "Next",
+    badgeTone: "soon",
+    tagline: "Hooks, captions, thumbnails, full content packages.",
+    description:
+      "Packaging tools, posting strategy, and output review — available inside the workspace when your account is active.",
+    cta: "Open Workspace",
+    href: "/dashboard",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(16,185,129,0.28), transparent 60%)",
+  },
+  {
+    id: "opportunities",
+    title: "LWA Opportunities",
+    badge: "Open",
+    badgeTone: "open",
+    tagline: "Support, advertise, partner, or invest with LWA.",
+    description:
+      "Every opportunity starts with a compliant inquiry so we can protect both sides and build trust first. No securities sold through this page.",
+    cta: "See Opportunities",
+    href: "/opportunities",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(245,158,11,0.28), transparent 60%)",
+  },
+  {
+    id: "marketplace",
+    title: "Marketplace",
+    badge: "Apply",
+    badgeTone: "soon",
+    tagline: "Sell products and services through LWA.",
+    description:
+      "Apply to become a verified seller. LWA helps drive creator attention and collects a platform percentage only through approved terms.",
+    cta: "Apply to Sell",
+    href: "/opportunities#marketplace",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(236,72,153,0.26), transparent 60%)",
+  },
+  {
+    id: "investor",
+    title: "Investor Portal",
+    badge: "Inquiry",
+    badgeTone: "inquiry",
+    tagline: "Investment, sponsorship, and partnership inquiries.",
+    description:
+      "Legal review is required before any securities or equity discussion takes place. Inquiries only — no securities are sold through this website.",
+    cta: "Submit Inquiry",
+    href: "/opportunities#invest",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(139,92,246,0.26), transparent 60%)",
+  },
+  {
+    id: "vault",
+    title: "Vault",
+    badge: "Soon",
+    badgeTone: "soon",
+    tagline: "Your saved outputs and history.",
+    description:
+      "Access past clip packs, archived runs, and saved packages. Sign in to open your vault.",
+    cta: "Open Vault",
+    href: "/history",
+    accentStyle:
+      "radial-gradient(circle at top left, rgba(20,184,166,0.26), transparent 60%)",
+  },
+];
+
+function badgeClass(tone: PathCard["badgeTone"]) {
+  if (tone === "live")
+    return "border-emerald-300/30 bg-emerald-300/15 text-emerald-100";
+  if (tone === "open")
+    return "border-amber-300/30 bg-amber-300/15 text-amber-100";
+  if (tone === "inquiry")
+    return "border-purple-300/30 bg-purple-300/15 text-purple-100";
+  return "border-white/15 bg-white/[0.07] text-ink/68";
+}
+
+export function PathPortal() {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  return (
+    <section
+      className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+      aria-label="LWA path selection"
+    >
+      {paths.map((path) => {
+        const isActive = activeId === path.id;
+        const inner = (
+          <div className="relative p-6">
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[28px] transition-opacity duration-300"
+              style={{
+                background: path.accentStyle,
+                opacity: isActive ? 1 : 0.55,
+              }}
+            />
+            <div className="relative">
+              <div className="flex items-start justify-between gap-3">
+                <h3 className="text-xl font-semibold text-ink">{path.title}</h3>
+                <span
+                  className={`shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${badgeClass(path.badgeTone)}`}
+                >
+                  {path.badge}
+                </span>
+              </div>
+              <p className="mt-3 text-sm font-medium leading-6 text-ink/72">
+                {path.tagline}
+              </p>
+
+              <div
+                className="overflow-hidden transition-all duration-300"
+                style={{
+                  maxHeight: isActive ? "220px" : "0px",
+                  opacity: isActive ? 1 : 0,
+                  marginTop: isActive ? "16px" : "0px",
+                }}
+              >
+                <p className="text-sm leading-6 text-ink/60">
+                  {path.description}
+                </p>
+                <span className="mt-4 inline-flex items-center justify-center rounded-full bg-[var(--gold)] px-5 py-2.5 text-sm font-semibold text-black transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--gold)]">
+                  {path.cta} →
+                </span>
+              </div>
+            </div>
+          </div>
+        );
+
+        const cardClass =
+          "group relative block overflow-hidden rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] transition-all duration-300 hover:border-[var(--gold-border)] hover:shadow-[0_16px_48px_rgba(109,92,255,0.18)] focus-within:border-[var(--gold-border)] focus-within:shadow-[0_16px_48px_rgba(109,92,255,0.18)]";
+
+        return (
+          <div
+            key={path.id}
+            onMouseEnter={() => setActiveId(path.id)}
+            onMouseLeave={() => setActiveId(null)}
+            onFocus={() => setActiveId(path.id)}
+            onBlur={() => setActiveId(null)}
+          >
+            {path.external ? (
+              <a
+                href={path.href}
+                target="_blank"
+                rel="noreferrer"
+                className={cardClass}
+                aria-label={`${path.title} — ${path.tagline}`}
+              >
+                {inner}
+              </a>
+            ) : (
+              <Link
+                href={path.href}
+                className={cardClass}
+                aria-label={`${path.title} — ${path.tagline}`}
+              >
+                {inner}
+              </Link>
+            )}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/lwa-web/components/VideoCard.tsx
+++ b/lwa-web/components/VideoCard.tsx
@@ -271,21 +271,28 @@ export default function VideoCard({
               </div>
             </div>
           ) : (
-            <div className="flex aspect-[9/16] min-h-[260px] flex-col justify-between bg-[radial-gradient(circle_at_top,var(--surface-gold-glow),transparent_24%),linear-gradient(180deg,var(--bg-card)_0%,var(--bg)_100%)] p-5">
+            <div className="flex min-h-[260px] flex-col justify-between rounded-[22px] border border-[var(--divider)] bg-[radial-gradient(circle_at_top,var(--surface-gold-glow),transparent_24%),linear-gradient(180deg,var(--bg-card)_0%,var(--bg)_100%)] p-5">
               <div className="flex items-center justify-between gap-3">
-                <span className="rounded-full border border-[var(--divider)] bg-[var(--surface-soft)] px-3 py-1 text-[11px] font-medium text-ink/78">
-                  Strategy only
+                <span className="rounded-full border border-[var(--gold-border)] bg-[var(--gold-dim)] px-3 py-1 text-[11px] font-semibold text-[var(--gold)]">
+                  Strategy-only package
                 </span>
                 <span className="rounded-full border border-[var(--divider)] bg-[var(--surface-soft)] px-3 py-1 text-[11px] text-ink/62">
                   {clipAuthorityLabel(postRank)}
                 </span>
               </div>
-              <div>
-                <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--gold)]">Next idea</p>
-                <h3 className="mt-4 text-lg font-semibold leading-7 text-ink">{clip.hook || clip.title}</h3>
-                <p className="mt-3 text-sm leading-6 text-ink/62">
-                  {clip.reason_not_rendered || clip.strategy_only_reason || "Shot plan ready. Use this as a strategy lane clip until media is available."}
+              <div className="space-y-3">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-ink/58">
+                  No playable preview was created for this source.
                 </p>
+                <p className="text-sm leading-6 text-ink/80">
+                  Use the hooks, captions, timestamps, and posting plan below.
+                </p>
+                <a
+                  href="/generate"
+                  className="inline-flex items-center rounded-full border border-[var(--gold-border)] bg-[var(--gold-dim)] px-4 py-2 text-xs font-semibold text-[var(--gold)] transition hover:opacity-80"
+                >
+                  Upload source file for rendered clips
+                </a>
               </div>
             </div>
           )}
@@ -313,9 +320,51 @@ export default function VideoCard({
           ) : null}
 
           {!compact ? <h3 className="line-clamp-2 text-lg font-semibold leading-tight text-ink">{clip.title}</h3> : null}
-          <p className={compact ? "text-base font-semibold leading-7 text-ink" : "text-sm leading-6 text-ink/88"}>
-            {clip.hook || clip.title}
-          </p>
+
+          <div className="space-y-2">
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Hook</p>
+              <p className={compact ? "mt-1 text-base font-semibold leading-7 text-ink" : "mt-1 text-sm font-medium leading-6 text-ink/90"}>
+                {clip.hook || clip.title}
+              </p>
+            </div>
+
+            {clip.caption ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Caption</p>
+                <p className="mt-1 text-sm leading-6 text-ink/80">{clip.caption}</p>
+              </div>
+            ) : null}
+
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Score</p>
+              <p className="mt-1 text-sm font-semibold text-ink/88">{scoreValue}</p>
+            </div>
+
+            {(clip.timestamp_start || clip.timestamp_end) ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Timestamp</p>
+                <p className="mt-1 text-sm text-ink/72">
+                  {[clip.timestamp_start, clip.timestamp_end].filter(Boolean).join(" – ")}
+                </p>
+              </div>
+            ) : null}
+
+            {showRecoverRender && clip.recovery_recommendation ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Recovery guidance</p>
+                <p className="mt-1 text-sm leading-6 text-ink/68">{clip.recovery_recommendation}</p>
+              </div>
+            ) : null}
+
+            {clip.target_platform ? (
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.22em] text-muted">Platform</p>
+                <p className="mt-1 text-sm text-ink/72">{clip.target_platform}</p>
+              </div>
+            ) : null}
+          </div>
+
           <p className="text-sm leading-6 text-ink/62">{whyThisMatters}</p>
 
           <DirectorBrainPackagePanel clip={clip} />

--- a/lwa-web/components/clip-studio.tsx
+++ b/lwa-web/components/clip-studio.tsx
@@ -292,7 +292,8 @@ const appNavItems = [
 
 const marketingNavItems = [
   { href: "/generate", label: rewriteSurfaceLabel("Generate") },
-  { href: "/campaigns", label: rewriteSurfaceLabel("Campaigns") },
+  { href: "/operator", label: "Operator" },
+  { href: "/realm", label: "Realms" },
 ] as const;
 
 const VIDEO_LOADING_STAGES = ["Source ingest", "Moment scan", "Clip ranking", "Packaging", "Render/export", "Delivery"];

--- a/lwa-web/components/clip-studio.tsx
+++ b/lwa-web/components/clip-studio.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ChangeEvent, FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { buildUtmUrl, getPrimaryMoneyLink } from "../lib/money-links";
 import { AccountWorkspace } from "./account-workspace";
 import { AuthPanel } from "./auth-panel";
 import { BatchPanel } from "./batch-panel";
@@ -105,6 +106,15 @@ import { useStableResults } from "../hooks/useStableResults";
 
 const platforms: PlatformOption[] = ["TikTok", "Instagram Reels", "YouTube Shorts"];
 type SourceMode = "video" | "image" | "idea";
+
+function isLiveStreamUrl(url: string): boolean {
+  const lower = url.toLowerCase();
+  return (
+    lower.includes("twitch.tv/") ||
+    lower.includes("youtube.com/live") ||
+    lower.includes("/live/")
+  );
+}
 const FREE_LAUNCH_MODE = process.env.NEXT_PUBLIC_FREE_LAUNCH_MODE === "true";
 
 const PLATFORM_BLOCKED_SOURCE_MESSAGE =
@@ -359,6 +369,7 @@ export function ClipStudio({
   const [bundleExportState, setBundleExportState] = useState<"idle" | "exporting" | "ready" | "failed">("idle");
   const [bundleExportMessage, setBundleExportMessage] = useState<string | null>(null);
   const [latestBundleExport, setLatestBundleExport] = useState<ExportBundleResponse | null>(null);
+  const [liveStreamWarning, setLiveStreamWarning] = useState(false);
   const [copiedPackageAction, setCopiedPackageAction] = useState<"lead" | "rendered" | "strategy" | "all" | null>(null);
   const [inputFocused, setInputFocused] = useState(false);
   const [generatorHovered, setGeneratorHovered] = useState(false);
@@ -686,10 +697,15 @@ export function ClipStudio({
     await refreshAccount(token);
   }
 
-  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: FormEvent<HTMLFormElement>, bypassLiveCheck = false) {
     event.preventDefault();
     if (sourceMode === "video" && !videoUrl.trim() && !selectedUploadId) {
       setError(isGuest ? "Paste a public source URL to generate your clip pack." : "Paste a public source URL or upload a file to generate your clip pack.");
+      return;
+    }
+
+    if (sourceMode === "video" && videoUrl.trim() && !bypassLiveCheck && isLiveStreamUrl(videoUrl)) {
+      setLiveStreamWarning(true);
       return;
     }
     if (sourceMode === "image" && !selectedUploadId) {
@@ -1258,35 +1274,46 @@ export function ClipStudio({
         : generatorHovered
           ? "hover"
           : "idle";
+  const primaryLink = getPrimaryMoneyLink();
+  const primaryLinkUrl = buildUtmUrl(primaryLink, "clip_studio_quota");
+
   const paywallCard = paywallMessage ? (
-    <div className="rounded-[18px] border border-[var(--gold-border)] bg-[var(--gold-dim)] px-5 py-4">
-      <p className="text-sm font-semibold text-[var(--gold)]">
-        {FREE_LAUNCH_MODE && !user ? "Free launch guard active." : "Out of credits."}
-      </p>
-      <p className="mt-1 text-sm text-white/55">
-        {user
-          ? "Choose a checkout path, request a demo, or wait for reset."
-          : FREE_LAUNCH_MODE
-            ? "Try again in a minute, upload a smaller source, or switch to prompt mode."
-            : "Sign in free to keep generating and save your clips."}
-      </p>
-      {FREE_LAUNCH_MODE && !user ? null : (
-        <div className="mt-3">
-          {!user ? (
+    <div className="rounded-[18px] border border-[var(--gold-border)] bg-[var(--gold-dim)] px-5 py-5">
+      {!user ? (
+        <>
+          <p className="text-base font-semibold text-[var(--gold)]">You have used your free launch credits.</p>
+          <p className="mt-2 text-sm leading-6 text-white/70">Create an account or upgrade when paid plans open.</p>
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+            <a
+              href={primaryLinkUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center rounded-full bg-[var(--gold)] px-5 py-2.5 text-sm font-semibold text-black hover:opacity-90"
+            >
+              Join Waitlist
+            </a>
             <button
               type="button"
               onClick={() => {
-                setAuthMode("login");
-                setAuthOpen(true);
+                const text = activeResult ? JSON.stringify(activeResult, null, 2) : "";
+                if (text) void navigator.clipboard?.writeText(text);
               }}
-              className="rounded-full bg-[var(--gold)] px-5 py-2.5 text-sm font-semibold text-black hover:opacity-90"
+              className="inline-flex items-center justify-center rounded-full border border-[var(--gold-border)] px-5 py-2.5 text-sm font-medium text-[var(--gold)] hover:opacity-80"
             >
-              Sign in free
+              Save my work
             </button>
-          ) : (
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="text-sm font-semibold text-[var(--gold)]">
+            {FREE_LAUNCH_MODE ? "Free launch guard active." : "Out of credits."}
+          </p>
+          <p className="mt-1 text-sm text-white/55">Choose a checkout path, request a demo, or wait for reset.</p>
+          <div className="mt-3">
             <MoneyCtaPanel variant="compact" source="clip_studio_quota" title="Choose how to keep generating" />
-          )}
-        </div>
+          </div>
+        </>
       )}
     </div>
   ) : null;
@@ -1337,6 +1364,12 @@ export function ClipStudio({
     setBundleExportState("exporting");
     setBundleExportMessage(null);
 
+    const hasRenderedClip = orderedClips.some((clip) => clipHasRenderedMedia(clip));
+    const requestId = activeResult.request_id || "bundle";
+    const suggestedFilename = hasRenderedClip
+      ? `lwa-clip-package-${requestId}.json`
+      : `lwa-strategy-bundle-${requestId}.json`;
+
     try {
       const bundle = await exportClipBundle(
         {
@@ -1345,12 +1378,27 @@ export function ClipStudio({
         },
         token,
       );
-      const link = document.createElement("a");
-      link.href = bundle.download_url;
-      link.download = bundle.file_name || "lwa-bundle.zip";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+
+      if (bundle.download_url && !bundle.download_url.endsWith(".json")) {
+        const link = document.createElement("a");
+        link.href = bundle.download_url;
+        link.download = bundle.file_name || suggestedFilename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } else {
+        const payload = bundle.download_url ? bundle : { ...bundle, clips: activeResult.clips, request_id: requestId };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = bundle.file_name || suggestedFilename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
+
       setLatestBundleExport(bundle);
       setBundleExportState("ready");
       setBundleExportMessage(
@@ -1941,6 +1989,34 @@ export function ClipStudio({
 
         {isLoading ? <LoadingSequence stages={loadingStages} activeIndex={loadingStageIndex} onCancel={handleCancelGeneration} /> : null}
 
+        {liveStreamWarning ? (
+          <div className="rounded-[18px] border border-amber-300/30 bg-amber-300/10 px-5 py-4">
+            <p className="text-sm font-semibold text-amber-100">Live streams and blocked platform URLs may not render clips directly.</p>
+            <p className="mt-1 text-sm text-amber-100/70">Upload the source file for best results, or continue for a strategy-only package.</p>
+            <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={(e) => {
+                  setLiveStreamWarning(false);
+                  void onSubmit(e as unknown as FormEvent<HTMLFormElement>, true);
+                }}
+                className="inline-flex items-center justify-center rounded-full border border-amber-300/40 bg-amber-300/15 px-4 py-2 text-sm font-medium text-amber-100 hover:opacity-80"
+              >
+                Continue anyway
+              </button>
+              <label className="inline-flex cursor-pointer items-center justify-center rounded-full border border-[var(--divider)] bg-[var(--surface-soft)] px-4 py-2 text-sm font-medium text-ink/80 hover:opacity-80">
+                Upload file instead
+                <input
+                  type="file"
+                  accept=".mp4,.mov,.m4v,.webm,.mp3,.wav,.m4a,.aac,.ogg,.oga,.flac,video/*,audio/*"
+                  className="hidden"
+                  onChange={(e) => { setLiveStreamWarning(false); void onUploadSelected(e); }}
+                />
+              </label>
+            </div>
+          </div>
+        ) : null}
+
         {error ? <InlineAlert tone="error">{error}</InlineAlert> : null}
         {paywallCard}
       </form>
@@ -2012,6 +2088,34 @@ export function ClipStudio({
             </div>
 
             {isLoading ? <LoadingSequence stages={loadingStages} activeIndex={loadingStageIndex} onCancel={handleCancelGeneration} /> : null}
+
+            {liveStreamWarning ? (
+              <div className="rounded-[18px] border border-amber-300/30 bg-amber-300/10 px-5 py-4">
+                <p className="text-sm font-semibold text-amber-100">Live streams and blocked platform URLs may not render clips directly.</p>
+                <p className="mt-1 text-sm text-amber-100/70">Upload the source file for best results, or continue for a strategy-only package.</p>
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      setLiveStreamWarning(false);
+                      void onSubmit(e as unknown as FormEvent<HTMLFormElement>, true);
+                    }}
+                    className="inline-flex items-center justify-center rounded-full border border-amber-300/40 bg-amber-300/15 px-4 py-2 text-sm font-medium text-amber-100 hover:opacity-80"
+                  >
+                    Continue anyway
+                  </button>
+                  <label className="inline-flex cursor-pointer items-center justify-center rounded-full border border-[var(--divider)] bg-[var(--surface-soft)] px-4 py-2 text-sm font-medium text-ink/80 hover:opacity-80">
+                    Upload file instead
+                    <input
+                      type="file"
+                      accept=".mp4,.mov,.m4v,.webm,.mp3,.wav,.m4a,.aac,.ogg,.oga,.flac,video/*,audio/*"
+                      className="hidden"
+                      onChange={(e) => { setLiveStreamWarning(false); void onUploadSelected(e); }}
+                    />
+                  </label>
+                </div>
+              </div>
+            ) : null}
 
             {error ? <InlineAlert tone="error">{error}</InlineAlert> : null}
 
@@ -2314,7 +2418,11 @@ export function ClipStudio({
               disabled={bundleExportState === "exporting" || !activeResult?.clips?.length}
               className="secondary-button inline-flex w-full items-center justify-center rounded-full px-5 py-3 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
             >
-              {bundleExportState === "exporting" ? "Building bundle..." : "Export full bundle"}
+              {bundleExportState === "exporting"
+                ? "Building bundle..."
+                : renderedClipCount > 0
+                  ? "Download Clip Package"
+                  : "Download Strategy Bundle"}
             </button>
             {visibleManifestUrl ? (
               <a

--- a/lwa-web/lib/lwa-agents.ts
+++ b/lwa-web/lib/lwa-agents.ts
@@ -1,0 +1,149 @@
+export type LwaAgentId =
+  | "omega-prime"
+  | "jackal-warden"
+  | "veil-oracle"
+  | "iron-seraph"
+  | "horned-sentinel"
+  | "shadow-scribe"
+  | "grave-monk";
+
+export type LwaAgent = {
+  id: LwaAgentId;
+  name: string;
+  title: string;
+  productArea: string;
+  aiRole: string;
+  tagline: string;
+  description: string;
+  allowedActions: string[];
+  blockedActions: string[];
+  reviewRequired: true;
+  route: string;
+  visualPrompt: string;
+};
+
+const SHARED_BLOCKED_ACTIONS = [
+  "publish_without_review",
+  "deploy_to_production",
+  "delete_database",
+  "modify_secrets",
+  "change_pricing_without_approval",
+  "guarantee_income",
+  "make_legal_claims_as_final",
+];
+
+export const LWA_AGENTS: Record<LwaAgentId, LwaAgent> = {
+  "omega-prime": {
+    id: "omega-prime",
+    name: "Omega Prime",
+    title: "High Director of the Signal",
+    productArea: "Strategy and command",
+    aiRole: "product strategy, dashboard guidance, launch planning, page hierarchy",
+    tagline: "He does not chase attention. He commands it.",
+    description:
+      "Omega Prime oversees the full product signal. He reads the launch state, orders the next move, and keeps every surface aligned to the real product story.",
+    allowedActions: ["read_dashboard", "suggest_strategy", "rank_pages", "audit_launch_state"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/realm",
+    visualPrompt: "A commanding figure in dark armor with a single glowing sigil at his chest, facing the horizon.",
+  },
+  "jackal-warden": {
+    id: "jackal-warden",
+    name: "Jackal Warden",
+    title: "Guardian of the Threshold",
+    productArea: "Trust, safety, compliance",
+    aiRole: "marketplace protection, claim review, fraud warnings, disclosure checks",
+    tagline: "Every gate opens for him. Every lie dies at the door.",
+    description:
+      "Jackal Warden reviews content claims, flags overclaims, and keeps the marketplace honest. He does not allow false income promises, fake reviews, or disclosure violations past his gate.",
+    allowedActions: ["flag_overclaims", "review_marketplace_listings", "check_ftc_disclosures", "warn_fraud_patterns"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/marketplace",
+    visualPrompt: "A sharp-eyed sentinel in layered dark armor at a stone gate, one hand raised to stop passage.",
+  },
+  "veil-oracle": {
+    id: "veil-oracle",
+    name: "Veil Oracle",
+    title: "Reader of the Hidden Signal",
+    productArea: "Trend intelligence",
+    aiRole: "trend ideas, content timing, platform signals, content calendar",
+    tagline: "She sees the trend before the crowd names it.",
+    description:
+      "Veil Oracle reads platform signals and surfaces trend timing so creators can move before the wave breaks. She does not guarantee virality.",
+    allowedActions: ["suggest_trend_angles", "read_platform_signals", "build_content_calendar", "score_timing"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/realm",
+    visualPrompt: "A cloaked figure surrounded by floating fragments of data, eyes faintly luminous, reading invisible signals.",
+  },
+  "iron-seraph": {
+    id: "iron-seraph",
+    name: "Iron Seraph",
+    title: "Forgemaster of Workflows",
+    productArea: "Automation and engineering",
+    aiRole: "workflow automation, code-task drafting, deployment checks",
+    tagline: "He turns chaos into machinery.",
+    description:
+      "Iron Seraph handles the structural layer: automation tasks, deployment readiness checks, and workflow design. He does not push to production without review.",
+    allowedActions: ["draft_workflow_specs", "check_deployment_readiness", "automate_task_sequences", "review_api_contracts"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/operator",
+    visualPrompt: "A winged metallic figure with forge-light in its hands, building a framework of glowing structural lines.",
+  },
+  "horned-sentinel": {
+    id: "horned-sentinel",
+    name: "Horned Sentinel",
+    title: "Watcher of the Outer Gate",
+    productArea: "Design QA and visual framing",
+    aiRole: "layout audits, responsive QA, visual polish, page quality checks",
+    tagline: "He stands where the frame breaks.",
+    description:
+      "Horned Sentinel patrols the visual layer: contrast issues, broken layouts, mobile regressions, and off-brand moments. He flags, does not redesign.",
+    allowedActions: ["audit_contrast", "flag_layout_breaks", "check_responsive_states", "score_visual_polish"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/realm",
+    visualPrompt: "A broad-shouldered guardian with curved horns standing at the edge of a glowing interface frame.",
+  },
+  "shadow-scribe": {
+    id: "shadow-scribe",
+    name: "Shadow Scribe",
+    title: "Keeper of the Living Archive",
+    productArea: "Copy, docs, scripts, lore, knowledge base",
+    aiRole: "website copy, docs, prompt packs, training material",
+    tagline: "Nothing is forgotten. Everything becomes leverage.",
+    description:
+      "Shadow Scribe maintains the written layer of the system: product copy, documentation, prompt packs, scripts, and lore. He does not overwrite without review.",
+    allowedActions: ["draft_copy", "write_docs", "build_prompt_packs", "maintain_lore"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/realm",
+    visualPrompt: "A cloaked figure at a vast archive desk, surrounded by floating pages of text that never stop moving.",
+  },
+  "grave-monk": {
+    id: "grave-monk",
+    name: "Grave Monk",
+    title: "Voice Beyond the Silence",
+    productArea: "Voice, cadence, narration, audio",
+    aiRole: "hooks, voiceover scripts, audio direction, cadence scoring",
+    tagline: "He speaks once. The dead algorithm listens.",
+    description:
+      "Grave Monk shapes the vocal layer: hook cadence, voiceover scripts, audio direction, and the rhythm that makes a clip land. He does not post without review.",
+    allowedActions: ["score_hook_cadence", "write_voiceover_scripts", "direct_audio_angles", "review_hook_pacing"],
+    blockedActions: SHARED_BLOCKED_ACTIONS,
+    reviewRequired: true,
+    route: "/realm",
+    visualPrompt: "A still, robed figure in near-darkness, a single open hand held upward with faint sound-wave light.",
+  },
+};
+
+export function getLwaAgent(id: LwaAgentId): LwaAgent {
+  return LWA_AGENTS[id];
+}
+
+export function getAllLwaAgents(): LwaAgent[] {
+  return Object.values(LWA_AGENTS);
+}

--- a/lwa-web/lib/production-council.ts
+++ b/lwa-web/lib/production-council.ts
@@ -1,0 +1,80 @@
+export type CouncilRoleId =
+  | "founder"
+  | "product-architect"
+  | "engineer"
+  | "ai-media"
+  | "game-systems"
+  | "design"
+  | "marketplace-ops"
+  | "blockchain"
+  | "legal";
+
+export type CouncilRole = {
+  id: CouncilRoleId;
+  realTitle: string;
+  mythicTitle: string;
+  owns: string;
+};
+
+export const PRODUCTION_COUNCIL: Record<CouncilRoleId, CouncilRole> = {
+  founder: {
+    id: "founder",
+    realTitle: "Founder",
+    mythicTitle: "High Director",
+    owns: "vision, brand, capital, partnerships, final product direction",
+  },
+  "product-architect": {
+    id: "product-architect",
+    realTitle: "Product Architect",
+    mythicTitle: "Architect of Realms",
+    owns: "product structure, roadmap, user flows, system architecture",
+  },
+  engineer: {
+    id: "engineer",
+    realTitle: "Principal Full-Stack Engineer",
+    mythicTitle: "Hand of the Director",
+    owns: "website, backend, dashboard, APIs, database, deployment",
+  },
+  "ai-media": {
+    id: "ai-media",
+    realTitle: "AI Media Pipeline Engineer",
+    mythicTitle: "Forgemaster of Signals",
+    owns: "clipping, transcription, captions, hooks, scoring, rendering",
+  },
+  "game-systems": {
+    id: "game-systems",
+    realTitle: "Game Systems Designer",
+    mythicTitle: "Loremaster of the Realms",
+    owns: "classes, factions, XP, quests, progression, world logic",
+  },
+  design: {
+    id: "design",
+    realTitle: "UI/UX Designer",
+    mythicTitle: "Veilwright",
+    owns: "premium dark design, clarity, ease of use",
+  },
+  "marketplace-ops": {
+    id: "marketplace-ops",
+    realTitle: "Marketplace Ops",
+    mythicTitle: "Auditor",
+    owns: "sellers, payouts, disputes, trust, fraud prevention, marketplace rules",
+  },
+  blockchain: {
+    id: "blockchain",
+    realTitle: "Blockchain Engineer",
+    mythicTitle: "Sigilbearer",
+    owns: "optional proof systems, badges, relics, wallets, provenance",
+  },
+  legal: {
+    id: "legal",
+    realTitle: "Legal Compliance",
+    mythicTitle: "Keeper of the Charter",
+    owns: "terms, privacy, creator rules, FTC language, compliance",
+  },
+};
+
+export const COUNCIL_BRAND_LINE = "The Council builds the system. The characters guide the world.";
+
+export function getAllCouncilRoles(): CouncilRole[] {
+  return Object.values(PRODUCTION_COUNCIL);
+}

--- a/lwa-web/next.config.ts
+++ b/lwa-web/next.config.ts
@@ -1,7 +1,38 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "media-src 'self' blob: https:",
+      "connect-src 'self' https:",
+      "font-src 'self' data:",
+      "frame-ancestors 'self'",
+    ].join("; "),
+  },
+];
+
 const nextConfig: NextConfig = {
   poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/lwa-web/package-lock.json
+++ b/lwa-web/package-lock.json
@@ -383,9 +383,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -401,9 +398,6 @@
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -421,9 +415,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,9 +430,6 @@
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1094,9 +1082,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,9 +1096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1128,9 +1110,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1145,9 +1124,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1162,9 +1138,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,9 +1152,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1196,9 +1166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1213,9 +1180,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

- Fixed homepage CTA fallback paths so no card ever renders "Add path when configured"
- Fixed guest generate UX: live stream preflight, strategy-only card, export download, out-of-credits CTA
- Added character agent and production council registries
- Added homepage council line: The Council builds the system. The characters guide the world.
- Added showcase, smoke-test, and contest polish docs

## Changes

### Phase 1 — Homepage CTA fallback
- `Request custom clip pack` → `demoForm || contact || booking || getPrimaryMoneyLink()`
- `Book demo` → `booking || demoForm || contact || getPrimaryMoneyLink()`
- `Join creator/referral program` → `affiliateForm || contact || getPrimaryMoneyLink()`
- `Support the build` → unchanged, already `getPrimaryMoneyLink()`
- `DEFAULT_WHOP_URL` verified correct: `https://whop.com/lwa-app/lwa-ai-content-repurposer/`

### Phase 2 — Guest generate UX
- **Live stream preflight**: URLs matching `twitch.tv/`, `youtube.com/live`, or `/live/` now show a non-blocking amber notice before submitting, with "Continue anyway" and "Upload file instead" options
- **Strategy-only card**: Replaced black no-preview card with structured card — title "Strategy-only package", subtext "No playable preview was created for this source.", body "Use the hooks, captions, timestamps, and posting plan below.", button "Upload source file for rendered clips". No video player frame, no fake thumbnail
- **Export bundle**: Forces real file download via Blob when backend returns JSON; filename is `lwa-clip-package-{request_id}.json` (rendered clips present) or `lwa-strategy-bundle-{request_id}.json` (strategy-only)
- **Button label**: Shows "Download Clip Package" or "Download Strategy Bundle" depending on rendered clip presence
- **Result ordering**: Clip cards now render Hook → Caption → Score → Timestamp → Recovery guidance (degraded only) → Platform recommendation (available only)
- **402 paywall card**: Shows "You have used your free launch credits." with "Join Waitlist" (→ `getPrimaryMoneyLink()`) and "Save my work" (→ clipboard copy of latest result JSON). No raw backend error strings shown

### Phase 3 — Agent and council registries
- Created `lwa-web/lib/lwa-agents.ts` with 7 agents: omega-prime, jackal-warden, veil-oracle, iron-seraph, horned-sentinel, shadow-scribe, grave-monk. All have `reviewRequired: true` and shared `blockedActions`
- Created `lwa-web/lib/production-council.ts` with 9 council roles. Exports `COUNCIL_BRAND_LINE`
- Added homepage section above CTA grid with eyebrow "How LWA is built" and statement "The Council builds the system. The characters guide the world."
- No homepage redesign, no hero replacement, no section deletions

### Phase 4 — Contrast
- Strategy-only card body text bumped from `text-ink/62` to `text-ink/80` for readability on dark background

### Phase 5 — Docs
- `docs/showcase/LWA_AI_SHOWCASE_SUBMISSION.md` — contest submission template with what to say / not say
- `docs/runbooks/LWA_LIVE_SMOKE_TEST.md` — smoke test checklist, backend health check, env vars to verify, API spending decision tree
- `docs/runbooks/LWA_CONTEST_POLISH_SPRINT.md` — sprint summary, what changed, what remains

## Verification
- Backend compile: `python3 -m compileall lwa-backend/app lwa-backend/scripts` — **passed, zero errors**
- Frontend type-check: `npm run type-check` — **passed, exit 0**
- Frontend build: `npm run build` — **passed, exit 0, 59 static pages generated**

## Scope boundaries
- iOS (`lwa-ios/`) — untouched
- Backend business logic — untouched
- Marketplace payout logic — untouched
- Blockchain or social posting claims — untouched
- Pricing copy — untouched
- Safety language — untouched
- Route shapes or status codes — untouched

https://claude.ai/code/session_01UFnG8zc4bshKGir8Ku4J4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFnG8zc4bshKGir8Ku4J4S)_