### PR TITLE
docs: add council operating guidelines

### DIFF
--- a/COUNCIL_AUTONOMY_GUIDELINES.md
+++ b/COUNCIL_AUTONOMY_GUIDELINES.md
@@ -1,0 +1,239 @@
+# LWA Council Autonomy Guidelines
+
+## Purpose
+This document establishes the principles and guidelines for autonomous council work, enabling self-directed execution while maintaining strategic alignment and quality standards.
+
+## Core Autonomy Principles
+
+### 1. Strategic Alignment
+- **GitHub Issue #85 Integration:** All autonomous work must align with the council roadmap
+- **Live Product Protection:** Never compromise existing LWA functionality
+- **Future-Only Development:** Focus on future features without disrupting current systems
+- **Investor Readiness:** Maintain professional quality for all deliverables
+
+### 2. Decision Authority
+- **Autonomous Decision Making:** Council members can make independent decisions within their domain
+- **Cross-Council Coordination:** Coordinate with other councils for overlapping work
+- **Quality Standards:** Maintain high quality standards for all autonomous work
+- **Documentation Requirements:** Document all autonomous decisions and actions
+
+### 3. Execution Framework
+- **Template-Driven Work:** Use established templates for consistent outputs
+- **Batch Processing:** Leverage automated tools for efficiency
+- **Local Development:** Work in safe local environments
+- **Repository Integration:** Commit work with proper documentation
+
+## Autonomous Work Categories
+
+### Strategic Planning Autonomy
+- **Council Reports:** Generate comprehensive department reports independently
+- **Roadmap Updates:** Update strategic roadmaps based on progress and priorities
+- **Investor Materials:** Create professional documentation for stakeholders
+- **Technical Specifications:** Develop detailed implementation plans
+
+### Asset Creation Autonomy
+- **Blender Assets:** Create 3D models, environments, and animations independently
+- **Visual Effects:** Design particle systems and visual effects
+- **Character Development:** Create character models and animations
+- **Environment Design:** Build realm environments and spaces
+
+### Technical Development Autonomy
+- **Code Implementation:** Write clean, safe code for future features
+- **System Architecture:** Design scalable technical systems
+- **Integration Planning:** Plan integration with existing systems
+- **Testing Frameworks:** Create comprehensive testing procedures
+
+### Documentation Autonomy
+- **Technical Documentation:** Write clear technical specifications
+- **User Guides:** Create user-facing documentation
+- **API Documentation:** Document interfaces and integrations
+- **Process Documentation:** Maintain workflow and process guides
+
+## Autonomous Decision Framework
+
+### Decision Criteria
+- **Strategic Value:** Does this advance the council roadmap?
+- **Quality Impact:** Does this meet quality standards?
+- **Risk Assessment:** Does this protect the live product?
+- **Resource Efficiency:** Is this an efficient use of resources?
+
+### Decision Process
+1. **Assessment:** Evaluate the request against decision criteria
+2. **Planning:** Create a plan using appropriate templates
+3. **Execution:** Execute the work autonomously
+4. **Review:** Review and validate the results
+5. **Integration:** Integrate the work into the repository
+
+### Escalation Criteria
+- **Live Product Impact:** Any work that might affect live systems
+- **Cross-Council Conflict:** Work that conflicts with other councils
+- **Quality Issues:** Work that doesn't meet quality standards
+- **Resource Constraints:** Work that requires additional resources
+
+## Autonomous Work Standards
+
+### Quality Standards
+- **Completeness:** All deliverables must be complete and ready for use
+- **Consistency:** Follow established templates and patterns
+- **Clarity:** Clear, unambiguous documentation and code
+- **Professionalism:** High-quality, investor-ready materials
+
+### Safety Standards
+- **Live Product Protection:** Never modify live systems without explicit approval
+- **Repository Cleanliness:** Maintain clean, organized repository
+- **Testing Requirements:** Test all changes in safe environments
+- **Backup Procedures:** Maintain backups of critical work
+
+### Collaboration Standards
+- **Cross-Council Coordination:** Ensure work aligns across departments
+- **Documentation Sharing:** Share knowledge and findings
+- **Progress Transparency:** Maintain clear progress tracking
+- **Conflict Resolution:** Address conflicts through established processes
+
+## Autonomous Work Tools
+
+### Template Library
+- **Department Reports:** Standardized reporting templates
+- **Character Development:** Character creation templates
+- **Technical Specifications:** System design templates
+- **Investor Materials**: Professional presentation templates
+
+### Automation Tools
+- **Anthropic Batch API:** Automated report generation
+- **Asset Pipeline:** Automated asset creation and optimization
+- **Documentation Generation:** Automated documentation creation
+- **Quality Control:** Automated validation and testing
+
+### Development Environment
+- **Local Development:** Safe local development environment
+- **Version Control:** Git-based version management
+- **Testing Frameworks:** Comprehensive testing procedures
+- **Documentation Tools:** Professional documentation generation
+
+## Autonomous Work Examples
+
+### Example 1: Independent Character Asset Creation
+1. **Assessment:** Council identifies need for new character model
+2. **Decision:** Council decides to create character autonomously
+3. **Planning:** Use CHARACTER_TEMPLATE.md to define character specifications
+4. **Execution:** Create Blender model following template specifications
+5. **Testing:** Validate model in local environment
+6. **Documentation:** Update asset index and documentation
+7. **Integration:** Commit to repository with proper documentation
+
+### Example 2: Independent System Architecture Design
+1. **Assessment:** Council identifies need for system architecture
+2. **Decision:** Council decides to design architecture autonomously
+3. **Planning:** Use DEPARTMENT_REPORT_TEMPLATE.md for specification
+4. **Execution:** Write comprehensive technical specification
+5. **Testing:** Validate architecture through review
+6. **Documentation:** Create implementation guide
+7. **Integration:** Commit specification to repository
+
+### Example 3: Independent Council Report Generation
+1. **Assessment:** Council needs quarterly report
+2. **Decision:** Council decides to generate report autonomously
+3. **Planning:** Use Anthropic Batch API for automated generation
+4. **Execution:** Generate reports using established prompts
+5. **Testing:** Review and validate report content
+6. **Documentation:** Update council status and next steps
+7. **Integration:** Commit reports to repository
+
+## Autonomous Work Triggers
+
+### Time-Based Triggers
+- **Weekly:** Council status updates and progress reports
+- **Monthly:** Comprehensive council reports and planning
+- **Quarterly:** Strategic reviews and roadmap updates
+- **Annually:** Annual planning and budget reviews
+
+### Event-Based Triggers
+- **New Requirements:** When new requirements are identified
+- **System Updates:** When systems need updates or changes
+- **Issue Resolution:** When issues need to be addressed
+- **Opportunity Identification:** When new opportunities arise
+
+### Priority-Based Triggers
+- **High Priority:** Critical system issues or investor needs
+- **Medium Priority:** Regular council operations and planning
+- **Low Priority:** Enhancement opportunities and improvements
+
+## Autonomous Work Metrics
+
+### Productivity Metrics
+- **Deliverables Completed:** Number of completed deliverables
+- **Quality Score:** Quality assessment of completed work
+- **Timeline Adherence:** Adherence to planned timelines
+- **Resource Efficiency**: Efficient use of resources and tools
+
+### Quality Metrics
+- **Completeness:** Percentage of required elements included
+- **Accuracy:** Accuracy of technical specifications and documentation
+- **Consistency:** Consistency with established standards and patterns
+- **Professionalism**: Professional quality of outputs
+
+### Impact Metrics
+- **Strategic Alignment:** Alignment with strategic objectives
+- **Stakeholder Satisfaction:** Satisfaction of stakeholders and investors
+- **System Improvement:** Improvement in system capabilities
+- **Risk Reduction:** Reduction in identified risks
+
+## Autonomous Work Challenges
+
+### Common Challenges
+- **Scope Creep:** Maintaining focus on defined deliverables
+- **Quality Control:** Ensuring high quality in autonomous work
+- **Coordination:** Coordinating work across multiple councils
+- **Resource Management:** Managing resources effectively
+
+### Mitigation Strategies
+- **Clear Boundaries:** Maintain clear scope and boundaries
+- **Quality Standards:** Implement comprehensive quality control
+- **Regular Reviews:** Conduct regular cross-council reviews
+- **Resource Planning:** Plan resource allocation carefully
+
+### Risk Management
+- **Live Product Risk:** Never compromise live systems
+- **Quality Risk:** Maintain high quality standards
+- **Coordination Risk:** Ensure proper coordination
+- **Resource Risk**: Manage resources efficiently
+
+## Autonomous Work Success Criteria
+
+### Success Indicators
+- **Completed Deliverables:** All planned deliverables completed
+- **Quality Standards:** All work meets quality standards
+- **Timeline Adherence:** Work completed within planned timelines
+- **Stakeholder Satisfaction:** Stakeholders satisfied with outcomes
+
+### Continuous Improvement
+- **Process Refinement:** Continuously refine processes
+- **Tool Enhancement**: Enhance tools and templates
+- **Skill Development:** Develop skills and capabilities
+- **Knowledge Sharing:** Share knowledge and best practices
+
+## Council Autonomy Matrix
+
+### High Autonomy Areas
+- **Asset Creation:** Full autonomy for Blender assets and visual effects
+- **Documentation:** Full autonomy for technical and user documentation
+- **Planning:** Full autonomy for strategic planning and roadmap updates
+- **Testing:** Full autonomy for testing framework development
+
+### Medium Autonomy Areas
+- **Code Implementation:** Autonomy with cross-council coordination
+- **System Architecture:** Autonomy with stakeholder review
+- **Integration Planning:** Autonomy with live system protection
+- **Quality Control:** Autonomy with established standards
+
+### Low Autonomy Areas
+- **Live Product Changes:** No autonomy without explicit approval
+- **Cross-Council Conflicts:** Requires coordination and resolution
+- **Resource Allocation:** Requires coordination with other councils
+- **Strategic Decisions:** Requires council-wide alignment
+
+## Conclusion
+
+The LWA Council Autonomy Guidelines enable self-directed work that advances the creator-world engine while maintaining strategic alignment and quality standards. By following these guidelines, council members can work autonomously to achieve strategic objectives and maintain high quality standards.
+
+The key to success is maintaining the balance between autonomous decision-making and strategic alignment, ensuring that all work advances the council objectives while protecting the stability and reliability of the live product.

--- a/COUNCIL_COMMUNICATION_PROTOCOLS.md
+++ b/COUNCIL_COMMUNICATION_PROTOCOLS.md
@@ -1,0 +1,323 @@
+# LWA Council Communication Protocols
+
+## Purpose
+This document establishes communication protocols for LWA council operations, ensuring effective coordination and information flow while maintaining autonomy and efficiency.
+
+## Communication Principles
+
+### Core Principles
+- **Clarity:** Communication should be clear and unambiguous
+- **Timeliness:** Communication should be timely and relevant
+- **Efficiency:** Communication should be efficient and purposeful
+- **Transparency:** Communication should be transparent and honest
+- **Respect:** Communication should be respectful and professional
+
+### Communication Channels
+- **Repository Communication:** GitHub issues, pull requests, and documentation
+- **Direct Communication:** Direct messaging for urgent matters
+- **Council Meetings:** Regular council meetings for coordination
+- **Documentation:** Written documentation for persistent information
+
+## Repository Communication
+
+### GitHub Issues
+#### Issue Creation
+- **Purpose:** Track tasks, bugs, and feature requests
+- **Format:** Use structured issue templates
+- **Priority:** Assign appropriate priority levels
+- **Labels:** Use consistent labeling system
+
+#### Issue Management
+- **Assignment:** Assign issues to appropriate council members
+- **Updates:** Provide regular updates on issue progress
+- **Resolution:** Resolve issues with clear resolution notes
+- **Documentation:** Document resolution in repository
+
+#### Issue Templates
+```markdown
+## Issue Type
+[ ] Bug Report
+[ ] Feature Request
+[ ] Task
+[ ] Documentation
+[ ] Other
+
+## Priority
+[ ] High
+[ ] Medium
+[ ] Low
+
+## Council
+[ ] Product Command
+[ ] Frontend/UX
+[ ] Blender Forge
+[ ] VFX/Effects
+[ ] Combat/Motion Controls
+[ ] AI NPC
+[ ] Game Systems
+[ ] Blockchain/NFT
+[ ] MCP/Connectors
+[ ] XR/VR/AR
+[ ] UDP/Multiplayer
+[ ] Security/Legal/Truth
+
+## Description
+[Detailed description of the issue]
+
+## Steps to Reproduce
+[Steps to reproduce the issue]
+
+## Expected Behavior
+[Expected behavior]
+
+## Actual Behavior
+[Actual behavior]
+
+## Environment
+[Environment information]
+
+## Additional Context
+[Additional context]
+```
+
+### Pull Requests
+#### Pull Request Creation
+- **Purpose:** Propose changes to repository
+- **Format:** Use structured pull request templates
+- **Review:** Ensure proper review process
+- **Documentation:** Document changes thoroughly
+
+#### Pull Request Template
+```markdown
+## Changes
+[Brief description of changes]
+
+## Purpose
+[Purpose of changes]
+
+## Testing
+[Testing performed]
+
+## Documentation
+[Documentation updated]
+
+## Impact
+[Impact on existing systems]
+
+## Checklist
+- [ ] Code follows style guidelines
+- [ ] Tests pass
+- [ ] Documentation updated
+- [ ] No breaking changes
+```
+
+### Documentation Updates
+#### Update Process
+- **Identify Need:** Identify documentation that needs updating
+- **Create Draft:** Create draft documentation updates
+- **Review:** Review updates with relevant stakeholders
+- **Commit:** Commit updates with clear messages
+
+#### Documentation Standards
+- **Format:** Use Markdown format
+- **Structure:** Use consistent structure
+- **Language:** Use clear, professional language
+- **Versioning:** Use version control for documentation
+
+## Direct Communication
+
+### When to Use Direct Communication
+- **Urgent Issues:** Time-sensitive issues requiring immediate attention
+- **Complex Discussions:** Complex topics requiring detailed discussion
+- **Sensitive Information:** Information not suitable for public repository
+- **Coordination Needs:** Coordination between multiple councils
+
+### Direct Communication Channels
+- **Slack/Discord:** Real-time messaging for urgent matters
+- **Email:** Formal communication for important decisions
+- **Video Calls:** Face-to-face communication for complex discussions
+- **Phone Calls:** Urgent communication when other channels unavailable
+
+### Direct Communication Guidelines
+- **Professionalism:** Maintain professional tone and language
+- **Clarity:** Be clear and concise in communication
+- **Documentation:** Document important discussions in repository
+- **Follow-up:** Follow up on discussions with repository updates
+
+## Council Meetings
+
+### Meeting Types
+- **Weekly Council Meetings:** Regular coordination meetings
+- **Strategic Planning Meetings:** Strategic planning sessions
+- **Issue Resolution Meetings:** Meetings to resolve specific issues
+- **Review Meetings:** Review of progress and outcomes
+
+### Meeting Structure
+#### Weekly Council Meetings
+- **Duration:** 60 minutes
+- **Frequency:** Weekly
+- **Participants:** All council members
+- **Agenda:** Progress updates, issue discussion, planning
+
+#### Strategic Planning Meetings
+- **Duration:** 2-4 hours
+- **Frequency:** Monthly or quarterly
+- **Participants:** Council leadership and relevant members
+- **Agenda:** Strategic review, planning, decision-making
+
+### Meeting Protocols
+- **Agenda:** Send agenda in advance
+- **Preparation:** Come prepared with updates and questions
+- **Participation:** Active participation from all members
+- **Follow-up:** Follow up with repository updates
+
+### Meeting Documentation
+- **Meeting Notes:** Document meeting notes in repository
+- **Action Items:** Track action items in issues
+- **Decisions:** Document decisions in repository
+- **Follow-up:** Follow up on action items
+
+## Communication Standards
+
+### Written Communication
+#### Language Standards
+- **Professionalism:** Use professional language
+- **Clarity:** Be clear and concise
+- **Consistency:** Use consistent terminology
+- **Accuracy:** Ensure accuracy of information
+
+#### Format Standards
+- **Markdown:** Use Markdown for repository communication
+- **Structure:** Use consistent structure
+- **Formatting:** Use proper formatting for readability
+- **Links:** Use proper links for references
+
+#### Tone Standards
+- **Respectful:** Maintain respectful tone
+- **Constructive:** Provide constructive feedback
+- **Collaborative:** Foster collaborative environment
+- **Supportive:** Be supportive of colleagues
+
+### Visual Communication
+#### Diagrams and Charts
+- **Purpose:** Use diagrams to clarify complex concepts
+- **Tools:** Use appropriate tools for diagram creation
+- **Format:** Use standard formats for diagrams
+- **Accessibility:** Ensure diagrams are accessible
+
+#### Screenshots and Images
+- **Purpose:** Use screenshots to illustrate points
+- **Quality:** Use high-quality images
+- **Relevance:** Ensure images are relevant
+- **Size:** Optimize image size for repository
+
+## Communication Workflows
+
+### Issue Resolution Workflow
+1. **Issue Identification:** Identify issue in repository
+2. **Issue Assignment:** Assign issue to appropriate council
+3. **Discussion:** Discuss issue in repository comments
+4. **Resolution:** Resolve issue with clear documentation
+5. **Closure:** Close issue with resolution notes
+
+### Feature Development Workflow
+1. **Feature Proposal:** Propose feature in repository
+2. **Discussion:** Discuss feature in repository
+3. **Decision:** Make decision on feature development
+4. **Implementation:** Implement feature with documentation
+5. **Review:** Review implementation with pull request
+6. **Integration:** Integrate feature into repository
+
+### Strategic Planning Workflow
+1. **Planning Session:** Conduct planning session
+2. **Documentation:** Document planning outcomes
+3. **Repository Update:** Update repository with plan
+4. **Implementation:** Implement plan with tracking
+5. **Review:** Review progress regularly
+6. **Adjustment:** Adjust plan as needed
+
+## Communication Tools
+
+### Repository Tools
+- **GitHub Issues:** Issue tracking and management
+- **GitHub Pull Requests:** Code review and integration
+- **GitHub Wiki:** Documentation and knowledge sharing
+- **GitHub Discussions:** Community discussion
+
+### Communication Tools
+- **Slack/Discord:** Real-time messaging
+- **Email:** Formal communication
+- **Video Conferencing:** Face-to-face communication
+- **Project Management:** Task and project tracking
+
+### Documentation Tools
+- **Markdown:** Text formatting
+- **Diagrams:** Visual communication
+- **Screenshots:** Visual illustration
+- **Templates:** Standardized formats
+
+## Communication Challenges
+
+### Common Challenges
+- **Communication Overload:** Too much communication
+- **Miscommunication:** Misunderstanding of messages
+- **Information Gaps:** Missing information
+- **Coordination Issues:** Poor coordination between councils
+
+### Mitigation Strategies
+- **Prioritization:** Prioritize communication channels
+- **Clarity:** Ensure clarity in communication
+- **Documentation:** Document important information
+- **Coordination:** Improve coordination processes
+
+### Risk Management
+- **Communication Risks:** Assess communication risks
+- **Mitigation Planning:** Plan mitigation strategies
+- **Monitoring:** Monitor communication effectiveness
+- **Improvement:** Continuously improve communication
+
+## Communication Metrics
+
+### Effectiveness Metrics
+- **Response Time:** Time to respond to communications
+- **Resolution Time:** Time to resolve issues
+- **Satisfaction:** Stakeholder satisfaction with communication
+- **Quality:** Quality of communication
+
+### Efficiency Metrics
+- **Communication Volume:** Volume of communications
+- **Channel Efficiency:** Efficiency of communication channels
+- **Process Efficiency:** Efficiency of communication processes
+- **Resource Efficiency**: Efficiency of communication resources
+
+### Quality Metrics
+- **Clarity:** Clarity of communication
+- **Accuracy:** Accuracy of information
+- **Completeness:** Completeness of communication
+- **Professionalism**: Professionalism of communication
+
+## Communication Best Practices
+
+### Regular Practices
+- **Daily Updates:** Daily progress updates in repository
+- **Weekly Reviews:** Weekly review meetings
+- **Monthly Planning:** Monthly strategic planning
+- **Quarterly Reviews**: Quarterly comprehensive reviews
+
+### Documentation Practices
+- **Document Everything:** Document all important communications
+- **Use Templates:** Use standardized templates
+- **Version Control:** Use version control for documentation
+- **Regular Updates:** Update documentation regularly
+
+### Collaboration Practices
+- **Cross-Council Coordination:** Coordinate between councils
+- **Stakeholder Communication:** Communicate with stakeholders
+- **Community Engagement:** Engage with community
+- **Feedback Collection:** Collect and act on feedback
+
+## Conclusion
+
+The LWA Council Communication Protocols provide comprehensive guidelines for effective communication while maintaining autonomy and efficiency. By following these protocols, council members can ensure that communication is clear, timely, and effective.
+
+The key to effective communication is maintaining the balance between autonomy and coordination, ensuring that information flows efficiently while enabling autonomous work and decision-making.

--- a/COUNCIL_CONTRIBUTION_GUIDELINES.md
+++ b/COUNCIL_CONTRIBUTION_GUIDELINES.md
@@ -1,0 +1,288 @@
+# LWA Council Contribution Guidelines
+
+## Purpose
+This document establishes comprehensive guidelines for contributing to LWA council work, ensuring high-quality, consistent, and valuable contributions while maintaining autonomous work principles.
+
+## Contribution Framework
+
+### Contribution Types
+- **Strategic Contributions:** Strategic planning and roadmap development
+- **Technical Contributions:** Technical specifications and implementations
+- **Asset Contributions:** Blender assets, visual effects, and creative content
+- **Documentation Contributions:** Technical documentation and user guides
+
+### Contribution Levels
+- **Level 1: Documentation** - Reports, specifications, and guides
+- **Level 2: Assets** - Blender models, textures, and visual effects
+- **Level 3: Code** - Feature implementations and system architecture
+- **Level 4: Integration** - Full system integration and deployment
+
+## Contribution Process
+
+### Step 1: Identify Contribution Opportunity
+1. **Assessment:** Assess current needs and gaps
+2. **Priority:** Determine priority level and impact
+3. **Resources:** Evaluate resource requirements
+4. **Alignment:** Ensure alignment with council roadmap
+
+### Step 2: Plan Contribution
+1. **Scope Definition:** Define scope and deliverables
+2. **Timeline:** Establish realistic timeline
+3. **Quality Standards:** Apply quality standards
+4. **Documentation:** Plan documentation requirements
+
+### Step 3: Execute Contribution
+1. **Development:** Execute contribution according to plan
+2. **Testing:** Test contribution thoroughly
+3. **Documentation:** Document contribution properly
+4. **Review:** Conduct self-review and peer review
+
+### Step 4: Integration
+1. **Quality Assurance:** Ensure quality standards are met
+2. **Repository Integration:** Integrate into repository
+3. **Communication:** Communicate contribution to stakeholders
+4. **Follow-up:** Monitor contribution impact and usage
+
+## Contribution Standards
+
+### Quality Standards
+- **Completeness:** All required elements are complete
+- **Accuracy:** All information is accurate and correct
+- **Consistency:** Follows established patterns and standards
+- **Professionalism:** Meets professional quality standards
+
+### Technical Standards
+- **Code Quality:** Clean, maintainable, well-documented code
+- **Asset Quality:** High-quality, optimized assets
+- **Documentation Quality:** Clear, comprehensive documentation
+- **Integration Quality:** Seamless integration with existing systems
+
+### Creative Standards
+- **Originality:** Original creative work
+- **Consistency:** Consistent with LWA aesthetic and themes
+- **Quality:** High-quality creative output
+- **Innovation:** Innovative approaches and ideas
+
+## Contribution Types
+
+### Strategic Contributions
+#### Council Reports
+- **Purpose:** Comprehensive department reporting
+- **Format:** Use DEPARTMENT_REPORT_TEMPLATE.md
+- **Content:** Strategic analysis, planning, and recommendations
+- **Quality:** Professional, comprehensive, actionable
+
+#### Roadmap Updates
+- **Purpose:** Update strategic roadmap
+- **Format:** Structured roadmap documentation
+- **Content:** Timeline, milestones, dependencies
+- **Quality:** Clear, realistic, achievable
+
+#### Investor Materials
+- **Purpose:** Create investor-facing materials
+- **Format:** Professional presentation format
+- **Content:** Business case, financial projections, market analysis
+- **Quality:** Professional, compelling, accurate
+
+### Technical Contributions
+#### System Architecture
+- **Purpose:** Design system architecture
+- **Format:** Technical specification format
+- **Content:** System design, interfaces, data flows
+- **Quality:** Comprehensive, feasible, scalable
+
+#### Feature Implementation
+- **Purpose:** Implement new features
+- **Format:** Code with documentation
+- **Content:** Feature code, tests, documentation
+- **Quality:** Clean, tested, documented
+
+#### API Development
+- **Purpose:** Develop API interfaces
+- **Format:** API specification and implementation
+- **Content:** API design, implementation, documentation
+- **Quality:** Well-designed, documented, tested
+
+### Asset Contributions
+#### Blender Models
+- **Purpose:** Create 3D models
+- **Format:** Blender .blend files
+- **Content:** High-quality 3D models
+- **Quality:** Optimized, professional, consistent
+
+#### Visual Effects
+- **Purpose:** Create visual effects
+- **Format:** Particle systems and effects
+- **Content:** High-quality visual effects
+- **Quality:** Optimized, impressive, consistent
+
+#### Textures and Materials
+- **Purpose:** Create textures and materials
+- **Format:** Image files and material definitions
+- **Content:** High-quality textures and materials
+- **Quality:** Optimized, professional, consistent
+
+### Documentation Contributions
+#### Technical Documentation
+- **Purpose:** Create technical documentation
+- **Format:** Markdown documentation
+- **Content:** Comprehensive technical information
+- **Quality:** Clear, accurate, complete
+
+#### User Guides
+- **Purpose:** Create user documentation
+- **Format:** User-friendly documentation
+- **Content:** Step-by-step instructions
+- **Quality:** Clear, helpful, accurate
+
+#### API Documentation
+- **Purpose:** Create API documentation
+- **Format:** API specification format
+- **Content:** Complete API information
+- **Quality:** Comprehensive, accurate, usable
+
+## Contribution Guidelines
+
+### Before Contributing
+1. **Review Guidelines:** Review contribution guidelines thoroughly
+2. **Assess Need:** Assess contribution need and impact
+3. **Plan Approach:** Plan approach and timeline
+4. **Gather Resources:** Gather necessary resources and tools
+
+### During Contribution
+1. **Follow Standards:** Follow established standards and patterns
+2. **Document Progress:** Document progress regularly
+3. **Seek Feedback:** Seek feedback from peers
+4. **Maintain Quality:** Maintain high quality standards
+
+### After Contribution
+1. **Review Results:** Review contribution results
+2. **Gather Feedback:** Gather feedback from users
+3. **Document Lessons:** Document lessons learned
+4. **Plan Improvements:** Plan future improvements
+
+## Contribution Tools
+
+### Development Tools
+- **IDE:** Use appropriate IDE for development
+- **Version Control:** Use Git for version control
+- **Testing Tools:** Use appropriate testing tools
+- **Documentation Tools:** Use appropriate documentation tools
+
+### Asset Tools
+- **Blender:** Use Blender for 3D modeling
+- **Texture Tools:** Use appropriate texture tools
+- **Effect Tools:** Use appropriate effect tools
+- **Optimization Tools:** Use appropriate optimization tools
+
+### Communication Tools
+- **Repository:** Use repository for documentation
+- **Issues:** Use issues for tracking
+- **Discussions:** Use discussions for collaboration
+- **Meetings:** Use meetings for coordination
+
+## Contribution Review
+
+### Self-Review
+1. **Quality Check:** Check quality against standards
+2. **Completeness Check:** Ensure completeness
+3. **Accuracy Check:** Verify accuracy
+4. **Documentation Check:** Verify documentation
+
+### Peer Review
+1. **Technical Review:** Review technical aspects
+2. **Quality Review:** Review quality aspects
+3. **Standards Review:** Review standards compliance
+4. **Integration Review:** Review integration aspects
+
+### Stakeholder Review
+1. **User Review:** Review from user perspective
+2. **Business Review:** Review from business perspective
+3. **Technical Review:** Review from technical perspective
+4 **Strategic Review:** Review from strategic perspective
+
+## Contribution Metrics
+
+### Quality Metrics
+- **Completeness Score:** Percentage of required elements
+- **Accuracy Score:** Percentage of accurate information
+- **Consistency Score:** Consistency with standards
+- **Professionalism Score:** Professional quality assessment
+
+### Impact Metrics
+- **Strategic Value:** Strategic value of contribution
+- **User Value:** Value to end users
+- **Business Value:** Business value of contribution
+- **Technical Value:** Technical value of contribution
+
+### Process Metrics
+- **Timeliness:** Timeliness of contribution
+- **Efficiency:** Efficiency of contribution process
+- **Collaboration:** Collaboration effectiveness
+- **Learning:** Learning and development
+
+## Contribution Challenges
+
+### Common Challenges
+- **Quality Issues:** Maintaining high quality standards
+- **Timeline Issues:** Meeting realistic timelines
+- **Resource Issues:** Managing resource constraints
+- **Coordination Issues:** Coordinating with other contributors
+
+### Mitigation Strategies
+- **Quality Control:** Implement quality control processes
+- **Planning:** Plan contributions carefully
+- **Resource Management:** Manage resources efficiently
+- **Communication:** Maintain clear communication
+
+### Risk Management
+- **Quality Risks:** Assess and mitigate quality risks
+- **Timeline Risks:** Assess and mitigate timeline risks
+- **Resource Risks:** Assess and mitigate resource risks
+- **Coordination Risks:** Assess and mitigate coordination risks
+
+## Contribution Recognition
+
+### Recognition Types
+- **Quality Recognition:** Recognition for high-quality contributions
+- **Innovation Recognition:** Recognition for innovative contributions
+- **Impact Recognition:** Recognition for high-impact contributions
+- **Collaboration Recognition:** Recognition for collaborative contributions
+
+### Recognition Process
+1. **Nomination:** Nominate contributions for recognition
+2. **Evaluation:** Evaluate contributions against criteria
+3. **Selection:** Select contributions for recognition
+4. **Communication:** Communicate recognition to contributors
+
+### Recognition Benefits
+- **Motivation:** Motivate contributors to maintain high standards
+- **Learning:** Learn from recognized contributions
+- **Community:** Build community of excellence
+- **Growth:** Promote growth and development
+
+## Contribution Evolution
+
+### Continuous Improvement
+- **Process Improvement:** Continuously improve contribution processes
+- **Standard Updates:** Update standards as needed
+- **Tool Enhancement:** Enhance tools and resources
+- **Knowledge Sharing**: Share knowledge and best practices
+
+### Skill Development
+- **Technical Skills:** Develop technical skills
+- **Creative Skills:** Develop creative skills
+- **Communication Skills:** Develop communication skills
+- **Leadership Skills:** Develop leadership skills
+
+### Community Building
+- **Collaboration:** Foster collaboration among contributors
+- **Mentorship:** Provide mentorship to new contributors
+- **Knowledge Sharing:** Share knowledge and expertise
+- **Community Engagement**: Engage with broader community
+
+## Conclusion
+
+The LWA Council Contribution Guidelines provide comprehensive guidance for contributing to LWA council work while maintaining high standards and autonomous work principles. By following these guidelines, contributors can ensure that their contributions are valuable, high-quality, and aligned with strategic objectives.
+
+The key to successful contribution is maintaining the balance between autonomy and quality, ensuring that contributions advance the LWA platform while meeting professional standards and stakeholder needs.

--- a/COUNCIL_DECISION_FRAMEWORK.md
+++ b/COUNCIL_DECISION_FRAMEWORK.md
@@ -1,0 +1,229 @@
+# LWA Council Decision Framework
+
+## Purpose
+This document establishes the decision-making framework for LWA council operations, enabling autonomous decision-making while maintaining strategic alignment and quality standards.
+
+## Decision Authority Matrix
+
+### High Authority Decisions
+- **Strategic Direction:** Council can make autonomous strategic decisions
+- **Technical Specifications:** Council can make autonomous technical decisions
+- **Asset Creation:** Council can make autonomous asset creation decisions
+- **Documentation:** Council can make autonomous documentation decisions
+
+### Medium Authority Decisions
+- **Code Implementation:** Council can make decisions with cross-council coordination
+- **System Architecture:** Council can make decisions with stakeholder review
+- **Integration Planning:** Council can make decisions with live system protection
+- **Resource Allocation:** Council can make decisions with resource constraints
+
+### Low Authority Decisions
+- **Live Product Changes:** No authority without explicit approval
+- **Cross-Council Conflicts:** Requires coordination and resolution
+- **Budget Allocation:** Requires organizational approval
+- **Strategic pivots:** Requires council-wide alignment
+
+## Decision Criteria
+
+### Primary Criteria
+- **Strategic Alignment:** Does this advance the council roadmap?
+- **Quality Impact:** Does this meet quality standards?
+- **Risk Assessment:** Does this protect the live product?
+- **Resource Efficiency:** Is this an efficient use of resources?
+
+### Secondary Criteria
+- **Stakeholder Value:** Does this create value for stakeholders?
+- **User Impact:** Does this benefit end users?
+- **Technical Feasibility:** Is this technically feasible?
+- **Timeline Realism:** Is this achievable within realistic timeframe?
+
+### Tertiary Criteria
+- **Innovation Value:** Does this introduce innovation?
+- **Learning Opportunity:** Does this provide learning opportunities?
+- **Scalability:** Does this scale appropriately?
+- **Maintainability:** Is this maintainable long-term?
+
+## Decision Process
+
+### Step 1: Decision Identification
+1. **Identify Decision:** Clearly define the decision to be made
+2. **Assess Authority:** Determine decision authority level
+3. **Gather Information:** Collect relevant information and data
+4. **Identify Stakeholders:** Identify affected stakeholders
+
+### Step 2: Analysis Phase
+1. **Apply Criteria:** Apply decision criteria to options
+2. **Risk Assessment:** Assess risks and mitigation strategies
+3. **Resource Analysis:** Analyze resource requirements
+4. **Timeline Analysis:** Analyze timeline implications
+
+### Step 3: Decision Making
+1. **Evaluate Options:** Evaluate all available options
+2. **Select Best Option:** Select option that best meets criteria
+3. **Document Decision:** Document decision and rationale
+4. **Communicate Decision:** Communicate decision to stakeholders
+
+### Step 4: Implementation Phase
+1. **Create Implementation Plan:** Create detailed implementation plan
+2. **Execute Decision:** Execute decision according to plan
+3. **Monitor Progress:** Monitor implementation progress
+4. **Adjust as Needed:** Adjust plan as needed
+
+### Step 5: Review Phase
+1. **Evaluate Outcomes:** Evaluate decision outcomes
+2. **Lessons Learned:** Identify lessons learned
+3. **Process Improvement:** Improve decision process
+4. **Document Results:** Document results and learning
+
+## Decision Types
+
+### Strategic Decisions
+- **Roadmap Planning:** Decisions about strategic direction
+- **Priority Setting:** Decisions about priority levels
+- **Resource Allocation:** Decisions about resource distribution
+- **Partnership Decisions:** Decisions about partnerships and collaborations
+
+### Technical Decisions
+- **Architecture Decisions:** Decisions about system architecture
+- **Technology Selection:** Decisions about technology choices
+- **Implementation Decisions:** Decisions about implementation approaches
+- **Integration Decisions:** Decisions about system integration
+
+### Operational Decisions
+- **Process Decisions:** Decisions about operational processes
+- **Quality Decisions:** Decisions about quality standards
+- **Timeline Decisions:** Decisions about timelines and schedules
+- **Resource Decisions:** Decisions about resource utilization
+
+### Creative Decisions
+- **Asset Creation:** Decisions about asset creation
+- **Design Decisions:** Decisions about design approaches
+- **Content Decisions:** Decisions about content creation
+- **Innovation Decisions:** Decisions about innovation initiatives
+
+## Decision Tools
+
+### Decision Matrices
+- **Criteria Matrix:** Weight criteria for decision evaluation
+- **Risk Matrix:** Assess risks and mitigation strategies
+- **Resource Matrix:** Evaluate resource requirements
+- **Timeline Matrix:** Evaluate timeline implications
+
+### Analytical Tools
+- **SWOT Analysis:** Analyze strengths, weaknesses, opportunities, threats
+- **Cost-Benefit Analysis:** Analyze costs and benefits
+- **Risk Assessment:** Assess risks and mitigation strategies
+- **Stakeholder Analysis:** Analyze stakeholder impacts
+
+### Visualization Tools
+- **Decision Trees:** Visualize decision paths
+- **Flowcharts:** Visualize decision processes
+- **Gantt Charts:** Visualize timelines
+- **Dashboards:** Visualize decision metrics
+
+## Decision Documentation
+
+### Decision Records
+- **Decision ID:** Unique identifier for each decision
+- **Decision Date:** Date decision was made
+- **Decision Maker:** Who made the decision
+- **Decision Rationale:** Rationale for decision
+- **Decision Outcome:** Outcome of decision
+
+### Decision Logs
+- **Decision Log:** Comprehensive log of all decisions
+- **Decision Summary:** Summary of key decisions
+- **Decision Trends:** Trends in decision patterns
+- **Decision Metrics:** Metrics on decision effectiveness
+
+### Decision Communication
+- **Decision Announcements:** Communicate decisions to stakeholders
+- **Decision Updates:** Provide updates on decision progress
+- **Decision Results:** Communicate decision results
+- **Decision Learning:** Share lessons learned
+
+## Decision Challenges
+
+### Common Challenges
+- **Information Gaps:** Insufficient information for decision
+- **Conflicting Priorities:** Conflicting priorities and objectives
+- **Resource Constraints:** Limited resources for implementation
+- **Timeline Pressure:** Pressure to make quick decisions
+
+### Mitigation Strategies
+- **Information Gathering:** Gather comprehensive information
+- **Prioritization:** Prioritize objectives and requirements
+- **Resource Planning:** Plan resource allocation carefully
+- **Timeline Management:** Manage timelines realistically
+
+### Risk Management
+- **Decision Risks:** Assess risks associated with decisions
+- **Mitigation Planning:** Plan risk mitigation strategies
+- **Contingency Planning:** Plan for contingencies
+- **Monitoring:** Monitor decision outcomes
+
+## Decision Success Metrics
+
+### Decision Quality Metrics
+- **Decision Accuracy:** Accuracy of decisions
+- **Decision Timeliness:** Timeliness of decisions
+- **Decision Consistency:** Consistency of decisions
+- **Decision Effectiveness:** Effectiveness of decisions
+
+### Process Metrics
+- **Decision Speed:** Speed of decision-making
+- **Decision Efficiency:** Efficiency of decision process
+- **Decision Satisfaction:** Stakeholder satisfaction with decisions
+- **Decision Learning:** Learning from decisions
+
+### Outcome Metrics
+- **Strategic Alignment:** Alignment with strategic objectives
+- **Stakeholder Value:** Value created for stakeholders
+- **User Impact:** Impact on end users
+- **Organizational Impact:** Impact on organization
+
+## Decision Governance
+
+### Decision Authority
+- **Council Authority:** Authority levels for different decision types
+- **Individual Authority:** Individual decision-making authority
+- **Collective Authority:** Collective decision-making authority
+- **Escalation Authority:** Authority for escalation decisions
+
+### Decision Accountability
+- **Individual Accountability:** Individual accountability for decisions
+- **Council Accountability:** Council accountability for decisions
+- **Organizational Accountability:** Organizational accountability for decisions
+- **Stakeholder Accountability:** Accountability to stakeholders
+
+### Decision Transparency
+- **Decision Process:** Transparent decision-making process
+- **Decision Rationale:** Transparent decision rationale
+- **Decision Outcomes:** Transparent decision outcomes
+- **Decision Learning:** Transparent learning from decisions
+
+## Continuous Improvement
+
+### Decision Process Improvement
+- **Process Review:** Regular review of decision processes
+- **Process Optimization:** Optimization of decision processes
+- **Process Standardization:** Standardization of decision processes
+- **Process Automation:** Automation of decision processes
+
+### Decision Capability Development
+- **Skill Development:** Develop decision-making skills
+- **Knowledge Development:** Develop decision-making knowledge
+- **Tool Development:** Develop decision-making tools
+- **Best Practices:** Develop and share best practices
+
+### Learning Organization
+- **Decision Learning:** Learn from decisions
+- **Knowledge Sharing:** Share decision knowledge
+- **Experience Sharing:** Share decision experience
+- **Continuous Learning:** Continuously learn and improve
+
+## Conclusion
+
+The LWA Council Decision Framework provides comprehensive guidelines for autonomous decision-making while maintaining strategic alignment and quality standards. By following this framework, council members can make effective decisions that advance the LWA platform and meet stakeholder needs.
+
+The key to effective decision-making is maintaining the balance between autonomy and alignment, ensuring that decisions are made efficiently while advancing strategic objectives and maintaining quality standards.

--- a/COUNCIL_INTEGRATION_GUIDE.md
+++ b/COUNCIL_INTEGRATION_GUIDE.md
@@ -1,0 +1,272 @@
+# LWA Council Integration Guide
+
+## Purpose
+This document provides comprehensive guidelines for integrating council outputs into the LWA ecosystem, ensuring seamless coordination between autonomous work and the broader platform.
+
+## Integration Framework
+
+### Integration Levels
+- **Level 1: Documentation Integration** - Council reports and specifications
+- **Level 2: Asset Integration** - Blender assets and visual content
+- **Level 3: Code Integration** - Technical implementations and systems
+- **Level 4: System Integration** - Full feature integration with live product
+
+### Integration Principles
+- **Safety First:** Never compromise live product functionality
+- **Gradual Integration:** Progress from documentation to full system integration
+- **Quality Assurance:** Validate all integrations thoroughly
+- **Cross-Council Coordination:** Ensure coordination between affected councils
+
+## Documentation Integration
+
+### Council Reports
+- **Repository Location:** `/reports/` directory
+- **File Naming:** `[COUNCIL_NAME]_REPORT_[DATE].md`
+- **Content Standards:** Use DEPARTMENT_REPORT_TEMPLATE.md
+- **Integration Steps:**
+  1. Generate report using Anthropic Batch API or templates
+  2. Review and validate content quality
+  3. Commit to repository with descriptive message
+  4. Update council status in master documentation
+
+### Technical Specifications
+- **Repository Location:** `/specs/` directory
+- **File Naming:** `[SYSTEM_NAME]_SPECIFICATION_[VERSION].md`
+- **Content Standards:** Include implementation details, API documentation, testing requirements
+- **Integration Steps:**
+  1. Create specification using appropriate template
+  2. Review technical feasibility and compatibility
+  3. Validate against existing systems
+  4. Commit to repository with implementation roadmap
+
+### User Documentation
+- **Repository Location:** `/docs/` directory
+- **File Naming:** `[FEATURE_NAME]_USER_GUIDE.md`
+- **Content Standards:** User-friendly language, step-by-step instructions
+- **Integration Steps:**
+  1. Create user guide based on technical specifications
+  2. Validate clarity and completeness
+  3. Test instructions against actual implementation
+  4. Commit to repository with version information
+
+## Asset Integration
+
+### Blender Assets
+- **Repository Location:** `/assets/blender/` directory
+- **File Naming:** `[ASSET_TYPE]_[ASSET_NAME]_v[VERSION].blend`
+- **Content Standards:** High-quality models, proper naming conventions
+- **Integration Steps:**
+  1. Create asset using CHARACTER_TEMPLATE.md or other templates
+  2. Validate asset quality and technical specifications
+  3. Generate preview renders and documentation
+  4. Commit to repository with asset metadata
+
+### Visual Effects
+- **Repository Location:** `/assets/vfx/` directory
+- **File Naming:** `[EFFECT_NAME]_v[VERSION].vfx`
+- **Content Standards:** Optimized particle systems, documentation
+- **Integration Steps:**
+  1. Create effect using VFX_EFFECT_TEMPLATE.md
+  2. Test effect in controlled environment
+  3. Optimize for performance and compatibility
+  4. Commit to repository with implementation notes
+
+### Textures and Materials
+- **Repository Location:** `/assets/textures/` directory
+- **File Naming:** `[TEXTURE_NAME]_[RESOLUTION].png`
+- **Content Standards:** Consistent resolution, proper naming
+- **Integration Steps:**
+  1. Create texture following material specifications
+  2. Validate quality and performance
+  3. Create material documentation
+  4. Commit to repository with usage guidelines
+
+## Code Integration
+
+### Feature Implementation
+- **Repository Location:** `/src/features/` directory
+- **File Naming:** `[FEATURE_NAME]/` with appropriate file structure
+- **Content Standards:** Clean code, documentation, testing
+- **Integration Steps:**
+  1. Implement feature based on technical specification
+  2. Write comprehensive tests
+  3. Document API and usage
+  4. Submit pull request for review
+
+### System Architecture
+- **Repository Location:** `/src/systems/` directory
+- **File Naming:** `[SYSTEM_NAME]/` with appropriate file structure
+- **Content Standards:** Modular design, clear interfaces
+- **Integration Steps:**
+  1. Implement system following architectural specification
+  2. Create integration tests
+  3. Document system interfaces
+  4. Submit pull request for review
+
+### API Development
+- **Repository Location:** `/src/api/` directory
+- **File Naming:** `[API_NAME]/` with appropriate file structure
+- **Content Standards:** RESTful design, comprehensive documentation
+- **Integration Steps:**
+  1. Implement API following specification
+  2. Create API documentation and examples
+  3. Write integration tests
+  4. Submit pull request for review
+
+## System Integration
+
+### Live Product Integration
+- **Safety Requirements:** Never compromise existing functionality
+- **Testing Requirements:** Comprehensive testing in staging environment
+- **Rollback Planning:** Always have rollback plan ready
+- **Integration Steps:**
+  1. Implement feature in isolated environment
+  2. Test thoroughly with staging data
+  3. Create deployment plan with rollback procedures
+  4. Deploy with monitoring and validation
+
+### Database Integration
+- **Safety Requirements:** Never modify live database without backup
+- **Migration Planning:** Plan database migrations carefully
+- **Testing Requirements:** Test migrations with test data
+- **Integration Steps:**
+  1. Create migration scripts
+  2. Test migrations with test database
+  3. Plan rollback procedures
+  4. Execute migration with monitoring
+
+### Third-Party Integration
+- **Safety Requirements:** Validate third-party services thoroughly
+- **API Management:** Manage API keys and credentials securely
+- **Testing Requirements:** Test with sandbox environments
+- **Integration Steps:**
+  1. Integrate with sandbox environment
+  2. Test all integration points
+  3. Implement error handling and monitoring
+  4. Deploy with comprehensive monitoring
+
+## Integration Workflow
+
+### Pre-Integration Phase
+1. **Review Requirements:** Validate integration requirements
+2. **Assess Impact:** Evaluate impact on existing systems
+3. **Plan Integration:** Create detailed integration plan
+4. **Prepare Environment:** Set up testing and staging environments
+
+### Integration Phase
+1. **Implement Integration:** Implement integration following plan
+2. **Test Integration:** Test thoroughly in controlled environment
+3. **Validate Results:** Validate integration meets requirements
+4. **Document Integration:** Document integration process and results
+
+### Post-Integration Phase
+1. **Monitor Performance:** Monitor system performance and stability
+2. **Collect Feedback:** Collect user feedback and issues
+3. **Address Issues:** Address any issues that arise
+4. **Update Documentation:** Update documentation based on integration
+
+## Integration Quality Assurance
+
+### Testing Requirements
+- **Unit Tests:** Test individual components
+- **Integration Tests:** Test integration points
+- **System Tests:** Test entire system
+- **User Acceptance Tests:** Test with real users
+
+### Performance Requirements
+- **Response Time:** Meet performance requirements
+- **Resource Usage:** Optimize resource usage
+- **Scalability:** Ensure system scales appropriately
+- **Reliability:** Ensure system reliability
+
+### Security Requirements
+- **Data Protection:** Protect sensitive data
+- **Access Control:** Implement proper access controls
+- **Input Validation:** Validate all inputs
+- **Error Handling**: Handle errors gracefully
+
+## Integration Tools
+
+### Version Control
+- **Git:** Version control for all code and documentation
+- **Branching Strategy:** Use feature branches for development
+- **Pull Requests:** Review all changes before integration
+- **Continuous Integration:** Automate testing and deployment
+
+### Testing Tools
+- **Unit Testing:** Jest, Mocha, or similar frameworks
+- **Integration Testing:** Cypress, Selenium, or similar tools
+- **Performance Testing:** Load testing tools
+- **Security Testing:** Security scanning tools
+
+### Documentation Tools
+- **Markdown:** Use Markdown for documentation
+- **API Documentation:** Use tools like Swagger or OpenAPI
+- **User Guides:** Use clear, user-friendly language
+- **Technical Documentation:** Use precise technical language
+
+## Integration Monitoring
+
+### Performance Monitoring
+- **Response Time:** Monitor API response times
+- **Resource Usage:** Monitor CPU, memory, and disk usage
+- **Error Rates:** Monitor error rates and types
+- **User Experience:** Monitor user experience metrics
+
+### Security Monitoring
+- **Access Logs:** Monitor access logs for suspicious activity
+- **Error Logs:** Monitor error logs for security issues
+- **Vulnerability Scanning:** Regular security vulnerability scanning
+- **Compliance Monitoring:** Monitor compliance with regulations
+
+### User Feedback Monitoring
+- **User Reports:** Monitor user-reported issues
+- **Usage Analytics:** Monitor usage patterns
+- **Satisfaction Surveys:** Monitor user satisfaction
+- **Support Tickets:** Monitor support ticket trends
+
+## Integration Challenges
+
+### Common Challenges
+- **Compatibility Issues:** Ensure compatibility with existing systems
+- **Performance Issues:** Optimize performance for integration
+- **Security Issues:** Address security vulnerabilities
+- **User Adoption:** Ensure users adopt new features
+
+### Mitigation Strategies
+- **Compatibility Testing:** Test compatibility thoroughly
+- **Performance Optimization:** Optimize performance continuously
+- **Security Audits**: Conduct regular security audits
+- **User Training:** Provide comprehensive user training
+
+### Risk Management
+- **Risk Assessment:** Assess integration risks carefully
+- **Mitigation Planning:** Plan risk mitigation strategies
+- **Contingency Planning:** Plan for contingencies
+- **Insurance**: Consider insurance for critical integrations
+
+## Integration Success Criteria
+
+### Technical Success
+- **Functionality:** Integration functions as specified
+- **Performance:** Integration meets performance requirements
+- **Reliability:** Integration is reliable and stable
+- **Security:** Integration meets security requirements
+
+### Business Success
+- **User Adoption:** Users adopt the integration
+- **Business Value:** Integration delivers business value
+- **Cost Efficiency:** Integration is cost-effective
+- **Strategic Alignment:** Integration aligns with strategic objectives
+
+### User Success
+- **User Satisfaction:** Users are satisfied with integration
+- **Ease of Use:** Integration is easy to use
+- **Documentation:** Documentation is clear and helpful
+- **Support:** Support is responsive and effective
+
+## Conclusion
+
+The LWA Council Integration Guide provides comprehensive guidelines for integrating council outputs into the LWA ecosystem. By following these guidelines, council members can ensure that their work is integrated safely, efficiently, and effectively.
+
+The key to successful integration is maintaining the balance between innovation and stability, ensuring that new features and systems enhance the LWA platform without compromising its reliability and performance.

--- a/COUNCIL_QUALITY_STANDARDS.md
+++ b/COUNCIL_QUALITY_STANDARDS.md
@@ -1,0 +1,314 @@
+# LWA Council Quality Standards
+
+## Purpose
+This document establishes comprehensive quality standards for all council work, ensuring consistent excellence across all autonomous outputs.
+
+## Quality Framework
+
+### Quality Dimensions
+- **Completeness:** All required elements are present and complete
+- **Accuracy:** All information is accurate and correct
+- **Consistency:** All work follows established patterns and standards
+- **Professionalism:** All work meets professional standards
+- **Usability:** All work is usable and practical
+
+### Quality Levels
+- **Level 1: Minimum Acceptable** - Meets basic requirements
+- **Level 2: Professional** - Meets professional standards
+- **Level 3: Excellent** - Exceeds professional standards
+- **Level 4: Exceptional** - Sets new standards for excellence
+
+## Documentation Quality Standards
+
+### Council Reports
+#### Completeness Requirements
+- [ ] All 15 required sections are present
+- [ ] Each section contains substantive content
+- [ ] Executive summary is comprehensive
+- [ ] Action plans are specific and actionable
+- [ ] Risk assessments are thorough
+
+#### Accuracy Requirements
+- [ ] All technical information is accurate
+- [ ] All timelines are realistic
+- [ ] All resource requirements are accurate
+- [ ] All dependencies are correctly identified
+- [ ] All assumptions are clearly stated
+
+#### Consistency Requirements
+- [ ] Formatting follows established template
+- [ ] Terminology is consistent throughout
+- [ ] Timeline and resource estimates are consistent
+- [ ] Cross-references are accurate
+- [ ] Style and tone are consistent
+
+#### Professionalism Requirements
+- [ ] Language is professional and clear
+- [ ] Structure is logical and easy to follow
+- [ ] Visual presentation is professional
+- [ ] Grammar and spelling are correct
+- [ ] Citations and references are properly formatted
+
+### Technical Specifications
+#### Completeness Requirements
+- [ ] All system components are described
+- [ ] All interfaces are documented
+- [ ] All dependencies are identified
+- [ ] All testing requirements are specified
+- [ ] All deployment requirements are documented
+
+#### Accuracy Requirements
+- [ ] All technical details are accurate
+- [ ] All API specifications are correct
+- [ ] All data structures are properly defined
+- [ ] All algorithms are correctly described
+- [ ] All performance requirements are realistic
+
+#### Consistency Requirements
+- [ ] Naming conventions are consistent
+- [ ] Data formats are consistent
+- [ ] Interface definitions are consistent
+- [ ] Documentation style is consistent
+- [ ] Version numbering is consistent
+
+#### Professionalism Requirements
+- [ ] Technical language is precise
+- [ ] Diagrams are clear and professional
+- [ ] Code examples are well-formatted
+- [ ] Explanations are clear and concise
+- [ ] Documentation is well-organized
+
+### User Documentation
+#### Completeness Requirements
+- [ ] All features are documented
+- [ ] All user workflows are described
+- [ ] All troubleshooting steps are included
+- [ ] All setup procedures are documented
+- [ ] All FAQ items are addressed
+
+#### Accuracy Requirements
+- [ ] All instructions are accurate
+- [ ] All screenshots are current
+- [ ] All examples work as described
+- [ ] All system requirements are correct
+- [ ] All compatibility information is accurate
+
+#### Consistency Requirements
+- [ ] Terminology is consistent
+- [ ] Formatting is consistent
+- [ ] Navigation is consistent
+- [ ] Examples follow consistent patterns
+- [ ] Style and tone are consistent
+
+#### Professionalism Requirements
+- [ ] Language is user-friendly and clear
+- [ ] Instructions are step-by-step and easy to follow
+- [ ] Visual elements enhance understanding
+- [ ] Organization is logical and intuitive
+- [ ] Grammar and spelling are correct
+
+## Asset Quality Standards
+
+### Blender Assets
+#### Completeness Requirements
+- [ ] All required components are present
+- [ ] All materials are properly assigned
+- [ ] All textures are included
+- [ ] All rigging is complete
+- [ ] All animations are functional
+
+#### Accuracy Requirements
+- [ ] Models match specifications
+- [ ] Materials are accurate to design
+- [ ] Textures are properly scaled
+- [ ] Rigging follows anatomy
+- [ ] Animations follow timing specifications
+
+#### Consistency Requirements
+- [ ] Naming conventions are followed
+- [ ] Scale is consistent across assets
+- [ ] Material quality is consistent
+- [ ] Texture resolution is appropriate
+- [ ] Animation quality is consistent
+
+#### Professionalism Requirements
+- [ ] Models are clean and optimized
+- [ ] Materials are professional quality
+- [ ] Textures are high quality
+- [ ] Rigging is professional
+- [ ] Animations are smooth and natural
+
+### Visual Effects
+#### Completeness Requirements
+- [ ] All required effects are present
+- [ ] All particle systems are complete
+- [ ] All materials are assigned
+- [ ] All animations are functional
+- [ ] All triggers are implemented
+
+#### Accuracy Requirements
+- [ ] Effects match design specifications
+- [ ] Particle behavior is accurate
+- [ ] Material properties are correct
+- [ ] Animation timing is accurate
+- [ ] Performance characteristics meet requirements
+
+#### Consistency Requirements
+- [ ] Effect naming is consistent
+- [ ] Particle quality is consistent
+- [ ] Material quality is consistent
+- [ ] Animation quality is consistent
+- [ ] Performance is consistent
+
+#### Professionalism Requirements
+- [ ] Effects are visually impressive
+- [ ] Performance is optimized
+- [ ] Materials are professional quality
+- [ ] Animations are smooth
+- [ ] Integration is seamless
+
+## Code Quality Standards
+
+### Feature Implementation
+#### Completeness Requirements
+- [ ] All required features are implemented
+- [ ] All edge cases are handled
+- [ ] All error conditions are handled
+- [ ] All documentation is complete
+- [ ] All tests are implemented
+
+#### Accuracy Requirements
+- [ ] Code matches specifications
+- [ ] Logic is correct
+- [ ] Data handling is accurate
+- [ ] Error handling is appropriate
+- [ ] Performance meets requirements
+
+#### Consistency Requirements
+- [ ] Code follows established patterns
+- [ ] Naming conventions are consistent
+- [ ] Style guidelines are followed
+- [ ] Documentation style is consistent
+- [ ] Testing patterns are consistent
+
+#### Professionalism Requirements
+- [ ] Code is clean and maintainable
+- [ ] Comments are clear and helpful
+- [ ] Structure is logical
+- [ ] Performance is optimized
+- [ ] Security considerations are addressed
+
+### System Architecture
+#### Completeness Requirements
+- [ ] All system components are designed
+- [ ] All interfaces are defined
+- [ ] All data flows are documented
+- [ ] All security considerations are addressed
+- [ ] All scaling considerations are documented
+
+#### Accuracy Requirements
+- [ ] Architecture meets requirements
+- [ ] Interfaces are correctly defined
+- [ ] Data flows are accurate
+- [ ] Security measures are appropriate
+- [ ] Scaling plans are realistic
+
+#### Consistency Requirements
+- [ ] Architectural patterns are consistent
+- [ ] Interface definitions are consistent
+- [ ] Documentation style is consistent
+- [ ] Naming conventions are consistent
+- [ ] Design principles are consistent
+
+#### Professionalism Requirements
+- [ ] Architecture is well-designed
+- [ ] Documentation is comprehensive
+- [ ] Diagrams are clear
+- [ ] Decisions are well-justified
+- [ ] Future considerations are addressed
+
+## Quality Assurance Process
+
+### Pre-Quality Assurance
+1. **Self-Review:** Creator reviews work against standards
+2. **Peer Review:** Another council member reviews work
+3. **Template Validation:** Work follows template requirements
+4. **Completeness Check:** All required elements are present
+
+### Quality Assurance Testing
+1. **Functional Testing:** Work functions as specified
+2. **Integration Testing:** Work integrates properly
+3. **Performance Testing:** Work meets performance requirements
+4. **Security Testing:** Work meets security requirements
+
+### Post-Quality Assurance
+1. **Documentation Review:** Documentation is complete and accurate
+2. **User Acceptance:** Work meets user requirements
+3. **Stakeholder Approval:** Stakeholders approve work
+4. **Final Validation:** Work meets all quality standards
+
+## Quality Metrics
+
+### Documentation Metrics
+- **Completeness Score:** Percentage of required elements present
+- **Accuracy Score:** Percentage of accurate information
+- **Consistency Score:** Consistency with standards and patterns
+- **Professionalism Score:** Professional quality assessment
+
+### Asset Metrics
+- **Technical Quality:** Technical assessment of assets
+- **Visual Quality:** Visual assessment of assets
+- **Performance Quality:** Performance characteristics
+- **Integration Quality:** Integration with systems
+
+### Code Metrics
+- **Code Quality:** Code quality assessment
+- **Test Coverage:** Percentage of code tested
+- **Performance:** Performance characteristics
+- **Security:** Security assessment
+
+## Quality Improvement
+
+### Continuous Improvement
+- **Regular Reviews:** Regular quality reviews
+- **Feedback Collection:** Collect feedback from users
+- **Process Refinement:** Refine quality processes
+- **Standard Updates:** Update quality standards
+
+### Training and Development
+- **Quality Training:** Train council members on quality standards
+- **Skill Development:** Develop skills for quality work
+- **Best Practices:** Share best practices
+- **Knowledge Sharing:** Share quality knowledge
+
+### Tools and Resources
+- **Quality Tools:** Provide tools for quality assurance
+- **Templates:** Provide high-quality templates
+- **Guidelines:** Provide clear guidelines
+- **Examples:** Provide quality examples
+
+## Quality Enforcement
+
+### Quality Gates
+- **Pre-Commit Review:** Review work before committing
+- **Pull Request Review:** Review work before merging
+- **Release Review:** Review work before release
+- **Post-Release Review:** Review work after release
+
+### Quality Metrics
+- **Quality Scorecards:** Track quality metrics
+- **Quality Reports:** Generate quality reports
+- **Quality Trends:** Track quality trends
+- **Quality Goals:** Set quality goals
+
+### Quality Accountability
+- **Individual Responsibility:** Individual accountability for quality
+- **Council Responsibility:** Council accountability for quality
+- **Leadership Responsibility:** Leadership accountability for quality
+- **Organizational Responsibility:** Organizational accountability for quality
+
+## Conclusion
+
+The LWA Council Quality Standards provide comprehensive guidelines for ensuring high-quality work across all council activities. By following these standards, council members can ensure that their work meets professional standards and advances the LWA platform effectively.
+
+The key to quality excellence is maintaining consistent standards, conducting thorough reviews, and continuously improving processes and outcomes. Quality is not an accident but the result of deliberate effort and attention to detail.

--- a/COUNCIL_WORKFLOW.md
+++ b/COUNCIL_WORKFLOW.md
@@ -1,0 +1,226 @@
+# LWA Council Workflow - Autonomous Execution Framework
+
+## Purpose
+This document establishes the autonomous workflow for LWA council operations, enabling self-directed work that advances the creator-world engine while protecting the live product.
+
+## Council Structure
+
+### 12 Council Departments
+1. **Product Command Council** - Strategic direction and product vision
+2. **Frontend / UX Council** - User interface design and user experience
+3. **Blender Forge Council** - 3D asset creation and visual development
+4. **VFX / Effects Council** - Visual effects and particle systems
+5. **Combat / Motion Controls Council** - Combat mechanics and character movement
+6. **AI NPC / Character Memory Council** - AI systems and character behavior
+7. **Game Systems Council** - Core game mechanics and systems architecture
+8. **Blockchain / NFT / Economy Council** - Digital economy and ownership systems
+9. **MCP / Connector Council** - External system integrations and automation
+10. **XR / Meta VR / AR Council** - Extended reality and immersive experiences
+11. **UDP / Multiplayer Council** - Real-time networking and multiplayer systems
+12. **Security / Legal / Truth Council** - Protection, compliance, and content verification
+
+## Autonomous Work Principles
+
+### Core Principles
+- **Dangerous Creative Vision:** Ambitious worldbuilding and innovative features
+- **Surgical Code Execution:** Precise, minimal, and safe implementation
+- **Live Product Protection:** Never compromise existing functionality
+- **Future-Only Clarity:** Clear separation between current and future features
+- **Autonomous Decision Making:** Self-directed work with clear boundaries
+
+### Decision Framework
+- **What to Build:** Based on GitHub Issue #85 roadmap and council priorities
+- **How to Build:** Using templates, batch processing, and established patterns
+- **When to Build:** Continuous autonomous work with regular integration
+- **What Not to Build:** Anything that risks live product stability
+
+## Autonomous Work Workflow
+
+### Phase 1: Assessment & Planning
+1. **Review Current State:** Check existing assets, documentation, and progress
+2. **Identify Gaps:** Determine what needs to be built based on council priorities
+3. **Select Templates:** Choose appropriate templates from the template library
+4. **Create Action Plan:** Define specific deliverables and timeline
+
+### Phase 2: Creation & Development
+1. **Generate Content:** Use templates to create council reports and specifications
+2. **Develop Assets:** Create Blender assets, code, or documentation as needed
+3. **Quality Control:** Review and refine outputs against standards
+4. **Local Testing:** Validate functionality without affecting live systems
+
+### Phase 3: Integration & Documentation
+1. **Update Documentation:** Ensure all work is properly documented
+2. **Version Control:** Commit changes with clear, descriptive messages
+3. **Cross-Council Review**: Ensure coordination between departments
+4. **Progress Reporting**: Update council status and next steps
+
+## Autonomous Work Categories
+
+### Strategic Planning Work
+- **Council Reports:** Generate comprehensive department reports
+- **Roadmap Updates:** Maintain and update strategic roadmaps
+- **Investor Materials:** Create professional documentation
+- **Technical Specifications:** Develop detailed implementation plans
+
+### Asset Creation Work
+- **Blender Assets:** Create 3D models, environments, and animations
+- **Visual Effects:** Design particle systems and visual effects
+- **Character Development:** Create character models and animations
+- **Environment Design:** Build realm environments and spaces
+
+### Technical Development Work
+- **Code Implementation:** Write clean, safe code for future features
+- **System Architecture:** Design scalable technical systems
+- **Integration Planning:** Plan integration with existing systems
+- **Testing Frameworks:** Create comprehensive testing procedures
+
+### Documentation Work
+- **Technical Documentation:** Write clear technical specifications
+- **User Guides:** Create user-facing documentation
+- **API Documentation:** Document interfaces and integrations
+- **Process Documentation:** Maintain workflow and process guides
+
+## Autonomous Work Standards
+
+### Quality Standards
+- **Completeness:** All deliverables must be complete and ready for use
+- **Consistency:** Follow established templates and patterns
+- **Clarity:** Clear, unambiguous documentation and code
+- **Professionalism:** High-quality, investor-ready materials
+
+### Safety Standards
+- **Live Product Protection:** Never modify live systems without explicit approval
+- **Repository Cleanliness:** Maintain clean, organized repository
+- **Testing Requirements:** Test all changes in safe environments
+- **Backup Procedures:** Maintain backups of critical work
+
+### Collaboration Standards
+- **Cross-Council Coordination:** Ensure work aligns across departments
+- **Documentation Sharing:** Share knowledge and findings
+- **Progress Transparency:** Maintain clear progress tracking
+- **Conflict Resolution:** Address conflicts through established processes
+
+## Autonomous Work Tools
+
+### Template Library
+- **Department Reports:** Standardized reporting templates
+- **Character Development:** Character creation templates
+- **Technical Specifications:** System design templates
+- **Investor Materials**: Professional presentation templates
+
+### Batch Processing
+- **Anthropic Batch API:** Automated report generation
+- **Asset Pipeline:** Automated asset creation and optimization
+- **Documentation Generation:** Automated documentation creation
+- **Quality Control:** Automated validation and testing
+
+### Development Environment
+- **Local Development:** Safe local development environment
+- **Version Control:** Git-based version management
+- **Testing Frameworks:** Comprehensive testing procedures
+- **Documentation Tools:** Professional documentation generation
+
+## Autonomous Work Examples
+
+### Example 1: Character Asset Creation
+1. **Assessment:** Need new character model for Seven Agents
+2. **Planning:** Use CHARACTER_TEMPLATE.md to define character
+3. **Creation:** Create Blender model following template
+4. **Testing:** Validate model in local environment
+5. **Documentation:** Update asset index and documentation
+6. **Integration:** Commit to repository with proper documentation
+
+### Example 2: System Architecture Design
+1. **Assessment:** Need to design multiplayer system architecture
+2. **Planning:** Use DEPARTMENT_REPORT_TEMPLATE.md for specification
+3. **Creation:** Write comprehensive technical specification
+4. **Testing:** Validate architecture through review
+5. **Documentation:** Create implementation guide
+6. **Integration:** Commit specification to repository
+
+### Example 3: Council Report Generation
+1. **Assessment:** Need quarterly council report
+2. **Planning:** Use Anthropic Batch API for automated generation
+3. **Creation:** Generate reports using established prompts
+4. **Testing:** Review and validate report content
+5. **Documentation:** Update council status and next steps
+6. **Integration**: Commit reports to repository
+
+## Autonomous Work Triggers
+
+### Time-Based Triggers
+- **Weekly:** Council status updates and progress reports
+- **Monthly:** Comprehensive council reports and planning
+- **Quarterly:** Strategic reviews and roadmap updates
+- **Annually:** Annual planning and budget reviews
+
+### Event-Based Triggers
+- **New Asset Creation:** When new assets are needed
+- **System Updates:** When systems need updates or changes
+- **Issue Resolution:** When issues need to be addressed
+- **Opportunity Identification:** When new opportunities arise
+
+### Priority-Based Triggers
+- **High Priority:** Critical system issues or investor needs
+- **Medium Priority:** Regular council operations and planning
+- **Low Priority:** Enhancement opportunities and improvements
+
+## Autonomous Work Metrics
+
+### Productivity Metrics
+- **Deliverables Completed:** Number of completed deliverables
+- **Quality Score:** Quality assessment of completed work
+- **Timeline Adherence:** Adherence to planned timelines
+- **Resource Efficiency**: Efficient use of resources and tools
+
+### Quality Metrics
+- **Completeness:** Percentage of required elements included
+- **Accuracy:** Accuracy of technical specifications and documentation
+- **Consistency:** Consistency with established standards and patterns
+- **Professionalism**: Professional quality of outputs
+
+### Impact Metrics
+- **Strategic Alignment:** Alignment with strategic objectives
+- **Stakeholder Satisfaction:** Satisfaction of stakeholders and investors
+- **System Improvement**: Improvement in system capabilities
+- **Risk Reduction**: Reduction in identified risks
+
+## Autonomous Work Challenges
+
+### Common Challenges
+- **Scope Creep:** Maintaining focus on defined deliverables
+- **Quality Control:** Ensuring high quality in autonomous work
+- **Coordination:** Coordinating work across multiple councils
+- **Resource Management:** Managing resources effectively
+
+### Mitigation Strategies
+- **Clear Boundaries:** Maintain clear scope and boundaries
+- **Quality Standards:** Implement comprehensive quality control
+- **Regular Reviews:** Conduct regular cross-council reviews
+- **Resource Planning:** Plan resource allocation carefully
+
+### Risk Management
+- **Live Product Risk:** Never compromise live systems
+- **Quality Risk:** Maintain high quality standards
+- **Coordination Risk:** Ensure proper coordination
+- **Resource Risk**: Manage resources efficiently
+
+## Autonomous Work Success Criteria
+
+### Success Indicators
+- **Completed Deliverables:** All planned deliverables completed
+- **Quality Standards:** All work meets quality standards
+- **Timeline Adherence:** Work completed within planned timelines
+- **Stakeholder Satisfaction:** Stakeholders satisfied with outcomes
+
+### Continuous Improvement
+- **Process Refinement:** Continuously refine processes
+- **Tool Enhancement**: Enhance tools and templates
+- **Skill Development**: Develop skills and capabilities
+- **Knowledge Sharing**: Share knowledge and best practices
+
+## Conclusion
+
+The LWA Council Workflow enables autonomous work that advances the creator-world engine while protecting the live product. By following established principles, standards, and processes, the council can work autonomously to achieve strategic objectives and maintain high quality standards.
+
+The key to success is maintaining the balance between ambitious creative vision and surgical code execution, ensuring that all work advances the strategic objectives while protecting the stability and reliability of the live product.


### PR DESCRIPTION
## Summary

Adds the LWA council operating guideline documents as a dedicated docs-only branch.

## Files included

- `COUNCIL_AUTONOMY_GUIDELINES.md`
- `COUNCIL_COMMUNICATION_PROTOCOLS.md`
- `COUNCIL_CONTRIBUTION_GUIDELINES.md`
- `COUNCIL_DECISION_FRAMEWORK.md`
- `COUNCIL_INTEGRATION_GUIDE.md`
- `COUNCIL_QUALITY_STANDARDS.md`
- `COUNCIL_WORKFLOW.md`

## Safety notes

- Docs-only change.
- No app code touched.
- No backend contracts touched.
- No `lwa-ios` changes.
- No Blender `.blend`, PNG, MP4, WebM, GLB assets included.
- No API keys or environment files included.

## Verification from local run

Branch `docs/council-operating-guidelines` was created from clean `origin/main`, stash was applied safely, and the 7 markdown files were committed and pushed as commit `9e07742`.

## Next step

Review and merge this docs-only PR first. Leave PR #84 open; it still needs conflict-safe cherry-picking or a fresh replacement PR from current `main`.