### PR TITLE
feat: rebuild LWA homepage as Seven Agents world portal

### DIFF
--- a/lwa-web/app/page.tsx
+++ b/lwa-web/app/page.tsx
@@ -1,167 +1,97 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { AgentPathPortal } from "../components/AgentPathPortal";
+import { WorldHero } from "../components/WorldHero";
 import { Logo } from "../components/brand/Logo";
-import { PathPortal } from "../components/PathPortal";
 import { buildUtmUrl, getPrimaryMoneyLink } from "../lib/money-links";
 import { COUNCIL_BRAND_LINE } from "../lib/production-council";
 import { buildPageMetadata } from "../lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "LWA — AI Content Engine",
+  title: "LWA — Seven Agents Creator Engine",
   description:
-    "LWA turns long-form videos, uploads, and creator sources into short-form content packages with hooks, captions, timestamps, scores, and platform strategy.",
+    "LWA, pronounced lee-wuh, is an AI creator engine built around clipping, packaging, creator workflow, and the Seven Agents world portal.",
   path: "/",
   keywords: [
-    "LWA ai content engine",
+    "LWA lee-wuh",
+    "Seven Agents creator engine",
+    "AI clipping engine",
+    "Afro-futurist creator workflow",
     "viral clip packages",
-    "hooks captions timestamps",
-    "creator workflow",
-    "twitch stream clipping",
   ],
 });
 
 const proofPoints = [
   "Best clip first",
   "Rendered proof when available",
-  "Strategy fallback stays separate",
+  "Strategy-only results separated",
   "Hooks, captions, timestamps",
-  "Score and post order",
-  "Copy-ready package",
+  "Seven Agents path system",
+  "Future base-model identity",
 ];
 
 export default function HomePage() {
   const primaryLink = getPrimaryMoneyLink();
-  const primaryLinkUrl = buildUtmUrl(primaryLink, "homepage_hero");
+  const primaryLinkUrl = buildUtmUrl(primaryLink, "homepage_agent_world");
 
   return (
-    <section className="relative min-h-screen px-4 py-6 sm:px-6 lg:px-8">
-      {/* Cinematic background radial layers */}
+    <main className="relative min-h-screen overflow-hidden px-4 py-6 sm:px-6 lg:px-8">
+      <div className="pointer-events-none fixed inset-0 -z-10 bg-[#030305]" aria-hidden="true" />
       <div
-        className="pointer-events-none fixed inset-0 -z-10"
+        className="pointer-events-none fixed inset-0 -z-10 opacity-90"
         aria-hidden="true"
         style={{
           background:
-            "radial-gradient(ellipse 80% 60% at 50% -10%, rgba(109,92,255,0.22), transparent 70%), radial-gradient(ellipse 60% 50% at 90% 80%, rgba(185,28,28,0.18), transparent 60%), radial-gradient(ellipse 50% 40% at 10% 90%, rgba(16,185,129,0.12), transparent 60%)",
+            "radial-gradient(ellipse 90% 70% at 50% 0%, rgba(245,158,11,0.12), transparent 58%), radial-gradient(ellipse 70% 55% at 15% 78%, rgba(124,58,237,0.14), transparent 62%), radial-gradient(ellipse 70% 55% at 88% 72%, rgba(236,72,153,0.10), transparent 58%)",
         }}
       />
 
-      {/* Header */}
       <header className="mx-auto flex max-w-7xl items-center justify-between gap-4 pb-6">
         <Link href="/" aria-label="LWA home">
           <Logo animated />
         </Link>
         <nav className="hidden items-center gap-2 sm:flex">
-          <Link
-            href="/generate"
-            className="primary-button rounded-full px-5 py-2.5 text-sm font-semibold"
-          >
+          <Link href="/generate" className="primary-button rounded-full px-5 py-2.5 text-sm font-semibold">
             Enter Clip Engine
           </Link>
-          <a
-            href={primaryLinkUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="secondary-button rounded-full px-5 py-2.5 text-sm font-medium"
-          >
+          <a href={primaryLinkUrl} target="_blank" rel="noreferrer" className="secondary-button rounded-full px-5 py-2.5 text-sm font-medium">
             Support LWA
           </a>
         </nav>
       </header>
 
-      {/* Hero */}
-      <section className="mx-auto max-w-7xl pt-10 pb-14 text-center">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-[var(--accent-wine)]">
-          Any source in. Creator-ready content out.
-        </p>
-        <h1 className="mx-auto mt-6 max-w-4xl text-5xl font-semibold leading-[0.96] text-ink sm:text-7xl lg:text-[5.5rem]">
-          LWA
-        </h1>
-        <p className="mt-3 text-[11px] font-medium uppercase tracking-[0.32em] text-ink/55">
-          pronounced <span className="text-[var(--gold)]">lee-wuh</span>
-        </p>
-        <p className="mx-auto mt-4 max-w-2xl text-base leading-8 text-subtext sm:text-lg">
-          A deployed AI clipping engine that turns long-form videos, uploads,
-          and creator sources into short-form content packages — hooks,
-          captions, timestamps, scores, and platform strategy.
-        </p>
+      <WorldHero />
+      <AgentPathPortal />
 
-        {/* Cinematic character visual */}
-        <div className="relative mx-auto mt-10 max-w-xs overflow-hidden rounded-[38px] border border-white/14 shadow-[0_28px_90px_rgba(88,70,140,0.22)]">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(236,72,153,0.20),transparent_30%),radial-gradient(circle_at_78%_24%,rgba(109,92,255,0.18),transparent_34%),radial-gradient(circle_at_56%_86%,rgba(16,185,129,0.18),transparent_30%)]" />
-          <div className="relative overflow-hidden rounded-[38px] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.18))]">
-            <img
-              src="/brand-source/chars/athena.png"
-              alt="LWA — the signal engine"
-              className="h-full min-h-[280px] w-full object-cover object-center"
-            />
-            <div className="absolute inset-x-4 bottom-4 rounded-[22px] border border-white/12 bg-black/58 p-4 backdrop-blur-md">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[var(--gold)]">
-                Signal engine active
-              </p>
-              <p className="mt-1 text-sm font-semibold text-ink">
-                The characters guide the world.
-              </p>
+      <section className="mx-auto grid w-full max-w-7xl gap-4 pb-16 lg:grid-cols-[0.9fr_1.1fr]">
+        <div className="rounded-[32px] border border-white/10 bg-white/[0.035] p-6">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--gold)]">Clip Engine stays live</p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-ink">The world points back to the working product.</h2>
+          <p className="mt-4 text-sm leading-7 text-ink/62">
+            The Seven Agents are the front door, but the core product remains the deployed Clip Engine. Enter `/generate` to paste a source and create ranked clip packages.
+          </p>
+          <Link href="/generate" className="primary-button mt-6 inline-flex rounded-full px-6 py-3 text-sm font-semibold">
+            Open /generate
+          </Link>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {proofPoints.map((item) => (
+            <div key={item} className="metric-tile rounded-[24px] px-4 py-4 text-sm font-medium text-ink/80 backdrop-blur-sm">
+              {item}
             </div>
-          </div>
-        </div>
-
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <Link
-            href="/generate"
-            className="primary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-semibold"
-          >
-            Enter Clip Engine
-          </Link>
-          <Link
-            href="/operator"
-            className="secondary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-medium"
-          >
-            Operator Center
-          </Link>
+          ))}
         </div>
       </section>
 
-      {/* Path portal */}
-      <section className="mx-auto max-w-7xl pb-10">
-        <div className="mb-6 text-center">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">
-            Choose your path
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold text-ink sm:text-3xl">
-            Where do you want to go?
-          </h2>
-          <p className="mt-2 text-sm text-ink/52">
-            Hover or focus a card to see what each path takes you to.
+      <section className="mx-auto max-w-7xl pb-12">
+        <div className="rounded-[32px] border border-white/10 bg-black/35 p-6">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--gold)]">How LWA is built</p>
+          <p className="mt-2 text-base font-semibold text-ink sm:text-lg">{COUNCIL_BRAND_LINE}</p>
+          <p className="mt-4 text-xs leading-6 text-subtext/70">
+            No guaranteed virality or income claims. No live marketplace payouts, live social posting, crypto wallet collection, direct share sales, or blockchain economy. Opportunity paths are inquiry/apply first and require review where needed.
           </p>
         </div>
-        <PathPortal />
       </section>
-
-      {/* Council line */}
-      <section className="mx-auto max-w-7xl pb-4">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--accent-wine)]">
-          How LWA is built
-        </p>
-        <p className="mt-2 text-base font-semibold text-ink sm:text-lg">
-          {COUNCIL_BRAND_LINE}
-        </p>
-      </section>
-
-      {/* Proof points */}
-      <section className="mx-auto grid w-full max-w-7xl gap-3 pb-16 sm:grid-cols-3 lg:grid-cols-6">
-        {proofPoints.map((item) => (
-          <div
-            key={item}
-            className="metric-tile rounded-[22px] px-4 py-4 text-sm font-medium text-ink/80 backdrop-blur-sm"
-          >
-            {item}
-          </div>
-        ))}
-      </section>
-
-      <p className="mx-auto max-w-7xl pb-10 text-xs leading-6 text-subtext/70">
-        No guaranteed virality or income claims. No live marketplace payouts, live social posting, or blockchain economy. Whop is the live access path. All other features are in active development.
-      </p>
-    </section>
+    </main>
   );
 }

--- a/lwa-web/components/AgentPathPortal.tsx
+++ b/lwa-web/components/AgentPathPortal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { getAllLwaAgents, type LwaAgentId } from "../lib/lwa-agents";
+
+const portalMeta: Record<LwaAgentId, {
+  pathLabel: string;
+  status: "Live" | "Preview" | "Next" | "Inquiry" | "Apply" | "Soon" | "Trust";
+  cta: string;
+  route: string;
+  placement: string;
+  accent: string;
+}> = {
+  "omega-prime": {
+    pathLabel: "Clip Engine",
+    status: "Live",
+    cta: "Enter Clip Engine",
+    route: "/generate",
+    placement: "Central command",
+    accent: "rgba(245,158,11,0.34)",
+  },
+  "horned-sentinel": {
+    pathLabel: "Creator Mode",
+    status: "Preview",
+    cta: "Build Creator Package",
+    route: "/dashboard",
+    placement: "Signal lane",
+    accent: "rgba(34,211,238,0.26)",
+  },
+  "veil-oracle": {
+    pathLabel: "Director Brain",
+    status: "Next",
+    cta: "View Director Brain",
+    route: "/realm",
+    placement: "Oracle ring",
+    accent: "rgba(167,139,250,0.3)",
+  },
+  "grave-monk": {
+    pathLabel: "Opportunities",
+    status: "Inquiry",
+    cta: "Open Opportunities",
+    route: "/opportunities",
+    placement: "Gold forum",
+    accent: "rgba(245,158,11,0.25)",
+  },
+  "iron-seraph": {
+    pathLabel: "Marketplace",
+    status: "Apply",
+    cta: "Apply to Sell",
+    route: "/opportunities#marketplace",
+    placement: "Forge market",
+    accent: "rgba(236,72,153,0.24)",
+  },
+  "shadow-scribe": {
+    pathLabel: "Vault / Proof",
+    status: "Soon",
+    cta: "View Vault",
+    route: "/history",
+    placement: "Archive gate",
+    accent: "rgba(45,212,191,0.24)",
+  },
+  "jackal-warden": {
+    pathLabel: "Trust Layer",
+    status: "Trust",
+    cta: "Review Trust",
+    route: "/opportunities#legal-disclosure",
+    placement: "Firewall temple",
+    accent: "rgba(248,113,113,0.22)",
+  },
+};
+
+function statusClass(status: string) {
+  if (status === "Live") return "border-emerald-300/30 bg-emerald-300/15 text-emerald-100";
+  if (status === "Inquiry" || status === "Apply") return "border-amber-300/30 bg-amber-300/15 text-amber-100";
+  if (status === "Trust") return "border-rose-300/30 bg-rose-300/15 text-rose-100";
+  return "border-white/15 bg-white/[0.07] text-ink/70";
+}
+
+export function AgentPathPortal() {
+  const agents = getAllLwaAgents();
+  const [activeId, setActiveId] = useState<LwaAgentId | null>("omega-prime");
+
+  return (
+    <section id="agents" className="mx-auto w-full max-w-7xl py-16" aria-label="Seven Agents path portal">
+      <div className="mb-8 text-center">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-[var(--gold)]">Seven Agents Portal</p>
+        <h2 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-ink sm:text-5xl">Choose an agent. Enter a product path.</h2>
+        <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-ink/58">
+          Each LWA agent is a base model, a product guide, and a future customization foundation. Hover, focus, or tap to reveal the destination.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {agents.map((agent) => {
+            const meta = portalMeta[agent.id];
+            const isActive = activeId === agent.id;
+
+            return (
+              <Link
+                key={agent.id}
+                href={meta.route}
+                onMouseEnter={() => setActiveId(agent.id)}
+                onFocus={() => setActiveId(agent.id)}
+                onClick={() => setActiveId(agent.id)}
+                className="group relative min-h-[285px] overflow-hidden rounded-[30px] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.065),rgba(255,255,255,0.018))] p-5 transition duration-300 hover:-translate-y-1 hover:border-[var(--gold-border)] hover:shadow-[0_20px_70px_rgba(0,0,0,0.32)] focus:outline-none focus:ring-2 focus:ring-[var(--gold)]/60"
+                aria-label={`${agent.name} opens ${meta.pathLabel}`}
+              >
+                <div className="absolute inset-0 opacity-80 transition duration-300 group-hover:opacity-100" style={{ background: `radial-gradient(circle at 50% 12%, ${meta.accent}, transparent 44%)` }} />
+                <div className="absolute left-1/2 top-16 h-28 w-20 -translate-x-1/2 rounded-t-[60px] rounded-b-[24px] border border-white/15 bg-black/25 shadow-[0_0_38px_rgba(255,255,255,0.055)]" />
+                <div className="absolute left-1/2 top-9 h-12 w-12 -translate-x-1/2 rounded-full border border-white/18 bg-black/35" />
+                <div className="absolute left-1/2 top-[7.5rem] h-10 w-32 -translate-x-1/2 rounded-[100%] border border-white/10 bg-white/[0.025]" />
+
+                <div className="relative z-10 flex h-full flex-col justify-between">
+                  <div>
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-ink/48">{meta.placement}</p>
+                      <span className={`rounded-full border px-2.5 py-1 text-[9px] font-semibold uppercase tracking-[0.18em] ${statusClass(meta.status)}`}>{meta.status}</span>
+                    </div>
+                    <h3 className="mt-20 text-xl font-semibold text-ink">{agent.name}</h3>
+                    <p className="mt-1 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--gold)]">{meta.pathLabel}</p>
+                    <p className="mt-3 text-sm leading-6 text-ink/62">{agent.tagline}</p>
+                  </div>
+
+                  <div className={`mt-5 overflow-hidden transition-all duration-300 ${isActive ? "max-h-56 opacity-100" : "max-h-20 opacity-90 sm:max-h-0 sm:opacity-0 sm:group-hover:max-h-56 sm:group-hover:opacity-100 sm:group-focus:max-h-56 sm:group-focus:opacity-100"}`}>
+                    <p className="text-sm leading-6 text-ink/62">{agent.description}</p>
+                    <span className="mt-4 inline-flex rounded-full bg-[var(--gold)] px-4 py-2 text-sm font-semibold text-black">{meta.cta} →</span>
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+
+        <aside className="relative overflow-hidden rounded-[34px] border border-white/10 bg-black/45 p-6 lg:sticky lg:top-6 lg:self-start">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(245,158,11,0.18),transparent_42%)]" />
+          <div className="relative">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--gold)]">World routing</p>
+            <h3 className="mt-3 text-2xl font-semibold text-ink">No generic homepage. The agents are the map.</h3>
+            <p className="mt-4 text-sm leading-7 text-ink/62">
+              The portal is built so final 3D character renders can drop into the prepared asset paths without breaking the current build. Until then, the CSS model frames hold the world structure.
+            </p>
+            <div className="mt-6 space-y-3 text-sm text-ink/62">
+              <p><span className="text-ink">Primary:</span> Sovereign Director routes to the working Clip Engine.</p>
+              <p><span className="text-ink">Safe money paths:</span> opportunities and marketplace stay inquiry/apply first.</p>
+              <p><span className="text-ink">Future identity:</span> base-model customization remains preview-only.</p>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/lwa-web/components/WorldHero.tsx
+++ b/lwa-web/components/WorldHero.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { getLwaAgent } from "../lib/lwa-agents";
+
+const primaryAgent = getLwaAgent("omega-prime");
+
+export function WorldHero() {
+  return (
+    <section className="relative isolate mx-auto grid min-h-[78vh] w-full max-w-7xl items-center gap-10 overflow-hidden rounded-[42px] border border-white/10 bg-black/55 px-5 py-10 shadow-[0_30px_120px_rgba(0,0,0,0.55)] sm:px-8 lg:grid-cols-[0.92fr_1.08fr] lg:px-10 lg:py-12">
+      <div className="pointer-events-none absolute inset-0 -z-10" aria-hidden="true">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_-10%,rgba(216,180,92,0.16),transparent_35%),radial-gradient(circle_at_20%_65%,rgba(124,58,237,0.18),transparent_34%),radial-gradient(circle_at_84%_62%,rgba(245,158,11,0.14),transparent_36%),linear-gradient(180deg,rgba(255,255,255,0.055),rgba(0,0,0,0.32))]" />
+        <div className="absolute inset-x-8 bottom-10 h-px bg-gradient-to-r from-transparent via-[var(--gold)]/50 to-transparent" />
+        <div className="absolute left-1/2 top-1/2 h-[34rem] w-[34rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10" />
+        <div className="absolute left-1/2 top-1/2 h-[24rem] w-[24rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-[var(--gold)]/10" />
+        <div className="absolute inset-x-10 bottom-0 h-40 rounded-[100%] bg-[radial-gradient(ellipse_at_center,rgba(216,180,92,0.16),transparent_68%)]" />
+      </div>
+
+      <div className="relative z-10 text-center lg:text-left">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.34em] text-[var(--gold)]">
+          LWA — pronounced lee-wuh
+        </p>
+        <h1 className="mt-5 text-6xl font-semibold leading-[0.88] tracking-[-0.08em] text-ink sm:text-8xl lg:text-[8rem]">
+          LWA
+        </h1>
+        <p className="mt-6 max-w-xl text-lg leading-8 text-ink/72">
+          A cinematic AI creator engine for clipping, packaging, creator workflow, and the Seven Agents world system.
+        </p>
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
+          <Link href="/generate" className="primary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-semibold">
+            Enter Clip Engine
+          </Link>
+          <a href="#agents" className="secondary-button inline-flex items-center justify-center rounded-full px-7 py-3.5 text-base font-medium">
+            View Seven Agents
+          </a>
+        </div>
+        <p className="mt-5 max-w-xl text-xs leading-6 text-ink/48">
+          The agents are base-model identities and product portals. Character customization is future-ready metadata, not a live avatar editor.
+        </p>
+      </div>
+
+      <div className="relative min-h-[520px] overflow-hidden rounded-[36px] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.07),rgba(255,255,255,0.015))] p-5">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(245,158,11,0.22),transparent_34%),radial-gradient(circle_at_50%_72%,rgba(124,58,237,0.18),transparent_45%)]" />
+        <div className="absolute inset-x-10 bottom-14 h-12 rounded-[100%] border border-[var(--gold)]/25 bg-[var(--gold)]/8 blur-[1px]" />
+        <div className="absolute left-1/2 top-[54%] h-64 w-44 -translate-x-1/2 -translate-y-1/2 rounded-t-[90px] rounded-b-[36px] border border-[var(--gold)]/30 bg-[linear-gradient(180deg,rgba(255,255,255,0.12),rgba(0,0,0,0.2))] shadow-[0_0_70px_rgba(245,158,11,0.18)]" />
+        <div className="absolute left-1/2 top-[39%] h-24 w-24 -translate-x-1/2 rounded-full border border-[var(--gold)]/35 bg-black/35 shadow-[0_0_40px_rgba(245,158,11,0.22)]" />
+        <div className="absolute left-[calc(50%-6rem)] top-[50%] h-36 w-10 rotate-[-18deg] rounded-full border border-white/15 bg-white/[0.035]" />
+        <div className="absolute right-[calc(50%-6rem)] top-[50%] h-36 w-10 rotate-[18deg] rounded-full border border-white/15 bg-white/[0.035]" />
+        <div className="absolute left-1/2 top-[63%] h-28 w-56 -translate-x-1/2 rounded-[40px] border border-white/10 bg-black/25" />
+        <div className="absolute left-1/2 top-[50%] h-[23rem] w-[23rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10" />
+        <div className="absolute left-1/2 top-[50%] h-[16rem] w-[16rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-[var(--gold)]/15" />
+        <div className="absolute inset-x-5 bottom-5 rounded-[26px] border border-white/12 bg-black/62 p-5 backdrop-blur-md">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[var(--gold)]">
+            Central Base Model
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">{primaryAgent.name}</h2>
+          <p className="mt-2 text-sm leading-6 text-ink/62">{primaryAgent.description}</p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `WorldHero` as the new LWA world-entry hero with CSS-based cinematic environment/model fallback.
- Adds `AgentPathPortal` so the Seven Agents drive product navigation instead of generic SaaS cards.
- Rebuilds the homepage around the LWA Seven Agents portal while preserving `/generate` as the Clip Engine destination.
- Keeps unfinished avatar/customization/economy features framed as future-ready metadata only.

## Routes / portals

- Sovereign Director / Omega Prime → `/generate`
- Signal Warden / Horned Sentinel → `/dashboard`
- Hooded Oracle / Veil Oracle → `/realm`
- Revenue Alchemist / Grave Monk → `/opportunities`
- Market Forgemaster / Iron Seraph → `/opportunities#marketplace`
- Vault Sentinel / Shadow Scribe → `/history`
- Security Warden / Jackal Warden → `/opportunities#legal-disclosure`

## Safety boundaries

- Did not touch `lwa-ios/`.
- Did not redesign backend.
- Did not change `/generate` or ClipStudio API behavior.
- Did not add fake live 3D avatars, NFTs, wallets, payouts, share sales, or guaranteed income claims.
- Missing final art assets do not break build because current world/agent visuals use CSS fallback frames.

## Verification needed locally

```bash
cd lwa-web
npm run type-check
npm run build
cd ..
```

Closes #82.