### PR TITLE
docs: add Blender world asset pipeline status

### DIFF
--- a/docs/runbooks/LWA_BLENDER_WORLD_ASSET_PIPELINE_STATUS.md
+++ b/docs/runbooks/LWA_BLENDER_WORLD_ASSET_PIPELINE_STATUS.md
@@ -1,0 +1,441 @@
+# LWA Blender World Asset Pipeline Status Runbook
+
+## Overview
+
+This runbook documents the current state of the Blender world asset pipeline, local asset inventory, deck-ready assets, and the roadmap for Batch 3 character upgrades and asset promotion to the web platform.
+
+## Current Blender Asset Truth
+
+### Blender Infrastructure Status
+- **Local Blender Lab**: ACTIVE - Located at `/Users/bdm/LWA/blender`
+- **Asset Generation**: ACTIVE - Seven Agents and environments generated locally
+- **Export Pipeline**: ACTIVE - PNG preview batches exported locally
+- **Web Integration**: NOT IMPLEMENTED - Assets not yet in `lwa-web/public`
+- **Asset Management**: LOCAL ONLY - No web asset management system
+
+### Asset Generation Status
+```python
+Local Asset Generation:
+- Seven Agents: Generated locally, ready for refinement
+- Signal Current Environments: Generated locally
+- God Meat Relics: Generated locally
+- PNG Preview Batches: Exported locally
+- Character Poses: Need dynamic upgrade
+- Lighting: Need stronger rim lighting
+- Silhouettes: Need improvement
+- Camera Angles: Need optimization
+```
+
+### Pipeline Components
+- **Blender Workstation**: Local development environment
+- **Asset Library**: Local file organization
+- **Export System**: Manual PNG export process
+- **Quality Control**: Visual assessment workflow
+- **Version Control**: Git-based documentation tracking
+
+## Local-Only Asset Inventory
+
+### Generated Assets (LOCAL ONLY)
+- **Seven Agents**: Character models with basic poses
+- **Signal Current Environments**: Background/scene assets
+- **God Meat Relics**: Prop/interactive assets
+- **PNG Preview Batches**: Exported visual previews
+
+### Asset Categories
+```python
+Local Asset Categories:
+- Characters: Seven Agents with base poses
+- Environments: Signal Current realm backgrounds
+- Props: God Meat relics and interactive objects
+- Previews: PNG export batches for review
+- Concepts: Visual development assets
+```
+
+### File Structure (LOCAL ONLY)
+```
+/Users/bdm/LWA/blender/
+├── agents/
+│   ├── agent_01.blend
+│   ├── agent_02.blend
+│   └── ...
+├── environments/
+│   ├── signal_current_realm.blend
+│   └── ...
+├── props/
+│   ├── god_meat_relics.blend
+│   └── ...
+└── exports/
+    ├── batch_1_previews/
+    ├── batch_2_previews/
+    └── ...
+```
+
+## Deck-Ready Asset Shortlist
+
+### Batch 2 Strongest Visuals
+- **Gold Current Realm v3**: `gold_current_realm_v3.png` - Primary deck candidate
+- **Onyx Sea Dark Ocean**: `onyx_sea_dark_ocean.png` - Secondary deck candidate
+- **Moon Wolf God Meat v3**: `moon_wolf_god_meat_v3.png` - Character asset candidate
+- **Mirror Crow God Meat v3**: `mirror_crow_god_meat_v3.png` - Character asset candidate
+- **Nova Current Rider v3**: `nova_current_rider_v3.png` - Action asset candidate
+
+### Deck Selection Criteria
+- **Visual Impact**: Strong composition and lighting
+- **Brand Alignment**: Matches LWA visual identity
+- **Technical Quality**: High-resolution, clean export
+- **Story Potential**: Evokes narrative interest
+- **Versatility**: Works across multiple use cases
+
+### Asset Readiness Assessment
+```python
+Deck-Ready Assets:
+- gold_current_realm_v3.png: READY - Strongest visual, deck-ready
+- onyx_sea_dark_ocean.png: READY - Atmospheric, deck-ready
+- moon_wolf_god_meat_v3.png: NEEDS POSE - Good base, needs dynamic pose
+- mirror_crow_god_meat_v3.png: NEEDS POSE - Good base, needs dynamic pose
+- nova_current_rider_v3.png: NEEDS POSE - Good base, needs dynamic pose
+```
+
+## Assets Needing Refinement
+
+### Character Pose Upgrades Required
+- **Moon Wolf God Meat v3**: Needs dynamic action pose
+- **Mirror Crow God Meat v3**: Needs dramatic stance
+- **Nova Current Rider v3**: Needs movement/action pose
+- **All Seven Agents**: Need pose variety and expressiveness
+
+### Lighting Improvements Needed
+- **Stronger Rim Lighting**: All characters need enhanced rim lighting
+- **Dramatic Shadows**: Improve shadow depth and direction
+- **Environmental Lighting**: Better integration with scene lighting
+- **Highlight Emphasis**: Strengthen focal point lighting
+
+### Silhouette and Camera Work
+- **Better Silhouettes**: Improve character shape recognition
+- **Dynamic Camera Angles**: More interesting perspectives
+- **Composition Balance**: Better visual weight distribution
+- **Depth of Field**: Add selective focus for impact
+
+## Batch 3 Export Plan
+
+### Export Priorities
+1. **Character Pose Upgrades**: Dynamic poses for all Seven Agents
+2. **Lighting Enhancement**: Stronger rim lighting implementation
+3. **Camera Work**: Improved angles and composition
+4. **Quality Control**: Higher resolution exports
+5. **Format Standardization**: Consistent export settings
+
+### Export Workflow
+```python
+Batch 3 Export Process:
+1. Pose Refinement: Update character poses in Blender
+2. Lighting Setup: Implement enhanced rim lighting
+3. Camera Positioning: Optimize angles and composition
+4. Render Settings: High-resolution PNG export
+5. Quality Review: Visual assessment and approval
+6. File Organization: Proper naming and structure
+```
+
+### Technical Specifications
+- **Resolution**: 4K (3840x2160) for deck assets
+- **Format**: PNG with transparency support
+- **Color Space**: sRGB for web compatibility
+- **Compression**: Lossless for maximum quality
+- **Naming Convention**: Consistent descriptive naming
+
+## Character Pose Upgrade Plan
+
+### Pose Enhancement Goals
+- **Dynamic Action**: Movement and energy in poses
+- **Character Expression**: Personality and emotion
+- **Silhouette Strength**: Clear, recognizable shapes
+- **Storytelling**: Each pose tells a micro-story
+- **Brand Consistency**: Maintain LWA visual style
+
+### Specific Character Upgrades
+```python
+Character Pose Upgrades:
+- Moon Wolf: Hunting/leaping pose with dramatic movement
+- Mirror Crow: Perched/flight pose with wing spread
+- Nova Rider: Riding/action pose with energy effects
+- Agent 01-07: Unique personality poses for each agent
+- God Meat Relics: Interactive/display poses
+```
+
+### Pose Development Process
+1. **Reference Gathering**: Collect pose reference materials
+2. **Rigging Check**: Ensure character rigs support desired poses
+3. **Pose Blocking**: Rough pose positioning
+4. **Refinement**: Fine-tune pose details and curves
+5. **Lighting Integration**: Ensure lighting complements pose
+6. **Review and Iterate**: Multiple refinement cycles
+
+## Criteria for Promoting Assets into lwa-web/public
+
+### Technical Requirements
+- **File Size**: Under 2MB for web performance
+- **Format**: WebP for photos, PNG for transparency
+- **Resolution**: Appropriate for web use (1920x1080 max)
+- **Compression**: Optimized for fast loading
+- **Naming**: Descriptive, SEO-friendly filenames
+
+### Quality Standards
+- **Visual Quality**: High-resolution, clean exports
+- **Brand Alignment**: Matches LWA visual identity
+- **Composition**: Strong focal points and balance
+- **Color Consistency**: Cohesive color palette
+- **Accessibility**: Alt text and descriptive labels
+
+### Approval Process
+```python
+Asset Promotion Workflow:
+1. Technical Review: File size, format, resolution check
+2. Quality Assessment: Visual quality and brand alignment
+3. Performance Testing: Load time and optimization
+4. Accessibility Review: Alt text and labels
+5. Final Approval: Stakeholder sign-off
+6. Web Deployment: Move to lwa-web/public
+```
+
+## Optimization Requirements
+
+### File Size Optimization
+- **Image Compression**: WebP format with quality balance
+- **Resolution Scaling**: Appropriate sizes for different uses
+- **Format Selection**: WebP vs PNG based on content
+- **Progressive Loading**: Implement lazy loading where appropriate
+- **CDN Optimization**: Asset delivery optimization
+
+### Performance Standards
+- **Load Time**: Under 2 seconds for critical assets
+- **File Size**: Under 2MB per asset
+- **Format**: Modern web formats (WebP, AVIF)
+- **Responsive**: Multiple sizes for different screens
+- **Cached**: Proper cache headers for assets
+
+### Naming and Organization
+```python
+Asset Naming Convention:
+- Format: category_subtype_version.extension
+- Example: character_nova_rider_v3.webp
+- Categories: character, environment, prop, ui
+- Versions: v1, v2, v3 for iteration tracking
+- Descriptive: Clear, searchable names
+```
+
+### Accessibility Requirements
+- **Alt Text**: Descriptive alternative text for all images
+- **File Names**: Meaningful names for screen readers
+- **Color Contrast**: Ensure accessibility compliance
+- **Text Alternatives**: Text-based alternatives where needed
+- **Semantic HTML**: Proper image semantic markup
+
+## Asset Safety Rules
+
+### Content Guidelines
+- **Brand Safe**: All assets must be brand-appropriate
+- **Age Appropriate**: Suitable for all audiences
+- **Cultural Sensitivity**: Respectful of diverse audiences
+- **Legal Compliance**: No copyright or trademark issues
+- **Quality Standards**: High visual quality maintained
+
+### Technical Safety
+- **File Integrity**: No corrupted or damaged files
+- **Security**: No malicious code or scripts
+- **Privacy**: No personal or sensitive information
+- **Performance**: No performance-impacting assets
+- **Compatibility**: Cross-browser and device compatibility
+
+### Approval Safety
+- **Review Process**: Multi-level approval required
+- **Version Control**: Track all asset changes
+- **Backup Strategy**: Asset backup and recovery
+- **Rollback Plan**: Ability to revert changes
+- **Documentation**: Complete asset metadata
+
+## What Must Not Be Claimed Publicly
+
+### Forbidden Claims
+- **Asset Availability**: Cannot claim assets are publicly available
+- **Feature Completeness**: Cannot claim full asset pipeline is live
+- **Interactive Elements**: Cannot claim interactive 3D features
+- **Real-Time Rendering**: Cannot claim real-time 3D capabilities
+- **Asset Generation**: Cannot claim automated asset generation
+
+### Required Disclaimers
+- **Development Status**: Must clarify assets are in development
+- **Local Only**: Must clarify assets are local-only
+- **Future Plans**: Must clarify timeline is tentative
+- **Technical Limitations**: Must clarify current constraints
+- **Quality Assurance**: Must clarify ongoing refinement process
+
+### Safe Claims
+- **Asset Development**: Can claim asset development is underway
+- **Visual Style**: Can claim visual style development
+- **Local Creation**: Can claim local asset creation
+- **Quality Standards**: Can claim high quality standards
+- **Future Integration**: Can claim future web integration plans
+
+## Known Gaps
+
+### Technical Gaps
+1. **Web Integration**: No assets in `lwa-web/public`
+2. **Asset Pipeline**: No automated asset management
+3. **Performance Optimization**: No web optimization implemented
+4. **Version Control**: No asset versioning system
+5. **CDN Integration**: No content delivery network setup
+
+### Process Gaps
+1. **Approval Workflow**: No formal approval process
+2. **Quality Assurance**: No systematic QA process
+3. **Documentation**: Incomplete asset documentation
+4. **Backup Strategy**: No automated backup system
+5. **Performance Testing**: No load testing framework
+
+### Resource Gaps
+1. **Storage**: No dedicated asset storage solution
+2. **Processing**: No automated processing pipeline
+3. **Monitoring**: No asset performance monitoring
+4. **Analytics**: No asset usage analytics
+5. **Security**: No asset security scanning
+
+## Next Safe Implementation PR
+
+### Phase 1: Asset Promotion System
+```python
+# Add asset management system
+class AssetManager:
+    def promote_asset(self, local_path: str, web_path: str):
+        # Validate asset quality and size
+        # Optimize for web performance
+        # Generate accessibility metadata
+        # Deploy to lwa-web/public
+        pass
+
+# Add asset optimization
+class AssetOptimizer:
+    def optimize_for_web(self, asset_path: str):
+        # Convert to WebP format
+        # Resize for web use
+        # Compress for performance
+        # Generate responsive sizes
+        pass
+```
+
+### Phase 2: Character Pose Pipeline
+```python
+# Add pose upgrade system
+class PoseUpgradePipeline:
+    def upgrade_character_poses(self, character_list: list):
+        # Apply dynamic poses
+        # Enhance lighting
+        # Optimize camera angles
+        # Export optimized assets
+        pass
+
+# Add quality control
+class AssetQualityControl:
+    def review_asset_quality(self, asset_path: str):
+        # Check visual quality
+        # Validate technical specs
+        # Ensure brand consistency
+        # Approve for deployment
+        pass
+```
+
+### Phase 3: Web Integration
+```python
+# Add web asset delivery
+class WebAssetDelivery:
+    def deploy_assets(self, asset_batch: list):
+        # Deploy to CDN
+        # Update asset references
+        # Implement lazy loading
+        # Monitor performance
+        pass
+
+# Add asset monitoring
+class AssetMonitoring:
+    def track_asset_performance(self, asset_ids: list):
+        # Monitor load times
+        # Track usage patterns
+        # Report optimization opportunities
+        # Alert on performance issues
+        pass
+```
+
+## Implementation Priority
+
+### High Priority (Foundation)
+1. **Asset Promotion System**: Move local assets to web
+2. **Web Optimization**: Optimize assets for web performance
+3. **Quality Control**: Implement asset review process
+4. **Documentation**: Complete asset documentation
+
+### Medium Priority (Enhancement)
+1. **Character Pose Upgrades**: Implement dynamic poses
+2. **Lighting Enhancement**: Improve visual quality
+3. **Performance Monitoring**: Track asset performance
+4. **Automated Pipeline**: Streamline asset workflow
+
+### Low Priority (Optimization)
+1. **Advanced Rendering**: Higher quality exports
+2. **Interactive Elements**: 3D interaction capabilities
+3. **Asset Analytics**: Usage tracking and insights
+4. **Advanced Optimization**: ML-based optimization
+
+## Monitoring and Success Metrics
+
+### Key Performance Indicators
+- **Asset Load Time**: Average asset loading speed
+- **File Size Efficiency**: Compression ratio and performance
+- **User Engagement**: Asset interaction and usage
+- **Quality Score**: Visual quality assessment
+- **Deployment Success**: Asset deployment success rate
+
+### Monitoring Tools
+- **Performance Monitoring**: Web performance tracking
+- **Quality Assurance**: Automated quality checks
+- **Usage Analytics**: Asset usage patterns
+- **Error Tracking**: Asset delivery errors
+- **Security Scanning**: Asset vulnerability scanning
+
+## Testing Procedures
+
+### Asset Quality Tests
+1. **Visual Quality**: Manual visual assessment
+2. **Technical Specs**: File size and format validation
+3. **Performance**: Load time and optimization testing
+4. **Accessibility**: Screen reader and accessibility testing
+5. **Cross-Browser**: Compatibility testing across browsers
+
+### Integration Tests
+1. **Web Deployment**: Asset deployment to web
+2. **Performance Impact**: Effect on page load times
+3. **User Experience**: Impact on user interaction
+4. **Mobile Performance**: Mobile device optimization
+5. **CDN Performance**: Content delivery effectiveness
+
+## Documentation Requirements
+
+### Technical Documentation
+- **Asset Pipeline**: Complete asset workflow documentation
+- **Optimization Guide**: Web optimization best practices
+- **Quality Standards**: Asset quality requirements
+- **Deployment Guide**: Asset deployment procedures
+
+### Creative Documentation
+- **Visual Style Guide**: Asset style and branding guidelines
+- **Character Bible**: Character development documentation
+- **Environment Guide**: Environment creation standards
+- **Asset Catalog**: Complete asset inventory and metadata
+
+## Conclusion
+
+The LWA Blender world asset pipeline has a strong foundation with local asset generation and a clear vision for web integration. The current local-only assets provide excellent material for web deployment, with specific character pose upgrades and optimization needed for production readiness.
+
+**Priority**: High - Implement asset promotion system and web optimization
+**Risk**: Medium - Local assets are high quality but need web optimization
+**Timeline**: 1-2 weeks for basic web integration, 2-3 weeks for full character upgrades
+
+The current system is suitable for asset development and local testing, with clear roadmap for web deployment and user-facing asset delivery.


### PR DESCRIPTION
Adds docs-only runbook for local Blender asset inventory, deck-ready shortlist, Batch 3 character upgrades, asset safety rules, and future web promotion criteria.