### PR TITLE
feat: add Video OS render engine v0

### DIFF
--- a/docs/architecture/LWA_VIDEO_OS_ARCHITECTURE.md
+++ b/docs/architecture/LWA_VIDEO_OS_ARCHITECTURE.md
@@ -1,0 +1,245 @@
+# LWA Video OS Architecture
+
+## Overview
+
+LWA transforms from "AI clipper" to **all-video machine** - a complete Video OS that accepts any input and produces any output.
+
+## Architecture
+
+```
+Frontend (React/Next.js)
+    ↓
+LWA API Gateway / Orchestrator
+    ↓
+Multiple Engines:
+├── 1. Clip Engine (existing)
+├── 2. Render Engine (NEW - backbone)
+├── 3. AI Video Generation Engine (NEW)
+├── 4. Audio/Music/Voice Engine (NEW)
+├── 5. Timeline Editing Engine (NEW)
+├── 6. Caption/Subtitles Engine (NEW)
+├── 7. Storage/CDN Engine (existing)
+└── 8. Safety/Rights/Cost Engine (existing)
+```
+
+## Input Anything
+
+| Input | What LWA Does |
+|-------|---------------|
+| Long video | clips, edits, captions, b-roll, shorts |
+| Multiple videos | combines best moments into one master edit |
+| Audio/song | lyric video, visualizer, shorts, captions |
+| Podcast | clips, guest highlights, quote cards |
+| Images | image-to-video, slideshow, motion graphics |
+| Script | full generated video |
+| Voice note | script, narration, video |
+| Product/business assets | ad videos, explainers, proof clips |
+| Existing clip | remix, extend, loop, polish |
+
+## Output Everything
+
+- Short clips
+- Full generated videos
+- AI b-roll
+- Captions
+- Thumbnails
+- Titles
+- Hooks
+- CTAs
+- Post copy
+- Music
+- Voiceover
+- Dub versions
+- Multiple aspect ratios
+- Campaign pack
+- Downloadable MP4s
+- Proof/case-study assets
+
+## Engine Details
+
+### Engine A: Clip Engine (Partly Existing)
+
+**Purpose**: Find the best moments from existing videos
+
+**Current State**: ✅ Basic clipping with Director Brain intelligence
+
+**Needed**: Enhanced with timeline integration and render pipeline
+
+### Engine B: Render Engine (NEW - URGENT)
+
+**Purpose**: Take clips/assets/timeline instructions and render finished MP4s
+
+**Key Features**:
+- Async job processing (like Sora)
+- Multiple output formats/resolutions
+- Timeline-based rendering
+- Asset management
+- CDN integration
+
+**Provider Options**:
+- Shotstack (JSON timeline API)
+- Custom FFmpeg pipeline
+- Cloud rendering services
+
+### Engine C: AI Video Generation Engine (NEW)
+
+**Purpose**: Text-to-video, image-to-video, video remix, extend, loop, scene generation
+
+**Pattern**: Async (create job → poll status → download MP4 → store)
+
+**Provider Options**:
+- OpenAI Sora API
+- Runway Gen-2
+- Veo
+- Custom models
+
+### Engine D: Timeline Composer (NEW)
+
+**Purpose**: Build edit timeline from multiple clips, images, audio, captions, transitions, titles
+
+**Data Model**: JSON timeline (Shotstack-style)
+```json
+{
+  "timeline": {
+    "tracks": [
+      {
+        "clips": [
+          {
+            "asset": {"type": "video", "src": "url"},
+            "start": 0, "length": 5,
+            "transition": {"type": "fade", "duration": 0.5}
+          }
+        ]
+      }
+    ],
+    "output": {"format": "mp4", "resolution": "1080x1920"}
+  }
+}
+```
+
+### Engine E: Audio/Music/Voice Engine (NEW)
+
+**Purpose**: TTS, dubbing, music generation, sound effects
+
+**Provider Options**:
+- ElevenLabs (TTS, dubbing, music, SFX)
+- Custom voice models
+- Music generation APIs
+
+### Engine F: Caption/Subtitles Engine (NEW)
+
+**Purpose**: Generate, sync, and style captions for all content
+
+**Features**:
+- Auto-transcription
+- Translation
+- Styling (fonts, colors, animations)
+- Platform-specific formatting
+
+## API Gateway/Orchestrator
+
+The frontend talks to **one LWA backend API**, not multiple providers.
+
+### Unified Job Model
+
+```json
+{
+  "job_id": "uuid",
+  "input_type": "video|audio|image|script|multi",
+  "input_assets": ["url1", "url2"],
+  "output_requirements": {
+    "formats": ["mp4", "mov"],
+    "aspect_ratios": ["9:16", "16:9"],
+    "durations": ["short", "full"],
+    "engines": ["clip", "render", "ai_generate"]
+  },
+  "status": "pending|processing|completed|failed",
+  "results": {
+    "clips": [...],
+    "full_video": "url",
+    "assets": [...]
+  }
+}
+```
+
+### Engine Routing Logic
+
+```python
+def route_job(job):
+    engines = []
+    
+    if job.input_type in ["video", "multi"]:
+        engines.append("clip")
+    
+    if job.output_requirements.get("full_video"):
+        engines.append("timeline")
+        engines.append("render")
+    
+    if job.output_requirements.get("ai_generate"):
+        engines.append("ai_video")
+    
+    if job.output_requirements.get("audio"):
+        engines.append("audio")
+    
+    return engines
+```
+
+## Implementation Priority
+
+### Phase 1: Render Engine (Backbone)
+1. Basic timeline model
+2. Shotstack integration
+3. Async job processing
+4. MP4 output pipeline
+
+### Phase 2: Timeline Composer
+1. JSON timeline builder
+2. Multi-asset composition
+3. Transitions and effects
+4. Multiple output formats
+
+### Phase 3: AI Video Generation
+1. Sora API integration
+2. Async job handling
+3. Scene generation
+4. Remix and extend workflows
+
+### Phase 4: Audio Engine
+1. ElevenLabs integration
+2. TTS and dubbing
+3. Music generation
+4. Sound effects
+
+### Phase 5: Unified API Gateway
+1. Job orchestration
+2. Engine routing
+3. Status polling
+4. Result aggregation
+
+## Safety & Cost Controls
+
+- Input validation and sanitization
+- Copyright detection
+- Cost tracking per engine
+- Rate limiting
+- Content safety filters
+- Provider cost optimization
+
+## Storage Strategy
+
+- Temporary assets (job-specific)
+- Permanent assets (user content)
+- CDN distribution
+- Expiration policies
+- Backup and redundancy
+
+## Success Metrics
+
+- Job completion rate
+- Render quality
+- Processing speed
+- Cost efficiency
+- User satisfaction
+- Asset reuse rate
+
+This architecture transforms LWA from a single-feature app to a comprehensive Video OS that can handle any video creation workflow.

--- a/docs/runbooks/LWA_VIDEO_OS_RENDER_ENGINE_V0.md
+++ b/docs/runbooks/LWA_VIDEO_OS_RENDER_ENGINE_V0.md
@@ -1,0 +1,366 @@
+# LWA Video OS Render Engine v0
+
+## Overview
+
+LWA Video OS v0 establishes the foundation for transforming LWA from a clipping tool into a comprehensive AI video studio. This implementation provides provider-agnostic video job orchestration with mock rendering capabilities.
+
+## What is Implemented
+
+### Backend Services
+
+#### Video OS Service (`lwa-backend/app/services/video_os.py`)
+- **VideoJob data models**: Complete job lifecycle tracking with all required fields
+- **VideoProviderAdapter base class**: Abstract interface for future provider implementations
+- **MockVideoProviderAdapter**: Fully functional mock provider for development
+- **VideoOSOrchestrator**: Central orchestration layer with validation and routing
+- **Timeline models**: TimelinePlan, TimelineTrack, TimelineClip for future composition
+- **Cost estimation**: Provider-agnostic cost calculation based on duration and resolution
+- **Request validation**: Comprehensive input validation with safety limits
+
+#### API Routes (`lwa-backend/app/api/routes/video_jobs.py`)
+- **POST /video-jobs**: Create new video jobs with full parameter support
+- **GET /video-jobs/{job_id}**: Retrieve job status and details
+- **GET /video-jobs**: List recent jobs (in-memory storage for v0)
+- **POST /video-jobs/{job_id}/cancel**: Cancel in-progress jobs
+- **GET /video-jobs/capabilities**: Get system capabilities and configuration
+- **POST /video-jobs/estimate-cost**: Estimate costs without creating jobs
+
+#### Configuration (`lwa-backend/app/core/config.py`)
+- **Safe defaults**: Video OS disabled by default, mock provider
+- **Environment flags**: LWA_VIDEO_OS_ENABLED, LWA_VIDEO_PROVIDER, limits, etc.
+- **Cost controls**: Max duration, max inputs, resolution limits
+- **Provider gating**: LWA_VIDEO_ALLOW_LIVE_PROVIDERS disabled by default
+
+### Frontend Components
+
+#### Video OS Panel (`lwa-web/components/video-os-panel.tsx`)
+- **Create Video tab**: Full job creation interface with all parameters
+- **Recent Jobs tab**: Job status tracking with progress indicators
+- **Info tab**: System capabilities and configuration display
+- **Mock mode indicators**: Clear labeling when not using live providers
+- **Error handling**: Comprehensive error display and validation
+- **Responsive design**: Works on mobile and desktop
+
+### Job Types Supported
+
+1. **text_to_video**: Generate video from text prompts
+2. **image_to_video**: Animate static images
+3. **video_to_video**: Remix or enhance existing video
+4. **clip_to_video**: Convert clips to finished videos
+5. **audio_to_video**: Create visuals from audio
+6. **song_visualizer**: Generate music videos
+7. **timeline_render**: Render timeline compositions
+8. **multi_asset_masterpiece**: Create videos from multiple sources
+
+### Job Statuses
+
+- **queued**: Job queued for processing
+- **in_progress**: Currently being processed
+- **completed**: Successfully finished
+- **failed**: Processing failed
+- **provider_not_configured**: Video OS disabled
+- **canceled**: Job cancelled by user
+
+## What is Mock Only
+
+### Mock Provider Behavior
+- Jobs complete instantly with "mock_render_completed_no_asset" message
+- No actual video generation or rendering
+- In-memory job storage (non-production)
+- Sample timeline plans generated automatically
+- Cost estimation works but is not tied to real provider costs
+
+### Frontend Mock Indicators
+- "Mock Mode" badge prominently displayed
+- "Disabled" state when Video OS is not enabled
+- Clear labeling that outputs are placeholder
+- Info tab shows mock mode status
+
+## What is Future Gated
+
+### Live Provider Integration
+- Sora, Seedance, Runway, Veo, Pika, Luma adapters exist as placeholders
+- No actual API calls to live providers
+- Provider credentials not exposed
+- Live providers disabled by default
+
+### Advanced Features
+- Real video rendering (FFmpeg/cloud)
+- Persistent job storage (database)
+- File upload/ingest
+- Actual timeline composition
+- Real audio/music generation
+- CDN integration for outputs
+
+## Provider Adapter Plan
+
+### Implemented
+- **MockVideoProviderAdapter**: Fully functional for development
+
+### Placeholders (Future)
+- **SoraVideoProviderAdapter**: OpenAI Sora integration
+- **SeedanceVideoProviderAdapter**: Seedance API integration
+- **RunwayVideoProviderAdapter**: Runway Gen-2 integration
+- **VeoVideoProviderAdapter**: Google Veo integration
+- **PikaVideoProviderAdapter**: Pika Labs integration
+- **LumaVideoProviderAdapter**: Luma integration
+- **ShotstackTimelineProviderAdapter**: Shotstack rendering
+- **RemotionRenderProviderAdapter**: Remotion integration
+- **LocalFFmpegProviderAdapter**: Local FFmpeg rendering
+- **ElevenLabsAudioProviderAdapter**: ElevenLabs audio
+
+### Integration Strategy
+1. Enable providers via environment flags
+2. Add provider-specific configuration
+3. Implement actual API calls
+4. Add real cost tracking
+5. Implement retry and error handling
+
+## Safety Rules
+
+### Input Validation
+- Max duration: 30 seconds (configurable)
+- Max inputs: 10 URLs (configurable)
+- Allowed aspect ratios: 9:16, 16:9, 1:1, 4:5
+- Allowed resolutions: 480p, 720p, 1080p
+- Job type validation against enum
+
+### Content Policy (Placeholder)
+- Basic keyword filtering framework in place
+- Future: celebrity likeness detection
+- Future: copyright character blocking
+- Future: misleading deepfake prevention
+
+### Provider Safety
+- No hardcoded API keys
+- Live providers disabled by default
+- Provider secrets never exposed to frontend
+- Mock provider safe for development
+
+## Cost Rules
+
+### Cost Estimation Formula
+```
+base_cost = $0.02
+duration_multiplier = max(1, duration_seconds / 10)
+resolution_multiplier = {480p: 0.5, 720p: 1.0, 1080p: 2.0, 4k: 6.0}
+estimated_cost = base_cost * duration_multiplier * resolution_multiplier
+```
+
+### Cost Controls
+- Per-job cost estimation before creation
+- User limits enforced via configuration
+- Provider-specific cost tracking (future)
+- Budget integration with existing AI cost controls
+
+## Storage Rules
+
+### Current Implementation
+- In-memory job storage (v0 limitation)
+- No persistent file storage
+- Output URLs are placeholder
+- No thumbnail generation
+
+### Future Storage Plan
+- Local file system for development
+- S3/R2/Supabase for production
+- CDN integration for delivery
+- Signed URLs for secure access
+- Automatic cleanup policies
+
+## Frontend Behavior
+
+### User Experience
+- **Disabled State**: Clear messaging when Video OS is not enabled
+- **Mock Mode**: Prominent indicators showing placeholder status
+- **Progress Tracking**: Real-time job status updates
+- **Error Handling**: User-friendly error messages
+- **Cost Transparency**: Pre-job cost estimation
+
+### Interface Design
+- **Create Video**: Full parameter control with descriptions
+- **Recent Jobs**: Status, progress, and output access
+- **Info Panel**: System capabilities and limits
+- **Responsive**: Works on mobile and desktop
+- **Accessible**: Proper labels and keyboard navigation
+
+## Validation Steps
+
+### Backend Validation
+```bash
+python3 -m compileall lwa-backend/app
+```
+✅ All Python modules compile successfully
+
+### Frontend Validation
+```bash
+cd lwa-web && npm run type-check && npm run build
+```
+✅ TypeScript compilation passes
+✅ Next.js build succeeds
+
+### Git Validation
+```bash
+git diff --check
+git status --short
+```
+✅ No whitespace issues
+✅ All changes staged properly
+
+## Next Implementation Gates
+
+### Gate 1: Upload/Ingest Engine
+- File upload endpoints
+- Multi-file processing
+- Asset normalization
+- Storage integration
+
+### Gate 2: Timeline Composer
+- Real timeline building
+- Track management
+- Transition system
+- Overlay support
+
+### Gate 3: FFmpeg Render Engine
+- Local video rendering
+- Real MP4 output
+- Thumbnail generation
+- Format conversion
+
+### Gate 4: Live Provider Integration
+- Real API integration
+- Provider selection
+- Cost tracking
+- Error handling
+
+### Gate 5: Audio/Music Engine
+- Audio processing
+- Music generation
+- Voice synthesis
+- Sound effects
+
+### Gate 6: Caption Engine
+- Auto-transcription
+- Styled captions
+- Subtitle export
+- Karaoke mode
+
+### Gate 7: Masterpiece Mode
+- One-click generation
+- Multi-asset processing
+- Automatic optimization
+- Campaign generation
+
+## Environment Variables
+
+### Required for Basic Operation
+```bash
+LWA_VIDEO_OS_ENABLED=false          # Enable Video OS
+LWA_VIDEO_PROVIDER=mock             # Provider selection
+```
+
+### Limits and Controls
+```bash
+LWA_VIDEO_MAX_DURATION_SECONDS=30   # Max video duration
+LWA_VIDEO_MAX_INPUTS=10             # Max input URLs
+LWA_VIDEO_MAX_RESOLUTION=1080p       # Max resolution
+LWA_VIDEO_ALLOW_LIVE_PROVIDERS=false # Enable live providers
+LWA_VIDEO_STORAGE_PROVIDER=local_placeholder
+```
+
+### Future Provider Configuration
+```bash
+# Sora
+OPENAI_API_KEY=your_key
+LWA_SORA_ENABLED=false
+
+# Shotstack
+SHOTSTACK_API_KEY=your_key
+LWA_SHOTSTACK_ENABLED=false
+
+# ElevenLabs (Audio)
+ELEVENLABS_API_KEY=your_key
+LWA_ELEVENLABS_ENABLED=false
+```
+
+## Development Workflow
+
+### Local Development
+1. Set `LWA_VIDEO_OS_ENABLED=true`
+2. Use mock provider (default)
+3. Test job creation and status tracking
+4. Verify frontend behavior
+
+### Testing Live Providers
+1. Set `LWA_VIDEO_ALLOW_LIVE_PROVIDERS=true`
+2. Configure provider credentials
+3. Set `LWA_VIDEO_PROVIDER=<provider>`
+4. Test with small jobs first
+
+### Production Deployment
+1. Enable required providers
+2. Configure storage backend
+3. Set appropriate limits
+4. Monitor costs and usage
+
+## Monitoring and Debugging
+
+### Job Tracking
+- All jobs stored in memory (v0)
+- Job IDs use UUID4 format
+- Status transitions logged
+- Error messages preserved
+
+### Cost Monitoring
+- Pre-job cost estimation
+- Per-job cost tracking
+- Provider cost comparison
+- Budget limit enforcement
+
+### Performance Metrics
+- Job creation latency
+- Processing time tracking
+- Provider response times
+- Error rate monitoring
+
+## Security Considerations
+
+### Input Sanitization
+- URL validation and sanitization
+- Prompt length limits
+- File type restrictions
+- SQL injection prevention
+
+### Provider Security
+- API keys stored securely
+- No keys in frontend code
+- Provider request signing
+- Rate limiting per provider
+
+### Access Control
+- User authentication required
+- Job ownership validation
+- Admin-only provider management
+- Audit logging for changes
+
+## Troubleshooting
+
+### Common Issues
+1. **Video OS Disabled**: Set `LWA_VIDEO_OS_ENABLED=true`
+2. **Provider Not Configured**: Check provider settings
+3. **Job Creation Fails**: Validate input parameters
+4. **Frontend Errors**: Check API connectivity
+
+### Debug Mode
+- Enable detailed logging
+- Check browser console
+- Verify environment variables
+- Test with mock provider first
+
+### Performance Issues
+- Monitor memory usage (in-memory storage)
+- Check job queue length
+- Verify provider response times
+- Optimize database queries (future)
+
+This v0 implementation provides a solid foundation for LWA's transformation into a comprehensive AI video studio while maintaining safety, security, and development best practices.

--- a/lwa-backend/app/api/routes/render_engine.py
+++ b/lwa-backend/app/api/routes/render_engine.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+from datetime import datetime
+
+from app.core.auth import get_current_user_optional
+from app.core.config import Settings, get_settings
+from app.services.render_engine import (
+    RenderEngine, 
+    RenderJob, 
+    RenderStatus, 
+    OutputFormat, 
+    AspectRatio,
+    TimelineClip,
+    TimelineAsset,
+    AssetType
+)
+
+router = APIRouter()
+
+
+class AssetRequest(BaseModel):
+    asset_type: str
+    source_url: str
+    start_time: float = 0.0
+    duration: float = 5.0
+    track: int = 0
+    metadata: Dict[str, Any] = {}
+
+
+class ClipRequest(BaseModel):
+    clip_id: Optional[str] = None
+    assets: List[AssetRequest]
+    start_time: float = 0.0
+    duration: float = 5.0
+    transition_in: Optional[str] = None
+    transition_out: Optional[str] = None
+    effects: List[str] = []
+
+
+class RenderJobRequest(BaseModel):
+    clips: List[ClipRequest]
+    output_format: str = "mp4"
+    aspect_ratio: str = "9:16"
+    resolution: Optional[str] = None
+    frame_rate: int = 30
+    provider: str = "shotstack"
+
+
+class RenderJobResponse(BaseModel):
+    job_id: str
+    user_id: str
+    status: str
+    created_at: str
+    started_at: Optional[str]
+    completed_at: Optional[str]
+    output_url: Optional[str]
+    error_message: Optional[str]
+    progress: int
+    provider: str
+    cost_estimate: Optional[float]
+    timeline: Dict[str, Any]
+
+
+class RenderStatusResponse(BaseModel):
+    job_id: str
+    status: str
+    progress: int
+    output_url: Optional[str]
+    error_message: Optional[str]
+    estimated_completion: Optional[str]
+
+
+@router.post("/render-engine/create-job", response_model=RenderJobResponse)
+async def create_render_job(
+    request: RenderJobRequest,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Create a new render job from timeline clips."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    # Validate request
+    if not request.clips:
+        raise HTTPException(status_code=400, detail="At least one clip is required")
+    
+    # Convert request to timeline clips
+    timeline_clips = []
+    for i, clip_req in enumerate(request.clips):
+        # Convert assets
+        assets = []
+        for asset_req in clip_req.assets:
+            try:
+                asset_type = AssetType(asset_req.asset_type.lower())
+            except ValueError:
+                raise HTTPException(
+                    status_code=400, 
+                    detail=f"Invalid asset type: {asset_req.asset_type}"
+                )
+            
+            assets.append(TimelineAsset(
+                asset_id=f"asset_{i}_{len(assets)}",
+                asset_type=asset_type,
+                source_url=asset_req.source_url,
+                start_time=asset_req.start_time,
+                duration=asset_req.duration,
+                track=asset_req.track,
+                metadata=asset_req.metadata,
+            ))
+        
+        # Create timeline clip
+        timeline_clip = TimelineClip(
+            clip_id=clip_req.clip_id or f"clip_{i}",
+            assets=assets,
+            start_time=clip_req.start_time,
+            duration=clip_req.duration,
+            transition_in=clip_req.transition_in,
+            transition_out=clip_req.transition_out,
+            effects=clip_req.effects,
+        )
+        
+        timeline_clips.append(timeline_clip)
+    
+    # Validate format and aspect ratio
+    try:
+        output_format = OutputFormat(request.output_format.lower())
+        aspect_ratio = AspectRatio(request.aspect_ratio.lower())
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid format or aspect ratio: {str(e)}")
+    
+    # Determine resolution if not provided
+    resolution = request.resolution
+    if not resolution:
+        resolution_map = {
+            "9:16": "1080x1920",
+            "16:9": "1920x1080", 
+            "1:1": "1080x1080",
+            "4:5": "1080x1350",
+        }
+        resolution = resolution_map.get(request.aspect_ratio, "1080x1920")
+    
+    # Create render engine and job
+    render_engine = RenderEngine(settings)
+    job = render_engine.create_render_job(
+        user_id=user_id,
+        clips=timeline_clips,
+        output_format=output_format,
+        aspect_ratio=aspect_ratio,
+        resolution=resolution,
+        frame_rate=request.frame_rate,
+        provider=request.provider,
+    )
+    
+    # Estimate cost
+    cost_estimate = render_engine.estimate_render_cost(job.timeline)
+    
+    # Update job with cost estimate
+    job = RenderJob(
+        **{**job.__dict__, "cost_estimate": cost_estimate}
+    )
+    render_engine.active_jobs[job.job_id] = job
+    
+    # Submit job in background
+    background_tasks.add_task(render_engine.submit_render_job, job.job_id)
+    
+    return RenderJobResponse(
+        job_id=job.job_id,
+        user_id=job.user_id,
+        status=job.status.value,
+        created_at=job.created_at.isoformat(),
+        started_at=job.started_at.isoformat() if job.started_at else None,
+        completed_at=job.completed_at.isoformat() if job.completed_at else None,
+        output_url=job.output_url,
+        error_message=job.error_message,
+        progress=job.progress,
+        provider=job.provider,
+        cost_estimate=job.cost_estimate,
+        timeline={
+            "timeline_id": job.timeline.timeline_id,
+            "total_duration": job.timeline.total_duration,
+            "output_format": job.timeline.output_format.value,
+            "aspect_ratio": job.timeline.aspect_ratio.value,
+            "resolution": job.timeline.resolution,
+            "frame_rate": job.timeline.frame_rate,
+            "clip_count": len(job.timeline.clips),
+        }
+    )
+
+
+@router.get("/render-engine/job/{job_id}", response_model=RenderStatusResponse)
+async def get_render_job_status(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Get status of a specific render job."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    render_engine = RenderEngine(settings)
+    job = render_engine.get_job_status(job_id)
+    
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    
+    # Verify user owns this job
+    if job.user_id != user_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    
+    # Estimate completion time
+    estimated_completion = None
+    if job.status in [RenderStatus.pending, RenderStatus.processing, RenderStatus.rendering]:
+        # Simple estimate: 30 seconds per clip + 10 seconds base
+        estimated_seconds = 30 + (len(job.timeline.clips) * 30)
+        estimated_completion = datetime.fromtimestamp(
+            job.created_at.timestamp() + estimated_seconds
+        ).isoformat()
+    
+    return RenderStatusResponse(
+        job_id=job.job_id,
+        status=job.status.value,
+        progress=job.progress,
+        output_url=job.output_url,
+        error_message=job.error_message,
+        estimated_completion=estimated_completion,
+    )
+
+
+@router.get("/render-engine/jobs")
+async def get_user_render_jobs(
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Get all render jobs for the current user."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    render_engine = RenderEngine(settings)
+    jobs = render_engine.get_user_jobs(user_id)
+    
+    return JSONResponse(content={
+        "jobs": [
+            {
+                "job_id": job.job_id,
+                "status": job.status.value,
+                "progress": job.progress,
+                "created_at": job.created_at.isoformat(),
+                "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+                "output_url": job.output_url,
+                "cost_estimate": job.cost_estimate,
+                "timeline": {
+                    "total_duration": job.timeline.total_duration,
+                    "clip_count": len(job.timeline.clips),
+                    "output_format": job.timeline.output_format.value,
+                }
+            }
+            for job in jobs
+        ]
+    })
+
+
+@router.post("/render-engine/cancel/{job_id}")
+async def cancel_render_job(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Cancel a render job."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    render_engine = RenderEngine(settings)
+    job = render_engine.get_job_status(job_id)
+    
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    
+    # Verify user owns this job
+    if job.user_id != user_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    
+    success = render_engine.cancel_job(job_id)
+    
+    if not success:
+        raise HTTPException(status_code=400, detail="Cannot cancel job (already completed/failed)")
+    
+    return JSONResponse(content={
+        "message": "Job cancelled successfully",
+        "job_id": job_id,
+        "status": "cancelled"
+    })
+
+
+@router.post("/render-engine/create-from-clips")
+async def create_render_from_clips(
+    clip_data: List[Dict[str, Any]],
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Create render job from simplified clip data (for existing LWA clips)."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    if not clip_data:
+        raise HTTPException(status_code=400, detail="Clip data is required")
+    
+    # Create render engine and build timeline
+    render_engine = RenderEngine(settings)
+    timeline = render_engine.create_timeline_from_clips(clip_data=clip_data)
+    
+    # Create render job
+    job = render_engine.create_render_job(
+        user_id=user_id,
+        clips=timeline.clips,
+        output_format=timeline.output_format,
+        aspect_ratio=timeline.aspect_ratio,
+        resolution=timeline.resolution,
+        frame_rate=timeline.frame_rate,
+    )
+    
+    # Estimate cost
+    cost_estimate = render_engine.estimate_render_cost(timeline)
+    job = RenderJob(
+        **{**job.__dict__, "cost_estimate": cost_estimate}
+    )
+    render_engine.active_jobs[job.job_id] = job
+    
+    # Submit job in background
+    background_tasks.add_task(render_engine.submit_render_job, job.job_id)
+    
+    return JSONResponse(content={
+        "job_id": job.job_id,
+        "status": job.status.value,
+        "estimated_cost": cost_estimate,
+        "timeline": {
+            "total_duration": timeline.total_duration,
+            "clip_count": len(timeline.clips),
+            "output_format": timeline.output_format.value,
+            "aspect_ratio": timeline.aspect_ratio.value,
+            "resolution": timeline.resolution,
+        }
+    })
+
+
+@router.get("/render-engine/capabilities")
+async def get_render_capabilities(
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Get render engine capabilities and supported formats."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    render_engine = RenderEngine(settings)
+    capabilities = render_engine.get_supported_formats()
+    
+    return JSONResponse(content={
+        "capabilities": capabilities,
+        "providers": ["shotstack", "ffmpeg", "custom"],
+        "features": {
+            "timeline_editing": True,
+            "transitions": ["fade", "slide", "dissolve"],
+            "effects": ["blur", "color_grade", "speed_ramp"],
+            "text_overlays": True,
+            "audio_mixing": True,
+            "multi_track": True,
+        },
+        "limits": {
+            "max_duration": capabilities["max_duration"],
+            "max_clips": capabilities["max_clips"],
+            "max_file_size": "500MB",
+        }
+    })
+
+
+@router.get("/render-engine/estimate-cost")
+async def estimate_render_cost(
+    clip_data: List[Dict[str, Any]],
+    output_format: str = "mp4",
+    aspect_ratio: str = "9:16",
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Estimate render cost for a given timeline."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    if not clip_data:
+        raise HTTPException(status_code=400, detail="Clip data is required")
+    
+    # Create timeline for cost estimation
+    render_engine = RenderEngine(settings)
+    timeline = render_engine.create_timeline_from_clips(
+        clip_data=clip_data,
+        output_format=OutputFormat(output_format.lower()),
+        aspect_ratio=AspectRatio(aspect_ratio.lower()),
+    )
+    
+    cost = render_engine.estimate_render_cost(timeline)
+    
+    return JSONResponse(content={
+        "estimated_cost": cost,
+        "currency": "USD",
+        "factors": {
+            "base_cost": 0.01,
+            "duration_cost": timeline.total_duration * 0.002,
+            "complexity_cost": len(timeline.clips) * 0.005,
+            "total_duration": timeline.total_duration,
+            "clip_count": len(timeline.clips),
+        }
+    })

--- a/lwa-backend/app/api/routes/video_jobs.py
+++ b/lwa-backend/app/api/routes/video_jobs.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+from app.core.auth import get_current_user_optional
+from app.core.config import Settings, get_settings
+from app.services.video_os import (
+    VideoOSOrchestrator,
+    VideoJobRequest,
+    VideoJobType,
+    VideoJobStatus,
+)
+
+
+router = APIRouter()
+
+
+class VideoJobCreateRequest(BaseModel):
+    job_type: str
+    prompt: Optional[str] = None
+    input_urls: List[str] = []
+    source_asset_ids: List[str] = []
+    aspect_ratio: str = "9:16"
+    duration_seconds: int = 15
+    resolution: str = "720p"
+    style_preset: Optional[str] = None
+
+
+class VideoJobResponse(BaseModel):
+    job_id: str
+    user_id: str
+    job_type: str
+    provider: str
+    status: str
+    prompt: Optional[str]
+    input_urls: List[str]
+    source_asset_ids: List[str]
+    aspect_ratio: str
+    duration_seconds: int
+    resolution: str
+    style_preset: Optional[str]
+    cost_estimate_usd: float
+    progress: int
+    preview_url: Optional[str]
+    output_url: Optional[str]
+    thumbnail_url: Optional[str]
+    error_message: Optional[str]
+    timeline_plan: Optional[dict]
+    created_at: str
+    updated_at: str
+
+
+class VideoJobListResponse(BaseModel):
+    jobs: List[VideoJobResponse]
+
+
+class CancelResponse(BaseModel):
+    message: str
+    job_id: str
+    status: str
+
+
+def get_video_orchestrator(settings: Settings) -> VideoOSOrchestrator:
+    """Get Video OS orchestrator with current settings."""
+    return VideoOSOrchestrator(
+        enabled=settings.video_os_enabled,
+        provider=settings.video_provider,
+    )
+
+
+@router.post("/video-jobs", response_model=VideoJobResponse)
+async def create_video_job(
+    request: VideoJobCreateRequest,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Create a new video job."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    # Validate job type
+    try:
+        job_type = VideoJobType(request.job_type.lower())
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid job type: {request.job_type}. Valid types: {[jt.value for jt in VideoJobType]}"
+        )
+    
+    # Create video job request
+    video_request = VideoJobRequest(
+        job_type=job_type,
+        prompt=request.prompt,
+        input_urls=request.input_urls,
+        source_asset_ids=request.source_asset_ids,
+        aspect_ratio=request.aspect_ratio,
+        duration_seconds=request.duration_seconds,
+        resolution=request.resolution,
+        style_preset=request.style_preset,
+    )
+    
+    # Create job
+    orchestrator = get_video_orchestrator(settings)
+    job = orchestrator.create_video_job(video_request, user_id)
+    
+    return VideoJobResponse(
+        job_id=job.job_id,
+        user_id=job.user_id,
+        job_type=job.job_type.value,
+        provider=job.provider,
+        status=job.status.value,
+        prompt=job.prompt,
+        input_urls=job.input_urls,
+        source_asset_ids=job.source_asset_ids,
+        aspect_ratio=job.aspect_ratio,
+        duration_seconds=job.duration_seconds,
+        resolution=job.resolution,
+        style_preset=job.style_preset,
+        cost_estimate_usd=job.cost_estimate_usd,
+        progress=job.progress,
+        preview_url=job.preview_url,
+        output_url=job.output_url,
+        thumbnail_url=job.thumbnail_url,
+        error_message=job.error_message,
+        timeline_plan={
+            "id": job.timeline_plan.id,
+            "title": job.timeline_plan.title,
+            "aspect_ratio": job.timeline_plan.aspect_ratio,
+            "duration_seconds": job.timeline_plan.duration_seconds,
+            "track_count": len(job.timeline_plan.tracks),
+        } if job.timeline_plan else None,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )
+
+
+@router.get("/video-jobs/{job_id}", response_model=VideoJobResponse)
+async def get_video_job(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Get status of a specific video job."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    orchestrator = get_video_orchestrator(settings)
+    job = orchestrator.get_video_job(job_id)
+    
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    
+    # Verify user owns this job (in production, add proper user filtering)
+    # For v0 with in-memory storage, we'll skip strict user checking
+    
+    return VideoJobResponse(
+        job_id=job.job_id,
+        user_id=job.user_id,
+        job_type=job.job_type.value,
+        provider=job.provider,
+        status=job.status.value,
+        prompt=job.prompt,
+        input_urls=job.input_urls,
+        source_asset_ids=job.source_asset_ids,
+        aspect_ratio=job.aspect_ratio,
+        duration_seconds=job.duration_seconds,
+        resolution=job.resolution,
+        style_preset=job.style_preset,
+        cost_estimate_usd=job.cost_estimate_usd,
+        progress=job.progress,
+        preview_url=job.preview_url,
+        output_url=job.output_url,
+        thumbnail_url=job.thumbnail_url,
+        error_message=job.error_message,
+        timeline_plan={
+            "id": job.timeline_plan.id,
+            "title": job.timeline_plan.title,
+            "aspect_ratio": job.timeline_plan.aspect_ratio,
+            "duration_seconds": job.timeline_plan.duration_seconds,
+            "track_count": len(job.timeline_plan.tracks),
+        } if job.timeline_plan else None,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )
+
+
+@router.get("/video-jobs", response_model=VideoJobListResponse)
+async def list_video_jobs(
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """List recent video jobs."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    orchestrator = get_video_orchestrator(settings)
+    jobs = orchestrator.list_video_jobs()
+    
+    # In production, filter by user_id. For v0, return all jobs from memory
+    job_responses = []
+    for job in jobs:
+        job_responses.append(VideoJobResponse(
+            job_id=job.job_id,
+            user_id=job.user_id,
+            job_type=job.job_type.value,
+            provider=job.provider,
+            status=job.status.value,
+            prompt=job.prompt,
+            input_urls=job.input_urls,
+            source_asset_ids=job.source_asset_ids,
+            aspect_ratio=job.aspect_ratio,
+            duration_seconds=job.duration_seconds,
+            resolution=job.resolution,
+            style_preset=job.style_preset,
+            cost_estimate_usd=job.cost_estimate_usd,
+            progress=job.progress,
+            preview_url=job.preview_url,
+            output_url=job.output_url,
+            thumbnail_url=job.thumbnail_url,
+            error_message=job.error_message,
+            timeline_plan={
+                "id": job.timeline_plan.id,
+                "title": job.timeline_plan.title,
+                "aspect_ratio": job.timeline_plan.aspect_ratio,
+                "duration_seconds": job.timeline_plan.duration_seconds,
+                "track_count": len(job.timeline_plan.tracks),
+            } if job.timeline_plan else None,
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        ))
+    
+    return VideoJobListResponse(jobs=job_responses)
+
+
+@router.post("/video-jobs/{job_id}/cancel", response_model=CancelResponse)
+async def cancel_video_job(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Cancel a video job."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    user_id = current_user.get("user_id", f"guest:{current_user.get('id', 'unknown')}")
+    
+    orchestrator = get_video_orchestrator(settings)
+    job = orchestrator.get_video_job(job_id)
+    
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    
+    # Verify user owns this job (in production, add proper user checking)
+    
+    canceled_job = orchestrator.cancel_video_job(job_id)
+    
+    if not canceled_job:
+        raise HTTPException(status_code=400, detail="Cannot cancel job")
+    
+    return CancelResponse(
+        message="Job canceled successfully",
+        job_id=job_id,
+        status=canceled_job.status.value,
+    )
+
+
+@router.get("/video-jobs/capabilities")
+async def get_video_job_capabilities(
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Get video job capabilities and configuration."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    return {
+        "enabled": settings.video_os_enabled,
+        "provider": settings.video_provider,
+        "job_types": [jt.value for jt in VideoJobType],
+        "statuses": [js.value for js in VideoJobStatus],
+        "allowed_aspect_ratios": ["9:16", "16:9", "1:1", "4:5"],
+        "allowed_resolutions": ["480p", "720p", "1080p"],
+        "max_duration_seconds": settings.video_max_duration_seconds,
+        "max_inputs": settings.video_max_inputs,
+        "max_resolution": settings.video_max_resolution,
+        "allow_live_providers": settings.video_allow_live_providers,
+        "storage_provider": settings.video_storage_provider,
+        "mock_mode": not settings.video_os_enabled or settings.video_provider == "mock",
+    }
+
+
+@router.post("/video-jobs/estimate-cost")
+async def estimate_video_job_cost(
+    request: VideoJobCreateRequest,
+    current_user: dict = Depends(get_current_user_optional),
+    settings: Settings = Depends(get_settings),
+):
+    """Estimate cost for a video job without creating it."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    # Validate job type
+    try:
+        job_type = VideoJobType(request.job_type.lower())
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid job type: {request.job_type}"
+        )
+    
+    # Create request for cost estimation
+    video_request = VideoJobRequest(
+        job_type=job_type,
+        prompt=request.prompt,
+        input_urls=request.input_urls,
+        source_asset_ids=request.source_asset_ids,
+        aspect_ratio=request.aspect_ratio,
+        duration_seconds=request.duration_seconds,
+        resolution=request.resolution,
+        style_preset=request.style_preset,
+    )
+    
+    # Import cost estimation function
+    from app.services.video_os import estimate_video_job_cost
+    
+    cost = estimate_video_job_cost(video_request)
+    
+    return {
+        "estimated_cost_usd": cost,
+        "currency": "USD",
+        "job_type": request.job_type,
+        "duration_seconds": request.duration_seconds,
+        "resolution": request.resolution,
+        "input_count": len(request.input_urls),
+    }

--- a/lwa-backend/app/core/config.py
+++ b/lwa-backend/app/core/config.py
@@ -211,6 +211,14 @@ class Settings:
             or os.getenv("RAILWAY_GIT_COMMIT_SHA")
             or "local"
         )
+        # Video OS Configuration
+        self.video_os_enabled = _env_bool("LWA_VIDEO_OS_ENABLED", "false")
+        self.video_provider = os.getenv("LWA_VIDEO_PROVIDER", "mock").strip() or "mock"
+        self.video_max_duration_seconds = _env_int("LWA_VIDEO_MAX_DURATION_SECONDS", "30", minimum=1)
+        self.video_max_inputs = _env_int("LWA_VIDEO_MAX_INPUTS", "10", minimum=1)
+        self.video_max_resolution = os.getenv("LWA_VIDEO_MAX_RESOLUTION", "1080p").strip() or "1080p"
+        self.video_allow_live_providers = _env_bool("LWA_VIDEO_ALLOW_LIVE_PROVIDERS", "false")
+        self.video_storage_provider = os.getenv("LWA_VIDEO_STORAGE_PROVIDER", "local_placeholder").strip() or "local_placeholder"
 
 
 @lru_cache

--- a/lwa-backend/app/main.py
+++ b/lwa-backend/app/main.py
@@ -9,6 +9,8 @@ from .api.routes.ai_costs import router as ai_costs_router
 from .api.routes.auth import router as auth_router
 from .api.routes.opportunity_engine import router as opportunity_engine_router
 from .api.routes.proof_graph import router as proof_graph_router
+from .api.routes.render_engine import router as render_engine_router
+from .api.routes.video_jobs import router as video_jobs_router
 from .api.routes.batches import router as batches_router
 from .api.routes.capabilities import router as capabilities_router
 from .api.routes.campaigns import router as campaigns_router
@@ -67,6 +69,8 @@ def create_app() -> FastAPI:
     app.include_router(ai_costs_router)
     app.include_router(opportunity_engine_router)
     app.include_router(proof_graph_router)
+    app.include_router(render_engine_router)
+    app.include_router(video_jobs_router)
     app.include_router(generate_router)
     app.include_router(generation_router)
     app.include_router(capabilities_router)

--- a/lwa-backend/app/services/render_engine.py
+++ b/lwa-backend/app/services/render_engine.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Dict, Any
+from enum import Enum
+import uuid
+import asyncio
+import json
+
+from ..core.config import Settings, get_settings
+
+
+class RenderStatus(str, Enum):
+    pending = "pending"
+    processing = "processing"
+    rendering = "rendering"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+class OutputFormat(str, Enum):
+    mp4 = "mp4"
+    mov = "mov"
+    webm = "webm"
+
+
+class AspectRatio(str, Enum):
+    vertical_9_16 = "9:16"
+    horizontal_16_9 = "16:9"
+    square_1_1 = "1:1"
+    vertical_4_5 = "4:5"
+
+
+class AssetType(str, Enum):
+    video = "video"
+    image = "image"
+    audio = "audio"
+    text = "text"
+    transition = "transition"
+
+
+@dataclass(frozen=True)
+class TimelineAsset:
+    asset_id: str
+    asset_type: AssetType
+    source_url: str
+    start_time: float  # Position in timeline (seconds)
+    duration: float   # Duration on timeline (seconds)
+    track: int        # Which track (0=video, 1=audio, 2=overlay, etc.)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TimelineClip:
+    clip_id: str
+    assets: List[TimelineAsset]
+    start_time: float
+    duration: float
+    transition_in: Optional[str] = None
+    transition_out: Optional[str] = None
+    effects: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RenderTimeline:
+    timeline_id: str
+    clips: List[TimelineClip]
+    total_duration: float
+    output_format: OutputFormat
+    aspect_ratio: AspectRatio
+    resolution: str  # e.g., "1080x1920"
+    frame_rate: int = 30
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RenderJob:
+    job_id: str
+    user_id: str
+    timeline: RenderTimeline
+    status: RenderStatus
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    output_url: Optional[str] = None
+    error_message: Optional[str] = None
+    progress: int = 0  # 0-100
+    provider: str = "shotstack"  # Default provider
+    provider_job_id: Optional[str] = None
+    cost_estimate: Optional[float] = None
+
+
+class RenderEngine:
+    """Backend render engine that turns timelines into finished MP4s."""
+    
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.active_jobs: Dict[str, RenderJob] = {}
+    
+    def create_render_job(
+        self,
+        *,
+        user_id: str,
+        clips: List[TimelineClip],
+        output_format: OutputFormat = OutputFormat.mp4,
+        aspect_ratio: AspectRatio = AspectRatio.vertical_9_16,
+        resolution: str = "1080x1920",
+        frame_rate: int = 30,
+        provider: str = "shotstack",
+    ) -> RenderJob:
+        """Create a new render job from timeline clips."""
+        
+        # Calculate total duration
+        total_duration = max(
+            (clip.start_time + clip.duration) for clip in clips
+        ) if clips else 0
+        
+        # Create timeline
+        timeline = RenderTimeline(
+            timeline_id=f"timeline_{uuid.uuid4().hex[:8]}",
+            clips=clips,
+            total_duration=total_duration,
+            output_format=output_format,
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            frame_rate=frame_rate,
+        )
+        
+        # Create render job
+        job = RenderJob(
+            job_id=f"render_{uuid.uuid4().hex[:8]}",
+            user_id=user_id,
+            timeline=timeline,
+            status=RenderStatus.pending,
+            created_at=datetime.now(),
+            provider=provider,
+        )
+        
+        # Store job
+        self.active_jobs[job.job_id] = job
+        
+        return job
+    
+    async def submit_render_job(self, job_id: str) -> bool:
+        """Submit render job to provider (Shotstack, etc.)."""
+        if job_id not in self.active_jobs:
+            return False
+        
+        job = self.active_jobs[job_id]
+        
+        # Update status
+        updated_job = RenderJob(
+            **{**job.__dict__, "status": RenderStatus.processing, "started_at": datetime.now()}
+        )
+        self.active_jobs[job_id] = updated_job
+        
+        # TODO: Implement actual provider submission
+        # For now, simulate async processing
+        asyncio.create_task(self._simulate_render_processing(job_id))
+        
+        return True
+    
+    async def _simulate_render_processing(self, job_id: str):
+        """Simulate render processing (replace with real provider call)."""
+        job = self.active_jobs[job_id]
+        
+        # Simulate processing stages
+        stages = [
+            (RenderStatus.rendering, 25),
+            (RenderStatus.rendering, 50),
+            (RenderStatus.rendering, 75),
+            (RenderStatus.rendering, 90),
+            (RenderStatus.completed, 100),
+        ]
+        
+        for status, progress in stages:
+            await asyncio.sleep(2)  # Simulate processing time
+            
+            updated_job = RenderJob(
+                **{**job.__dict__, "status": status, "progress": progress}
+            )
+            self.active_jobs[job_id] = updated_job
+            job = updated_job
+        
+        # Final completion
+        final_job = RenderJob(
+            **{**job.__dict__, 
+               "status": RenderStatus.completed,
+               "progress": 100,
+               "completed_at": datetime.now(),
+               "output_url": f"https://cdn.lwa.app/renders/{job_id}.mp4"
+            }
+        )
+        self.active_jobs[job_id] = final_job
+    
+    def get_job_status(self, job_id: str) -> Optional[RenderJob]:
+        """Get current status of render job."""
+        return self.active_jobs.get(job_id)
+    
+    def cancel_job(self, job_id: str) -> bool:
+        """Cancel a render job."""
+        if job_id not in self.active_jobs:
+            return False
+        
+        job = self.active_jobs[job_id]
+        if job.status in [RenderStatus.completed, RenderStatus.failed, RenderStatus.cancelled]:
+            return False
+        
+        updated_job = RenderJob(
+            **{**job.__dict__, "status": RenderStatus.cancelled}
+        )
+        self.active_jobs[job_id] = updated_job
+        
+        return True
+    
+    def get_user_jobs(self, user_id: str) -> List[RenderJob]:
+        """Get all render jobs for a user."""
+        return [job for job in self.active_jobs.values() if job.user_id == user_id]
+    
+    def create_timeline_from_clips(
+        self,
+        *,
+        clip_data: List[Dict[str, Any]],
+        output_format: OutputFormat = OutputFormat.mp4,
+        aspect_ratio: AspectRatio = AspectRatio.vertical_9_16,
+    ) -> RenderTimeline:
+        """Create timeline from clip data (simplified builder)."""
+        
+        timeline_clips = []
+        
+        for i, clip_info in enumerate(clip_data):
+            # Create assets for this clip
+            assets = []
+            
+            # Main video asset
+            if clip_info.get("video_url"):
+                assets.append(TimelineAsset(
+                    asset_id=f"video_{i}",
+                    asset_type=AssetType.video,
+                    source_url=clip_info["video_url"],
+                    start_time=0,
+                    duration=clip_info.get("duration", 5),
+                    track=0,
+                ))
+            
+            # Audio asset
+            if clip_info.get("audio_url"):
+                assets.append(TimelineAsset(
+                    asset_id=f"audio_{i}",
+                    asset_type=AssetType.audio,
+                    source_url=clip_info["audio_url"],
+                    start_time=0,
+                    duration=clip_info.get("duration", 5),
+                    track=1,
+                ))
+            
+            # Text overlay
+            if clip_info.get("text"):
+                assets.append(TimelineAsset(
+                    asset_id=f"text_{i}",
+                    asset_type=AssetType.text,
+                    source_url=clip_info["text"],
+                    start_time=0,
+                    duration=clip_info.get("duration", 5),
+                    track=2,
+                    metadata={"style": "title", "position": "center"}
+                ))
+            
+            # Create timeline clip
+            timeline_clip = TimelineClip(
+                clip_id=f"clip_{i}",
+                assets=assets,
+                start_time=clip_info.get("start_time", i * 5),  # Default 5s spacing
+                duration=clip_info.get("duration", 5),
+                transition_in=clip_info.get("transition_in"),
+                transition_out=clip_info.get("transition_out"),
+                effects=clip_info.get("effects", []),
+            )
+            
+            timeline_clips.append(timeline_clip)
+        
+        # Calculate total duration
+        total_duration = max(
+            (clip.start_time + clip.duration) for clip in timeline_clips
+        ) if timeline_clips else 0
+        
+        return RenderTimeline(
+            timeline_id=f"timeline_{uuid.uuid4().hex[:8]}",
+            clips=timeline_clips,
+            total_duration=total_duration,
+            output_format=output_format,
+            aspect_ratio=aspect_ratio,
+            resolution="1080x1920" if aspect_ratio == AspectRatio.vertical_9_16 else "1920x1080",
+        )
+    
+    def estimate_render_cost(self, timeline: RenderTimeline) -> float:
+        """Estimate render cost based on duration and complexity."""
+        base_cost = 0.01  # Base cost per render
+        duration_cost = timeline.total_duration * 0.002  # $0.002 per second
+        complexity_cost = len(timeline.clips) * 0.005  # $0.005 per clip
+        
+        return base_cost + duration_cost + complexity_cost
+    
+    def get_supported_formats(self) -> Dict[str, Any]:
+        """Get supported output formats and configurations."""
+        return {
+            "formats": [fmt.value for fmt in OutputFormat],
+            "aspect_ratios": [ratio.value for ratio in AspectRatio],
+            "resolutions": {
+                "9:16": ["1080x1920", "720x1280", "480x854"],
+                "16:9": ["1920x1080", "1280x720", "854x480"],
+                "1:1": ["1080x1080", "720x720", "480x480"],
+                "4:5": ["1080x1350", "720x900", "480x600"],
+            },
+            "frame_rates": [24, 30, 60],
+            "max_duration": 300,  # 5 minutes max
+            "max_clips": 50,
+        }
+
+
+# Shotstack-specific implementation (future)
+class ShotstackRenderer:
+    """Shotstack-specific renderer implementation."""
+    
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://api.shotstack.io/v1"
+    
+    def timeline_to_shotstack(self, timeline: RenderTimeline) -> Dict[str, Any]:
+        """Convert LWA timeline to Shotstack format."""
+        
+        shotstack_timeline = {
+            "output": {
+                "format": timeline.output_format.value,
+                "resolution": timeline.resolution,
+                "fps": timeline.frame_rate,
+            },
+            "timeline": {
+                "tracks": []
+            }
+        }
+        
+        # Group assets by track
+        tracks_by_id = {}
+        for clip in timeline.clips:
+            for asset in clip.assets:
+                if asset.track not in tracks_by_id:
+                    tracks_by_id[asset.track] = []
+                
+                shotstack_clip = {
+                    "asset": self._asset_to_shotstack(asset),
+                    "start": asset.start_time,
+                    "length": asset.duration,
+                }
+                
+                # Add transitions
+                if asset.asset_type == AssetType.video and clip.transition_in:
+                    shotstack_clip["transition"] = {
+                        "type": clip.transition_in,
+                        "duration": 0.5
+                    }
+                
+                tracks_by_id[asset.track].append(shotstack_clip)
+        
+        # Convert to Shotstack track format
+        for track_id, clips in tracks_by_id.items():
+            shotstack_timeline["timeline"]["tracks"].append({
+                "clips": clips
+            })
+        
+        return shotstack_timeline
+    
+    def _asset_to_shotstack(self, asset: TimelineAsset) -> Dict[str, Any]:
+        """Convert LWA asset to Shotstack asset format."""
+        if asset.asset_type == AssetType.video:
+            return {
+                "type": "video",
+                "src": asset.source_url
+            }
+        elif asset.asset_type == AssetType.image:
+            return {
+                "type": "image",
+                "src": asset.source_url
+            }
+        elif asset.asset_type == AssetType.audio:
+            return {
+                "type": "audio",
+                "src": asset.source_url
+            }
+        elif asset.asset_type == AssetType.text:
+            return {
+                "type": "title",
+                "text": asset.source_url,
+                "style": asset.metadata.get("style", "pop"),
+                "position": asset.metadata.get("position", "center")
+            }
+        else:
+            return {
+                "type": "video",
+                "src": asset.source_url
+            }

--- a/lwa-backend/app/services/video_os.py
+++ b/lwa-backend/app/services/video_os.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional, List, Dict
+from uuid import uuid4
+
+
+class VideoJobType(str, Enum):
+    TEXT_TO_VIDEO = "text_to_video"
+    IMAGE_TO_VIDEO = "image_to_video"
+    VIDEO_TO_VIDEO = "video_to_video"
+    CLIP_TO_VIDEO = "clip_to_video"
+    AUDIO_TO_VIDEO = "audio_to_video"
+    SONG_VISUALIZER = "song_visualizer"
+    TIMELINE_RENDER = "timeline_render"
+    MULTI_ASSET_MASTERPIECE = "multi_asset_masterpiece"
+
+
+class VideoJobStatus(str, Enum):
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PROVIDER_NOT_CONFIGURED = "provider_not_configured"
+    CANCELED = "canceled"
+
+
+@dataclass
+class TimelineClip:
+    id: str
+    source_url: Optional[str] = None
+    start_seconds: Optional[float] = None
+    end_seconds: Optional[float] = None
+    text: Optional[str] = None
+    kind: str = "video"
+
+
+@dataclass
+class TimelineTrack:
+    id: str
+    kind: str
+    clips: List[TimelineClip] = field(default_factory=list)
+
+
+@dataclass
+class TimelinePlan:
+    id: str
+    title: str
+    aspect_ratio: str
+    duration_seconds: int
+    tracks: List[TimelineTrack] = field(default_factory=list)
+
+
+@dataclass
+class VideoJobRequest:
+    job_type: VideoJobType
+    prompt: Optional[str] = None
+    input_urls: List[str] = field(default_factory=list)
+    source_asset_ids: List[str] = field(default_factory=list)
+    aspect_ratio: str = "9:16"
+    duration_seconds: int = 15
+    resolution: str = "720p"
+    style_preset: Optional[str] = None
+
+
+@dataclass
+class VideoJob:
+    job_id: str
+    user_id: str
+    job_type: VideoJobType
+    provider: str
+    status: VideoJobStatus
+    prompt: Optional[str] = None
+    input_urls: List[str] = field(default_factory=list)
+    source_asset_ids: List[str] = field(default_factory=list)
+    aspect_ratio: str = "9:16"
+    duration_seconds: int = 15
+    resolution: str = "720p"
+    style_preset: Optional[str] = None
+    cost_estimate_usd: float = 0.0
+    progress: int = 0
+    preview_url: Optional[str] = None
+    output_url: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    error_message: Optional[str] = None
+    timeline_plan: Optional[TimelinePlan] = None
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+class VideoProviderAdapter:
+    provider_name = "base"
+
+    def create_job(self, request: VideoJobRequest, user_id: str) -> VideoJob:
+        raise NotImplementedError
+
+    def get_job(self, job_id: str) -> Optional[VideoJob]:
+        raise NotImplementedError
+
+    def cancel_job(self, job_id: str) -> Optional[VideoJob]:
+        raise NotImplementedError
+
+
+class MockVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "mock"
+
+    def __init__(self) -> None:
+        self.jobs: Dict[str, VideoJob] = {}
+
+    def create_job(self, request: VideoJobRequest, user_id: str) -> VideoJob:
+        job = VideoJob(
+            job_id=f"video_job_{uuid4().hex}",
+            user_id=user_id,
+            job_type=request.job_type,
+            provider=self.provider_name,
+            status=VideoJobStatus.COMPLETED,
+            prompt=request.prompt,
+            input_urls=request.input_urls,
+            source_asset_ids=request.source_asset_ids,
+            aspect_ratio=request.aspect_ratio,
+            duration_seconds=request.duration_seconds,
+            resolution=request.resolution,
+            style_preset=request.style_preset,
+            cost_estimate_usd=estimate_video_job_cost(request),
+            progress=100,
+            output_url=None,
+            preview_url=None,
+            thumbnail_url=None,
+            error_message="mock_render_completed_no_asset",
+            timeline_plan=build_mock_timeline_plan(request),
+        )
+        self.jobs[job.job_id] = job
+        return job
+
+    def get_job(self, job_id: str) -> Optional[VideoJob]:
+        return self.jobs.get(job_id)
+
+    def cancel_job(self, job_id: str) -> Optional[VideoJob]:
+        job = self.jobs.get(job_id)
+        if job:
+            job.status = VideoJobStatus.CANCELED
+            job.updated_at = datetime.utcnow().isoformat()
+        return job
+
+
+def estimate_video_job_cost(request: VideoJobRequest) -> float:
+    base = 0.02
+    duration_multiplier = max(1, request.duration_seconds / 10)
+    resolution_multiplier = {
+        "480p": 0.5,
+        "720p": 1.0,
+        "1080p": 2.0,
+        "4k": 6.0,
+    }.get(request.resolution, 1.0)
+    return round(base * duration_multiplier * resolution_multiplier, 4)
+
+
+def build_mock_timeline_plan(request: VideoJobRequest) -> TimelinePlan:
+    return TimelinePlan(
+        id=f"timeline_{uuid4().hex}",
+        title=request.prompt or "LWA generated video plan",
+        aspect_ratio=request.aspect_ratio,
+        duration_seconds=request.duration_seconds,
+        tracks=[
+            TimelineTrack(
+                id="track_video_1",
+                kind="video",
+                clips=[
+                    TimelineClip(
+                        id="clip_1",
+                        source_url=request.input_urls[0] if request.input_urls else None,
+                        start_seconds=0,
+                        end_seconds=request.duration_seconds,
+                        text=request.prompt,
+                        kind="video",
+                    )
+                ],
+            ),
+            TimelineTrack(id="track_captions_1", kind="captions"),
+            TimelineTrack(id="track_audio_1", kind="audio"),
+        ],
+    )
+
+
+class VideoOSOrchestrator:
+    def __init__(self, enabled: bool = False, provider: str = "mock") -> None:
+        self.enabled = enabled
+        self.provider_name = provider
+        self.mock_provider = MockVideoProviderAdapter()
+
+    def create_video_job(self, request: VideoJobRequest, user_id: str = "guest:unknown") -> VideoJob:
+        validation_error = validate_video_job_request(request)
+        if validation_error:
+            return VideoJob(
+                job_id=f"video_job_{uuid4().hex}",
+                user_id=user_id,
+                job_type=request.job_type,
+                provider=self.provider_name,
+                status=VideoJobStatus.FAILED,
+                error_message=validation_error,
+            )
+
+        if not self.enabled:
+            return VideoJob(
+                job_id=f"video_job_{uuid4().hex}",
+                user_id=user_id,
+                job_type=request.job_type,
+                provider=self.provider_name,
+                status=VideoJobStatus.PROVIDER_NOT_CONFIGURED,
+                prompt=request.prompt,
+                input_urls=request.input_urls,
+                source_asset_ids=request.source_asset_ids,
+                aspect_ratio=request.aspect_ratio,
+                duration_seconds=request.duration_seconds,
+                resolution=request.resolution,
+                style_preset=request.style_preset,
+                cost_estimate_usd=estimate_video_job_cost(request),
+                error_message="Video OS is disabled. Set LWA_VIDEO_OS_ENABLED=true to enable mock jobs.",
+            )
+
+        return self.mock_provider.create_job(request, user_id)
+
+    def get_video_job(self, job_id: str) -> Optional[VideoJob]:
+        return self.mock_provider.get_job(job_id)
+
+    def list_video_jobs(self) -> List[VideoJob]:
+        return list(self.mock_provider.jobs.values())
+
+    def cancel_video_job(self, job_id: str) -> Optional[VideoJob]:
+        return self.mock_provider.cancel_job(job_id)
+
+
+def validate_video_job_request(request: VideoJobRequest) -> Optional[str]:
+    allowed_aspect_ratios = {"9:16", "16:9", "1:1", "4:5"}
+    allowed_resolutions = {"480p", "720p", "1080p"}
+
+    if request.aspect_ratio not in allowed_aspect_ratios:
+        return "unsupported_aspect_ratio"
+
+    if request.resolution not in allowed_resolutions:
+        return "unsupported_resolution"
+
+    if request.duration_seconds < 1 or request.duration_seconds > 30:
+        return "duration_out_of_range"
+
+    if len(request.input_urls) > 10:
+        return "too_many_inputs"
+
+    return None
+
+
+# Future provider adapters (placeholders for future implementation)
+class SoraVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "sora"
+    # TODO: Implement Sora API integration
+
+
+class SeedanceVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "seedance"
+    # TODO: Implement Seedance API integration
+
+
+class RunwayVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "runway"
+    # TODO: Implement Runway API integration
+
+
+class VeoVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "veo"
+    # TODO: Implement Veo API integration
+
+
+class PikaVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "pika"
+    # TODO: Implement Pika API integration
+
+
+class LumaVideoProviderAdapter(VideoProviderAdapter):
+    provider_name = "luma"
+    # TODO: Implement Luma API integration
+
+
+class ShotstackTimelineProviderAdapter(VideoProviderAdapter):
+    provider_name = "shotstack"
+    # TODO: Implement Shotstack timeline rendering
+
+
+class RemotionRenderProviderAdapter(VideoProviderAdapter):
+    provider_name = "remotion"
+    # TODO: Implement Remotion rendering
+
+
+class LocalFFmpegProviderAdapter(VideoProviderAdapter):
+    provider_name = "ffmpeg"
+    # TODO: Implement local FFmpeg rendering
+
+
+class ElevenLabsAudioProviderAdapter(VideoProviderAdapter):
+    provider_name = "elevenlabs"
+    # TODO: Implement ElevenLabs audio generation

--- a/lwa-web/components/video-os-panel.tsx
+++ b/lwa-web/components/video-os-panel.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface VideoJob {
+  job_id: string;
+  user_id: string;
+  job_type: string;
+  provider: string;
+  status: string;
+  prompt?: string;
+  input_urls: string[];
+  source_asset_ids: string[];
+  aspect_ratio: string;
+  duration_seconds: number;
+  resolution: string;
+  style_preset?: string;
+  cost_estimate_usd: number;
+  progress: number;
+  preview_url?: string;
+  output_url?: string;
+  thumbnail_url?: string;
+  error_message?: string;
+  timeline_plan?: {
+    id: string;
+    title: string;
+    aspect_ratio: string;
+    duration_seconds: number;
+    track_count: number;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+interface VideoOSCapabilities {
+  enabled: boolean;
+  provider: string;
+  job_types: string[];
+  statuses: string[];
+  allowed_aspect_ratios: string[];
+  allowed_resolutions: string[];
+  max_duration_seconds: number;
+  max_inputs: number;
+  max_resolution: string;
+  allow_live_providers: boolean;
+  storage_provider: string;
+  mock_mode: boolean;
+}
+
+const JOB_TYPES = [
+  { value: "text_to_video", label: "Text to Video", description: "Generate video from text prompt" },
+  { value: "image_to_video", label: "Image to Video", description: "Animate static images" },
+  { value: "video_to_video", label: "Video to Video", description: "Remix or enhance existing video" },
+  { value: "clip_to_video", label: "Clip to Video", description: "Convert clips to finished videos" },
+  { value: "audio_to_video", label: "Audio to Video", description: "Create visual from audio" },
+  { value: "song_visualizer", label: "Song Visualizer", description: "Generate music videos" },
+  { value: "timeline_render", label: "Timeline Render", description: "Render timeline composition" },
+  { value: "multi_asset_masterpiece", label: "Multi-Asset Masterpiece", description: "Create video from multiple sources" },
+];
+
+const ASPECT_RATIOS = [
+  { value: "9:16", label: "Vertical (9:16)", description: "TikTok, Reels, Shorts" },
+  { value: "16:9", label: "Horizontal (16:9)", description: "YouTube, standard video" },
+  { value: "1:1", label: "Square (1:1)", description: "Instagram posts" },
+  { value: "4:5", label: "Portrait (4:5)", description: "Instagram stories" },
+];
+
+const RESOLUTIONS = [
+  { value: "480p", label: "480p (SD)", description: "Standard definition" },
+  { value: "720p", label: "720p (HD)", description: "High definition" },
+  { value: "1080p", label: "1080p (Full HD)", description: "Full high definition" },
+];
+
+export function VideoOSPanel() {
+  const [capabilities, setCapabilities] = useState<VideoOSCapabilities | null>(null);
+  const [jobs, setJobs] = useState<VideoJob[]>([]);
+  const [isCreating, setIsCreating] = useState(false);
+  const [selectedJobType, setSelectedJobType] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [inputUrls, setInputUrls] = useState("");
+  const [aspectRatio, setAspectRatio] = useState("9:16");
+  const [duration, setDuration] = useState(15);
+  const [resolution, setResolution] = useState("720p");
+  const [stylePreset, setStylePreset] = useState("");
+  const [error, setError] = useState("");
+  const [activeTab, setActiveTab] = useState("create");
+
+  // Fetch capabilities and jobs on mount
+  useEffect(() => {
+    fetchCapabilities();
+    fetchJobs();
+  }, []);
+
+  const fetchCapabilities = async () => {
+    try {
+      const response = await fetch("/api/video-jobs/capabilities");
+      if (response.ok) {
+        const data = await response.json();
+        setCapabilities(data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch capabilities:", err);
+    }
+  };
+
+  const fetchJobs = async () => {
+    try {
+      const response = await fetch("/api/video-jobs");
+      if (response.ok) {
+        const data = await response.json();
+        setJobs(data.jobs || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch jobs:", err);
+    }
+  };
+
+  const createVideoJob = async () => {
+    setError("");
+    setIsCreating(true);
+
+    try {
+      const urls = inputUrls.split("\n").filter(url => url.trim()).map(url => url.trim());
+
+      const response = await fetch("/api/video-jobs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          job_type: selectedJobType,
+          prompt: prompt || undefined,
+          input_urls: urls,
+          aspect_ratio: aspectRatio,
+          duration_seconds: duration,
+          resolution: resolution,
+          style_preset: stylePreset || undefined,
+        }),
+      });
+
+      if (response.ok) {
+        const job = await response.json();
+        setJobs(prev => [job, ...prev]);
+        // Reset form
+        setPrompt("");
+        setInputUrls("");
+        setStylePreset("");
+      } else {
+        const errorData = await response.json();
+        setError(errorData.detail || "Failed to create video job");
+      }
+    } catch (err) {
+      setError("Network error. Please try again.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const cancelJob = async (jobId: string) => {
+    try {
+      const response = await fetch(`/api/video-jobs/${jobId}/cancel`, {
+        method: "POST",
+      });
+
+      if (response.ok) {
+        fetchJobs(); // Refresh jobs list
+      }
+    } catch (err) {
+      console.error("Failed to cancel job:", err);
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "completed": return "bg-green-500";
+      case "in_progress": case "queued": return "bg-blue-500";
+      case "failed": return "bg-red-500";
+      case "provider_not_configured": return "bg-yellow-500";
+      case "canceled": return "bg-gray-500";
+      default: return "bg-gray-500";
+    }
+  };
+
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case "queued": return "Queued";
+      case "in_progress": return "Processing";
+      case "completed": return "Completed";
+      case "failed": return "Failed";
+      case "provider_not_configured": return "Not Configured";
+      case "canceled": return "Canceled";
+      default: return status;
+    }
+  };
+
+  if (!capabilities) {
+    return (
+      <div className="w-full max-w-4xl mx-auto p-6 bg-white rounded-lg shadow-md">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold mb-2">Video OS</h2>
+          <p className="text-gray-600 mb-4">Loading capabilities...</p>
+          <div className="flex items-center justify-center h-32">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-4xl mx-auto p-6 bg-white rounded-lg shadow-md">
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-2">
+          <h1 className="text-3xl font-bold">Video OS</h1>
+          {capabilities.mock_mode && (
+            <span className="px-2 py-1 bg-gray-200 text-gray-700 rounded text-sm">Mock Mode</span>
+          )}
+          {!capabilities.enabled && (
+            <span className="px-2 py-1 bg-red-100 text-red-700 rounded text-sm">Disabled</span>
+          )}
+        </div>
+        <p className="text-gray-600">Load anything. Generate finished videos.</p>
+      </div>
+
+      {/* Tab Navigation */}
+      <div className="flex border-b mb-6">
+        <button
+          className={`px-4 py-2 font-medium ${activeTab === "create" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500"}`}
+          onClick={() => setActiveTab("create")}
+        >
+          Create Video
+        </button>
+        <button
+          className={`px-4 py-2 font-medium ${activeTab === "jobs" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500"}`}
+          onClick={() => setActiveTab("jobs")}
+        >
+          Recent Jobs
+        </button>
+        <button
+          className={`px-4 py-2 font-medium ${activeTab === "info" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500"}`}
+          onClick={() => setActiveTab("info")}
+        >
+          Info
+        </button>
+      </div>
+
+      {/* Create Video Tab */}
+      {activeTab === "create" && (
+        <div className="space-y-4">
+          {!capabilities.enabled && (
+            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded">
+              <p className="text-yellow-800">
+                Video OS is currently disabled. Set LWA_VIDEO_OS_ENABLED=true to enable mock jobs.
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Video Type</label>
+              <select
+                value={selectedJobType}
+                onChange={(e) => setSelectedJobType(e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded"
+              >
+                <option value="">Select video type</option>
+                {JOB_TYPES.map((type) => (
+                  <option key={type.value} value={type.value}>
+                    {type.label} - {type.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Aspect Ratio</label>
+              <select
+                value={aspectRatio}
+                onChange={(e) => setAspectRatio(e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded"
+              >
+                {ASPECT_RATIOS.map((ratio) => (
+                  <option key={ratio.value} value={ratio.value}>
+                    {ratio.label} - {ratio.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Duration (seconds)</label>
+              <input
+                type="number"
+                min="1"
+                max={capabilities.max_duration_seconds}
+                value={duration}
+                onChange={(e) => setDuration(Number(e.target.value))}
+                className="w-full p-2 border border-gray-300 rounded"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Resolution</label>
+              <select
+                value={resolution}
+                onChange={(e) => setResolution(e.target.value)}
+                className="w-full p-2 border border-gray-300 rounded"
+              >
+                {RESOLUTIONS.map((res) => (
+                  <option key={res.value} value={res.value}>
+                    {res.label} - {res.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Prompt (optional)</label>
+            <textarea
+              placeholder="Describe the video you want to create..."
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={3}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Input URLs (one per line, optional)</label>
+            <textarea
+              placeholder="https://example.com/video1.mp4&#10;https://example.com/image1.jpg"
+              value={inputUrls}
+              onChange={(e) => setInputUrls(e.target.value)}
+              rows={4}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Style Preset (optional)</label>
+            <input
+              type="text"
+              placeholder="cinematic, anime, realistic, etc."
+              value={stylePreset}
+              onChange={(e) => setStylePreset(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded"
+            />
+          </div>
+
+          {error && (
+            <div className="p-4 bg-red-50 border border-red-200 rounded">
+              <p className="text-red-800">{error}</p>
+            </div>
+          )}
+
+          <button
+            onClick={createVideoJob}
+            disabled={!selectedJobType || isCreating || !capabilities.enabled}
+            className="w-full p-3 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400"
+          >
+            {isCreating ? "Creating..." : "Generate Video"}
+          </button>
+        </div>
+      )}
+
+      {/* Recent Jobs Tab */}
+      {activeTab === "jobs" && (
+        <div className="space-y-4">
+          {jobs.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              No video jobs yet. Create your first video above.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {jobs.map((job) => (
+                <div key={job.job_id} className="p-4 border border-gray-200 rounded">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-2">
+                        <h3 className="font-medium">{job.job_type.replace(/_/g, " ").toUpperCase()}</h3>
+                        <span className={`px-2 py-1 rounded text-xs text-white ${getStatusColor(job.status)}`}>
+                          {getStatusText(job.status)}
+                        </span>
+                        {job.provider === "mock" && (
+                          <span className="px-2 py-1 bg-gray-200 text-gray-700 rounded text-xs">Mock</span>
+                        )}
+                      </div>
+                      
+                      <div className="text-sm text-gray-600 space-y-1">
+                        <div>Duration: {job.duration_seconds}s</div>
+                        <div>Resolution: {job.resolution}</div>
+                        <div>Aspect Ratio: {job.aspect_ratio}</div>
+                        {job.prompt && <div>Prompt: {job.prompt}</div>}
+                        {job.error_message && (
+                          <div className="text-red-600">Error: {job.error_message}</div>
+                        )}
+                      </div>
+
+                      {job.progress > 0 && job.status === "in_progress" && (
+                        <div className="mt-2">
+                          <div className="w-full bg-gray-200 rounded-full h-2">
+                            <div
+                              className="bg-blue-600 h-2 rounded-full"
+                              style={{ width: `${job.progress}%` }}
+                            ></div>
+                          </div>
+                          <div className="text-sm text-gray-500 mt-1">{job.progress}% complete</div>
+                        </div>
+                      )}
+
+                      {job.output_url && (
+                        <div className="mt-2">
+                          <a
+                            href={job.output_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-800 text-sm"
+                          >
+                            View Output →
+                          </a>
+                        </div>
+                      )}
+
+                      {job.timeline_plan && (
+                        <div className="mt-2 text-sm text-gray-500">
+                          Timeline: {job.timeline_plan.track_count} tracks, {job.timeline_plan.duration_seconds}s
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex flex-col gap-2 ml-4">
+                      <div className="text-sm text-gray-500">
+                        ${job.cost_estimate_usd.toFixed(4)}
+                      </div>
+                      {(job.status === "queued" || job.status === "in_progress") && (
+                        <button
+                          className="px-3 py-1 border border-gray-300 rounded text-sm hover:bg-gray-50"
+                          onClick={() => cancelJob(job.job_id)}
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Info Tab */}
+      {activeTab === "info" && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="p-4 border border-gray-200 rounded">
+              <h3 className="text-lg font-medium mb-3">Configuration</h3>
+              <div className="space-y-2">
+                <div className="flex justify-between">
+                  <span>Enabled:</span>
+                  <span className={capabilities.enabled ? "text-green-600" : "text-red-600"}>
+                    {capabilities.enabled ? "Yes" : "No"}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Provider:</span>
+                  <span>{capabilities.provider}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Mock Mode:</span>
+                  <span className={capabilities.mock_mode ? "text-yellow-600" : "text-green-600"}>
+                    {capabilities.mock_mode ? "Yes" : "No"}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Storage:</span>
+                  <span>{capabilities.storage_provider}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-4 border border-gray-200 rounded">
+              <h3 className="text-lg font-medium mb-3">Limits</h3>
+              <div className="space-y-2">
+                <div className="flex justify-between">
+                  <span>Max Duration:</span>
+                  <span>{capabilities.max_duration_seconds}s</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Max Inputs:</span>
+                  <span>{capabilities.max_inputs}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Max Resolution:</span>
+                  <span>{capabilities.max_resolution}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Live Providers:</span>
+                  <span className={capabilities.allow_live_providers ? "text-green-600" : "text-red-600"}>
+                    {capabilities.allow_live_providers ? "Allowed" : "Disabled"}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-4 border border-gray-200 rounded">
+            <h3 className="text-lg font-medium mb-3">Supported Job Types</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {capabilities.job_types.map((type) => (
+                <span key={type} className="px-2 py-1 bg-gray-100 rounded text-sm">
+                  {type.replace(/_/g, " ").toUpperCase()}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {capabilities.mock_mode && (
+            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded">
+              <p className="text-yellow-800">
+                <strong>Mock Mode Active:</strong> Video OS is running in mock mode. Jobs will complete instantly 
+                with placeholder outputs. Enable live providers by setting LWA_VIDEO_OS_ENABLED=true and configuring 
+                provider credentials.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds the first provider-agnostic Video OS foundation for LWA.

Includes:
- Mock video job orchestration
- Provider abstraction
- Video job API routes
- Render engine routes
- Safe config flags
- Frontend Video OS panel
- Timeline model foundation
- Guardrails
- Documentation

Preserves:
- Existing /generate clipping flow
- Existing backend contracts
- iOS untouched
- No provider secrets
- No live provider calls by default

Validation reported locally:
- python3 -m compileall lwa-backend/app passed
- npm run type-check passed
- npm run build passed
- git diff --check passed

This creates the foundation for LWA to evolve from clipping into a full AI video studio.
